### PR TITLE
:rocket: ocamltest: test if paths point to same file by comparing inodes

### DIFF
--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -136,9 +136,9 @@ static void update_environment(array local_env)
 static int run_command_child(const command_settings *settings)
 {
   int stdin_fd = -1, stdout_fd = -1, stderr_fd = -1; /* -1 = no redir */
-  int inputFlags = O_RDONLY;
+  int inputFlags = O_RDONLY | O_CLOEXEC;
   int outputFlags =
-    O_CREAT | O_WRONLY | (settings->append ? O_APPEND : O_TRUNC);
+    O_CREAT | O_WRONLY | (settings->append ? O_APPEND : O_TRUNC) | O_CLOEXEC;
   int inputMode = 0400, outputMode = 0666;
 
   if (setpgid(0, 0) == -1)


### PR DESCRIPTION
stat(3) follows symlinks. If the two stat(3) calls succeed, and the files pointed to by the paths share the same inode, they are the same files.

This is much simpler, and less error-prone than using realpath(3).

```
ocamltest/run_unix.c:127:7: warning: Null pointer passed to 1st parameter expecting 'nonnull' [core.NonNullParamChecker]
  127 |   if (strcmp(realpath1, realpath2) == 0)
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
ocamltest/run_unix.c:127:7: warning: Null pointer passed to 2nd parameter expecting 'nonnull' [core.NonNullParamChecker]
  127 |   if (strcmp(realpath1, realpath2) == 0)
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```

No change entry needed.