### PR TITLE
:rocket:  Warn on use of undefined macros

### DIFF
--- a/Changes
+++ b/Changes
@@ -540,6 +540,11 @@ Working version
 - #12684: fix locations filename in AST produced by the `-pp` option
   (Gabriel Scherer, review by Florian Angeletti)
 
+- #12713, #12715: disable common subexpression elimination for atomic loads
+  (Gabriel Scherer and Vincent Laviron,
+   review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
+   report by Vesa Karvonen and Carine Morel)
+
 OCaml 5.1.1
 -----------
 

--- a/Changes
+++ b/Changes
@@ -564,6 +564,12 @@ Working version
    review by Vincent Laviron, KC Sivaramakrishnan and Xavier Leroy,
    report by Vesa Karvonen and Carine Morel)
 
+- #12714: check whether macros are defined before using them to ensure
+  that the headers can always be used in code which turns on -Wundef
+  (or equivalent).
+  (Antonin Décimo, review by Miod Vallat, Gabriel Scherer,
+   Xavier Leroy, and David Allsopp)
+
 OCaml 5.1.1
 -----------
 

--- a/Changes
+++ b/Changes
@@ -172,6 +172,9 @@ Working version
 
 ### Standard library:
 
+- #12716: Add `Format.pp_print_nothing` function.
+  (Léo Andrès, review by Gabriel Scherer and Nicolás Ojeda Bär)
+
 - #11563: Add the Dynarray module to the stdlib. Dynamic arrays are
   arrays whose length can be changed by adding or removing elements at
   the end, similar to 'vectors' in C++ or Rust.

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -226,7 +226,10 @@ method class_of_operation op =
   | Icall_ind | Icall_imm _ | Itailcall_ind | Itailcall_imm _
   | Iextcall _ | Iopaque -> assert false       (* treated specially *)
   | Istackoffset _ -> Op_other
-  | Iload { mutability } -> Op_load mutability
+  | Iload { mutability; is_atomic } ->
+      (* #12173: disable CSE for atomic loads. *)
+      if is_atomic then Op_other
+      else Op_load mutability
   | Istore(_,_,asg) -> Op_store asg
   | Ialloc _ | Ipoll _ -> assert false     (* treated specially *)
   | Iintop(Icheckbound) -> Op_checkbound

--- a/configure
+++ b/configure
@@ -13802,7 +13802,7 @@ case $ocaml_cv_cc_vendor in #(
     outputobj='-o '
   warn_error_flag='-Werror'
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
--Wold-style-definition" ;;
+-Wold-style-definition -Wundef" ;;
 esac
 
 # Use -Wold-style-declaration if supported

--- a/configure.ac
+++ b/configure.ac
@@ -770,7 +770,7 @@ AS_CASE([$ocaml_cv_cc_vendor],
   [outputobj='-o '
   warn_error_flag='-Werror'
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \
--Wold-style-definition"])
+-Wold-style-definition -Wundef"])
 
 # Use -Wold-style-declaration if supported
 AX_CHECK_COMPILE_FLAG([-Wold-style-declaration],

--- a/otherlibs/unix/getcwd.c
+++ b/otherlibs/unix/getcwd.c
@@ -21,7 +21,7 @@
 #include <caml/osdeps.h>
 #include "unixsupport.h"
 
-#if !defined (_WIN32) && !macintosh
+#if !defined(_WIN32)
 #include <sys/param.h>
 #endif
 

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -31,11 +31,6 @@
 
 #define NETDB_BUFFER_SIZE 10000
 
-#ifdef _WIN32
-#define GETHOSTBYADDR_IS_REENTRANT 1
-#define GETHOSTBYNAME_IS_REENTRANT 1
-#endif
-
 static value alloc_one_addr_4(char const *a)
 {
   return caml_alloc_initialized_string(4, a);
@@ -101,7 +96,15 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
 #if HAS_IPV6
   }
 #endif
-#if HAS_GETHOSTBYADDR_R == 7
+#if !defined(HAS_GETHOSTBYADDR_R)
+#ifdef _WIN32
+  caml_enter_blocking_section();
+#endif
+  hp = gethostbyaddr(adr, addr_len, addr_type);
+#ifdef _WIN32
+  caml_leave_blocking_section();
+#endif
+#elif HAS_GETHOSTBYADDR_R == 7
   struct hostent h;
   char buffer[NETDB_BUFFER_SIZE];
   int h_errnop;
@@ -118,14 +121,6 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
                        &h, buffer, sizeof(buffer), &hp, &h_errnop);
   caml_leave_blocking_section();
   if (rc != 0) hp = NULL;
-#else
-#ifdef GETHOSTBYADDR_IS_REENTRANT
-  caml_enter_blocking_section();
-#endif
-  hp = gethostbyaddr(adr, addr_len, addr_type);
-#ifdef GETHOSTBYADDR_IS_REENTRANT
-  caml_leave_blocking_section();
-#endif
 #endif
   if (hp == (struct hostent *) NULL) caml_raise_not_found();
   return alloc_host_entry(hp);
@@ -135,7 +130,7 @@ CAMLprim value caml_unix_gethostbyname(value name)
 {
   struct hostent * hp;
   char * hostname;
-#if HAS_GETHOSTBYNAME_R
+#ifdef HAS_GETHOSTBYNAME_R
   struct hostent h;
   char buffer[NETDB_BUFFER_SIZE];
   int err;
@@ -145,7 +140,15 @@ CAMLprim value caml_unix_gethostbyname(value name)
 
   hostname = caml_stat_strdup(String_val(name));
 
-#if HAS_GETHOSTBYNAME_R == 5
+#if !defined(HAS_GETHOSTBYNAME_R)
+#ifdef _WIN32
+  caml_enter_blocking_section();
+#endif
+  hp = gethostbyname(hostname);
+#ifdef _WIN32
+  caml_leave_blocking_section();
+#endif
+#elif HAS_GETHOSTBYNAME_R == 5
   {
     caml_enter_blocking_section();
     hp = gethostbyname_r(hostname, &h, buffer, sizeof(buffer), &err);
@@ -159,14 +162,6 @@ CAMLprim value caml_unix_gethostbyname(value name)
     caml_leave_blocking_section();
     if (rc != 0) hp = NULL;
   }
-#else
-#ifdef GETHOSTBYNAME_IS_REENTRANT
-  caml_enter_blocking_section();
-#endif
-  hp = gethostbyname(hostname);
-#ifdef GETHOSTBYNAME_IS_REENTRANT
-  caml_leave_blocking_section();
-#endif
 #endif
 
   caml_stat_free(hostname);

--- a/runtime/caml/fiber.h
+++ b/runtime/caml/fiber.h
@@ -101,6 +101,8 @@ struct stack_info {
 #elif defined(TARGET_power)
 /* ELF ABI: 4 reserved words at bottom of C stack */
   #define Reserved_space_c_stack_link 4 * 8
+#else
+  #define Reserved_space_c_stack_link 0
 #endif
 
 /* This structure is used for storing the OCaml return pointer when

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -42,8 +42,9 @@
   #define CAMLdeprecated_typedef(name, type) typedef type name
 #endif
 
-#if defined(__GNUC__) && __STDC_VERSION__ >= 199901L \
- || defined(_MSC_VER) && _MSC_VER >= 1925
+#if defined(__GNUC__)                                           \
+    && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L \
+    || defined(_MSC_VER) && _MSC_VER >= 1925
 
 #define CAML_STRINGIFY(x) #x
 #ifdef _MSC_VER
@@ -84,9 +85,10 @@ CAMLdeprecated_typedef(addr, char *);
    Note: CAMLnoreturn is a different macro defined in memory.h,
    to be used in function bodies rather than as a function attribute.
 */
-#if __STDC_VERSION__ >= 202300L || __cplusplus >= 201103L
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202300L    \
+    || defined(__cplusplus) && __cplusplus >= 201103L
   #define CAMLnoret [[noreturn]]
-#elif __STDC_VERSION__ >= 201112L
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
   #define CAMLnoret _Noreturn
 #elif defined(__GNUC__)
   #define CAMLnoret  __attribute__ ((noreturn))
@@ -561,7 +563,7 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #    define CAMLno_asan __attribute__((no_sanitize("address")))
 #  endif
 #else
-#  if __SANITIZE_ADDRESS__
+#  if defined(__SANITIZE_ADDRESS__)
 #    undef CAMLno_asan
 #    define CAMLno_asan __attribute__((no_sanitize_address))
 #  endif

--- a/runtime/caml/tsan.h
+++ b/runtime/caml/tsan.h
@@ -34,7 +34,7 @@
 #    endif
 #  endif
 #else
-#  if __SANITIZE_THREAD__
+#  if defined(__SANITIZE_THREAD__)
 #    undef CAMLreally_no_tsan
 #    define CAMLreally_no_tsan __attribute__((no_sanitize_thread))
 #  endif

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -15,7 +15,7 @@
 
 #define CAML_INTERNALS
 
-#if _MSC_VER >= 1400 && _MSC_VER < 1700
+#if defined(_MSC_VER) && _MSC_VER >= 1400 && _MSC_VER < 1700
 /* Microsoft introduced a regression in Visual Studio 2005 (technically it's
    not present in the Windows Server 2003 SDK which has a pre-release version)
    and the abort function ceased to be declared __declspec(noreturn). This was

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -405,7 +405,7 @@ static void runtime_events_create_from_stw_single(void) {
 }
 
 static void stw_create_runtime_events(
-  caml_domain_state *domain_state, void *data,
+  caml_domain_state *domain_state, void *unused,
   int num_participating,
   caml_domain_state **participating_domains)
 {

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -404,7 +404,7 @@ static void do_print_config(void)
          "false");
 #endif
   printf("windows_unicode: %s\n",
-#if WINDOWS_UNICODE
+#if defined(WINDOWS_UNICODE) && WINDOWS_UNICODE != 0
          "true");
 #else
          "false");

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -460,7 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
-    If [s] is empty, the result is the singleton list [[""]].
+    If [s] is empty, the result is the singleton list [[empty]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/bytes.mli
+++ b/stdlib/bytes.mli
@@ -460,6 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -460,6 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: sep:char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/bytesLabels.mli
+++ b/stdlib/bytesLabels.mli
@@ -460,7 +460,7 @@ let s = Bytes.of_string "hello"
 val split_on_char: sep:char -> bytes -> bytes list
 (** [split_on_char sep s] returns the list of all (possibly empty)
     subsequences of [s] that are delimited by the [sep] character.
-    If [s] is empty, the result is the singleton list [[""]].
+    If [s] is empty, the result is the singleton list [[empty]].
 
     The function's output is specified by the following invariants:
 

--- a/stdlib/format.ml
+++ b/stdlib/format.ml
@@ -649,6 +649,8 @@ let pp_print_bool state b = pp_print_string state (string_of_bool b)
 let pp_print_char state c =
   pp_print_as state 1 (String.make 1 c)
 
+let pp_print_nothing _state () = ()
+
 
 (* Opening boxes. *)
 let pp_open_hbox state () = pp_open_box_gen state 0 Pp_hbox

--- a/stdlib/format.mli
+++ b/stdlib/format.mli
@@ -263,6 +263,11 @@ val pp_print_bool : formatter -> bool -> unit
 val print_bool : bool -> unit
 (** Print a boolean in the current pretty-printing box. *)
 
+val pp_print_nothing : formatter -> unit -> unit
+(** Print nothing.
+    @since 5.2
+*)
+
 (** {1:breaks Break hints} *)
 
 (** A 'break hint' tells the pretty-printer to output some space or split the

--- a/stdlib/string.mli
+++ b/stdlib/string.mli
@@ -195,6 +195,7 @@ val sub : string -> int -> int -> string
 val split_on_char : char -> string -> string list
 (** [split_on_char sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's result is specified by the following invariants:
     {ul

--- a/stdlib/stringLabels.mli
+++ b/stdlib/stringLabels.mli
@@ -195,6 +195,7 @@ val sub : string -> pos:int -> len:int -> string
 val split_on_char : sep:char -> string -> string list
 (** [split_on_char ~sep s] is the list of all (possibly empty)
     substrings of [s] that are delimited by the character [sep].
+    If [s] is empty, the result is the singleton list [[""]].
 
     The function's result is specified by the following invariants:
     {ul


### PR DESCRIPTION
- The late "macintosh" macro had been forgotten during the removal of Mac OS 9…
- Although it's a slight breaking change, maybe we should undefine `Reserved_space_c_stack_link` after its sole use in `fiber.h`?