### PR TITLE
Enforce strict C99 flexible array members

### DIFF
--- a/Changes
+++ b/Changes
@@ -46,6 +46,9 @@ Working version
   (Miod Vallat, review by KC Sivaramakrishnan, feedback from Nick Barnes
    and Gabriel Scherer)
 
+- #13354: Use C99 flexible array member syntax everywhere.
+  (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and Xavier Leroy)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -336,7 +336,7 @@ debuginfo caml_debuginfo_next(debuginfo dbg)
    so it is referenced as an offset instead of stored inline */
 struct name_info {
   int32_t filename_offs;
-  char name[1];
+  char name[]; /* flexible array member */
 };
 
 /* Extended version of name_info including location fields which didn't fit
@@ -346,7 +346,7 @@ struct name_and_loc_info {
   uint16_t start_chr;
   uint16_t end_chr;
   int32_t end_offset; /* End character position relative to start bol */
-  char name[1];
+  char name[]; /* flexible array member */
 };
 
 /* Extract location information for the given frame descriptor */

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -367,7 +367,7 @@ CAMLexport value caml_callbackN (value closure, int narg, value args[])
 struct named_value {
   value val;
   struct named_value * next;
-  char name[1];
+  char name[]; /* flexible array member */
 };
 
 #define Named_value_size 13
@@ -391,7 +391,6 @@ static unsigned int hash_value_name(char const *name)
 CAMLprim value caml_register_named_value(value vname, value val)
 {
   const char * name = String_val(vname);
-  size_t namelen = strlen(name);
   unsigned int h = hash_value_name(name);
   int found = 0;
 
@@ -406,9 +405,10 @@ CAMLprim value caml_register_named_value(value vname, value val)
     }
   }
   if (!found) {
-    struct named_value * nv = (struct named_value *)
+    size_t namelen = strlen(name) + 1;
+    struct named_value * nv =
       caml_stat_alloc(sizeof(struct named_value) + namelen);
-    memcpy(nv->name, name, namelen + 1);
+    memcpy(nv->name, name, namelen);
     nv->val = val;
     nv->next = named_value_table[h];
     named_value_table[h] = nv;

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -82,7 +82,7 @@ struct caml_ba_array {
   intnat num_dims;            /* Number of dimensions */
   intnat flags;  /* Kind of element array + memory layout + allocation status */
   struct caml_ba_proxy * proxy; /* The proxy for sub-arrays, or NULL */
-  intnat dim[]  /*[num_dims]*/; /* Size in each dimension */
+  intnat dim[/* num_dims */]; /* Size in each dimension */
 };
 
 /* Size of struct caml_ba_array, in bytes, without [dim] array */

--- a/runtime/caml/finalise.h
+++ b/runtime/caml/finalise.h
@@ -45,7 +45,7 @@ struct finalisable {
 struct final_todo {
   struct final_todo *next;
   int size;
-  struct final item[1];  /* variable size */
+  struct final item[/* size */]; /* flexible array member */
 };
 
 /*

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -63,7 +63,7 @@ typedef struct {
   uintnat retaddr;
   uint16_t frame_data; /* frame size and various flags */
   uint16_t num_live;
-  uint16_t live_ofs[1 /* num_live */];
+  uint16_t live_ofs[/* num_live */]; /* flexible array member */
   /*
     If frame_has_allocs(), alloc lengths follow:
         uint8_t num_allocs;

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -39,7 +39,7 @@ struct skiplist {
 struct skipcell {
   uintnat key;
   uintnat data;
-  struct skipcell * forward[];  /* flexible array member */
+  struct skipcell * forward[]; /* flexible array member */
 };
 
 /* Initialize a skip list, statically */

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -172,7 +172,7 @@ struct core
     short number;
     short accessing_symbol;
     short nitems;
-    short items[1];
+    short items[/* nitems */]; /* flexible array member */
 };
 
 
@@ -184,7 +184,7 @@ struct shifts
     struct shifts *next;
     short number;
     short nshifts;
-    short shift[1];
+    short shift[/* nshifts */]; /* flexible array member */
 };
 
 
@@ -196,7 +196,7 @@ struct reductions
     struct reductions *next;
     short number;
     short nreds;
-    short rules[1];
+    short rules[/* nreds */]; /* flexible array member */
 };
 
 

--- a/yacc/lr0.c
+++ b/yacc/lr0.c
@@ -321,7 +321,7 @@ new_state(int symbol)
     iend = kernel_end[symbol];
     n = iend - isp1;
 
-    p = (core *) allocate((unsigned) (sizeof(core) + (n - 1) * sizeof(short)));
+    p = (core *) allocate((unsigned) (sizeof(core) + n * sizeof(short)));
     p->accessing_symbol = symbol;
     p->number = nstates;
     p->nitems = n;
@@ -423,8 +423,8 @@ void save_shifts(void)
     short *sp2;
     short *send;
 
-    p = (shifts *) allocate((unsigned) (sizeof(shifts) +
-                        (nshifts - 1) * sizeof(short)));
+    p = (shifts *) allocate(
+          (unsigned) (sizeof(shifts) + nshifts * sizeof(short)));
 
     p->number = this_state->number;
     p->nshifts = nshifts;
@@ -472,8 +472,8 @@ void save_reductions(void)
 
     if (count)
     {
-        p = (reductions *) allocate((unsigned) (sizeof(reductions) +
-                                        (count - 1) * sizeof(short)));
+        p = (reductions *) allocate(
+              (unsigned) (sizeof(reductions) + count * sizeof(short)));
 
         p->number = this_state->number;
         p->nreds = count;


### PR DESCRIPTION
In `[Use proper C99 flexible array members #12685](https://github.com/ocaml/ocaml/pull/12685)` we've fixed _almost all_ our code to use standard C flexible arrays.

Use compiler support (`-fstrict-flex-arrays`) to forbid non-standard C flexible arrays, and link when possible the flexible array size to the member containing its size using the `counted_by` attribute ([GCC 15](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108896), [LLVM 18](https://clang.llvm.org/docs/AttributeReference.html#counted-by)). This helps by documenting the relation between the two fields, with static analysis (`-fanalyzer`), and instrumented bounds-checking at runtime (think `_FORTIFY_SOURCE` and `__builtin_dynamic_object_size`).

One crucial requirement is that the counter must be initialized before the first reference to the flexible-array member. Another requirement is that the array must always contain at least as many elements as indicated by the counter. If I'm not mistaken, both of these are currently satisfied, and the compiler should warn if not.

References:
- [Bounds Checking Flexible Array Members](https://opensource.googleblog.com/2024/07/bounds-checking-flexible-array-members.html)
- [How to use the new counted_by attribute in C (and Linux)](https://embeddedor.com/blog/2024/06/18/how-to-use-the-new-counted_by-attribute-in-c-and-linux/)
- [Safer flexible arrays for the kernel](https://lwn.net/Articles/908817/)
- [Documenting counted-by relationships in kernel data structures](https://lwn.net/Articles/936728/)
- [GCC features to help harden the kernel](https://lwn.net/Articles/946041/)

---
⚠️ As the WinAPI uses FAM with size 1 ([Why do some structures end with an array of size 1?](https://devblogs.microsoft.com/oldnewthing/?p=38043)), passing `-fstrict-flex-arrays=n` with `n > 1` will break code.

⚠️ The BSD socket API uses non-standard flexible array members in `struct sockaddr` for type punning, but this doesn't seem to cause problems in practice.

```c
struct sockaddr {
  /* address family and length */
  char sa_data[14]; /* Address data, might be longer */
};
```