### PR TITLE
Define and use the `CAMLthread_local` macro for TLS variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -165,6 +165,9 @@ Working version
   (KC Sivaramakrishnan, report by Gabriel Scherer, review by Gabriel Scherer,
   Sadiq Jaffer and Fabrice Buoro)
 
+- #?????: Define and use the CAMLthread_local macro for TLS variables.
+  (Antonin Décimo and Samuel Hym, review by ?????)
+
 ### Code generation and optimizations:
 
 - #11239: on x86-64 and RISC-V, reduce alignment of OCaml stacks from 16 to 8.

--- a/configure
+++ b/configure
@@ -15269,8 +15269,8 @@ as_fn_error $? "C11 atomic support is required, use another C compiler
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
-# Full support for C11 __thread variables
-# macOS and MinGW-64 have problems with __thread variables accessed from DLLs
+# Full support for thread local storage
+# macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 case $host in #(
   *-apple-darwin*|*-mingw32*) :

--- a/configure.ac
+++ b/configure.ac
@@ -1128,8 +1128,8 @@ OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
 AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 
-# Full support for C11 __thread variables
-# macOS and MinGW-64 have problems with __thread variables accessed from DLLs
+# Full support for thread local storage
+# macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 AS_CASE([$host],
   [*-apple-darwin*|*-mingw32*], [],

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -78,9 +78,10 @@ Caml_inline void restore_stack_parent(caml_domain_state* domain_state,
 #include "caml/fix_code.h"
 #include "caml/fiber.h"
 
-static __thread opcode_t callback_code[] = { ACC, 0, APPLY, 0, POP, 1, STOP };
+static CAMLthread_local opcode_t callback_code[] =
+  { ACC, 0, APPLY, 0, POP, 1, STOP };
 
-static __thread int callback_code_inited = 0;
+static CAMLthread_local int callback_code_inited = 0;
 
 static void init_callback_code(void)
 {

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -43,7 +43,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern __thread caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else
 #ifdef __GNUC__

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "misc.h"
 
-extern __thread intnat caml_icount;
+extern CAMLthread_local intnat caml_icount;
 void caml_stop_here (void);
 void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -154,6 +154,17 @@ CAMLdeprecated_typedef(addr, char *);
 #error "How do I align values on this platform?"
 #endif
 
+#if defined(__cplusplus) && __cplusplus >= 201103L ||   \
+    defined(__STDC_VERSION__) && __STDC_VERSION__ > 201710L
+#define CAMLthread_local thread_local
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define CAMLthread_local _Thread_local
+#elif defined(__GNUC__)
+#define CAMLthread_local __thread
+#else
+#error "How do I use thread-local storage on this platform?"
+#endif
+
 /* Prefetching */
 
 #ifdef CAML_INTERNALS

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -141,7 +141,7 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-static __thread int lockdepth;
+static CAMLthread_local int lockdepth;
 #define DEBUG_LOCK(m) (lockdepth++)
 #define DEBUG_UNLOCK(m) (lockdepth--)
 #else

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -44,9 +44,9 @@
 
 #undef HAS_FULL_THREAD_VARIABLES
 
-/* Define HAS_FULL_THREAD_VARIABLES if C11 __thread variables are fully
-   supported, including across DLLs.  This is not the case with
-   macOS and with Windows + MinGW-64. */
+/* Define HAS_FULL_THREAD_VARIABLES if thread-local storage is fully supported,
+   including across DLLs. This is not the case with macOS and with Windows +
+   MinGW-w64. */
 
 #undef HAS_C99_FLOAT_OPS
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -242,7 +242,7 @@ uintnat caml_minor_heap_max_wsz;
 
 CAMLexport uintnat caml_minor_heaps_start;
 CAMLexport uintnat caml_minor_heaps_end;
-static __thread dom_internal* domain_self;
+static CAMLthread_local dom_internal* domain_self;
 
 /*
  * This structure is protected by all_domains_lock
@@ -297,7 +297,7 @@ static dom_internal* next_free_domain(void) {
   return stw_domains.domains[stw_domains.participating_domains];
 }
 
-CAMLexport __thread caml_domain_state* caml_state;
+CAMLexport CAMLthread_local caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -36,7 +36,7 @@
 
 extern code_t caml_start_code;
 
-__thread intnat caml_icount = 0;
+CAMLthread_local intnat caml_icount = 0;
 
 void caml_stop_here (void)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -239,7 +239,7 @@ Caml_inline void check_trap_barrier_for_effect
 #endif
 
 #ifdef DEBUG
-static __thread intnat caml_bcodcount;
+static CAMLthread_local intnat caml_bcodcount;
 #endif
 
 static value raise_unhandled_effect;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -68,7 +68,7 @@
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static __thread struct channel* last_channel_locked = NULL;
+static CAMLthread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -59,7 +59,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
 #endif
 
 #if defined(DEBUG)
-static __thread int noalloc_level = 0;
+static CAMLthread_local int noalloc_level = 0;
 int caml_noalloc_begin(void)
 {
   return noalloc_level++;

--- a/testsuite/tests/lib-marshal/intextaux_par.c
+++ b/testsuite/tests/lib-marshal/intextaux_par.c
@@ -20,7 +20,7 @@
 #define CAML_INTERNALS
 
 #define BLOCK_SIZE 512
-static __thread char marshal_block[BLOCK_SIZE];
+static CAMLthread_local char marshal_block[BLOCK_SIZE];
 
 value marshal_to_block(value vlen, value v, value vflags)
 {


### PR DESCRIPTION
The problem: we currently use the `__thread` **non-standard** storage class specifier for thread-local storage. MSVC has no support for that spelling.

What the standards say:
- C11/C17 defines the `_Thread_local` storage class specifier.
- C11/C17 defines the `<threads.h>` header, in which one can find the `#define thread_local _Thread_local` macro (defined as-is by the standard).
- If a compliant compiler defines the `__STDC_NO_THREADS__` macro, then the `<threads.h>` header doesn't exist.
- C23 removes the `_Thread_local` specifier and introduces `thread_local` as a keyword.
- C++11 has the `thread_local` storage class specifier.

What the compilers do:
- The `__thread` storage class specifier is a GNU C extension (supported by GCC and clang).
- MSVC has support for `_Thread_local` and `__declspec(thread)`.
- and yet testing with `cl /W4 /std:c17 /c test.c` (19.38.33129) or `x86_64-w64-mingw32-gcc -Wall -std=c17 -c test.c` (mingw-11.0 gcc-11.4 in Cygwin, mingw-12.0 gcc-13.2 in MSYS2) gives:
  ```c
  #if !defined(__STDC_NO_THREADS__)
  #include <threads.h>
  #endif 
  thread_local int x;
  ```
  ```
  test.c(2): fatal error C1083: Cannot open include file: 'threads.h': No such file or directory
  ```
  ```
  test.c:2:10: fatal error: threads.h: No such file or directory
    2 | #include <threads.h>
      |          ^~~~~~~~~~~
  compilation terminated.
  ```
  so long for compliance! Which is why I suggest making a special case under `#ifdef _WIN32`.
  I've opened bug reports against [mingw](https://sourceforge.net/p/mingw-w64/mailman/mingw-w64-public/thread/CACCWBSB2SqS4PhXmZHuhqQYJpyxUPNfGV-mDrMf4AB19%2BtxtPg%40mail.gmail.com/#msg51781776) and [msvc](https://developercommunity.visualstudio.com/t/C11-Define-__STDC_NO_THREADS__-if-C1/10510770).

Options:
1. Use `thread_local` as a keyword in C++11 and C23. Before, it is available as a macro in C11/C17 in `<threads.h>`. If `<threads.h>` is not available, we could add `#define thread_local /* appropriate thing here */` but we would risk conflicting with user code.
2. Introduce a `CAMLthread_local` sanely abstracting over all that.
3. Add a special case under MSVC and don't touch the existing code:
   ```c
   #ifdef _MSC_VER
   #define __thread __declspec(thread)
   #endif
   ```
   Note that `__thread` is a reserved identifier, so this is not ideal for compatibility.
   
We could detect non-compliant compilers in the configure script and define `__STDC_NO_THREADS__` ourselves, but we'd fiddle with a reserved identifier (bad), and that would be bad for forward compatibility if the header is added one day.

References:

- https://learn.microsoft.com/en-us/cpp/parallel/thread-local-storage-tls?view=msvc-170
- https://en.cppreference.com/w/c/thread
- https://gcc.gnu.org/onlinedocs/gcc/Thread-Local.html