### PR TITLE
Sub-microseconds sleeps on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -16,6 +16,10 @@ Working version
 
 ### Runtime system:
 
+- #?????: Use sub-millisecond precision for spin-waits and sleeping on
+  Windows.
+  (Antonin Décimo, review by ???)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -668,6 +668,9 @@ static void thread_detach_from_runtime(void)
   caml_thread_remove_and_free(th);
   /* Forget the now-freed thread info */
   st_tls_set(caml_thread_key, NULL);
+#ifdef _WIN32
+  caml_win32_destroy_high_resolution_timer();
+#endif
   /* Release domain lock */
   thread_lock_release(Caml_state->id);
 }
@@ -726,6 +729,10 @@ static void * caml_thread_tick(void * arg)
     atomic_store_release(&domain->requested_external_interrupt, 1);
     caml_interrupt_self();
   }
+
+#ifdef _WIN32
+  caml_win32_destroy_high_resolution_timer();
+#endif
   return NULL;
 }
 

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -15,7 +15,9 @@
 
 /* Win32 implementation of the "st" interface */
 
+#define CAML_INTERNALS
 #define WIN32_LEAN_AND_MEAN
+#include <caml/misc.h>
 #include <windows.h>
 
 typedef DWORD st_timeout;
@@ -27,7 +29,10 @@ Caml_inline st_timeout st_timeout_of_msec(int msec)
 
 Caml_inline void st_msleep(const st_timeout *timeout)
 {
-  Sleep(*timeout);
+  DWORD msec = *timeout;
+  const struct timespec req =
+    { .tv_sec = msec / MSEC_PER_SEC, .tv_nsec = msec % MSEC_PER_SEC };
+  caml_win32_nanosleep(&req, NULL);
 }
 
 #include "st_pthreads.h"

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -19,6 +19,7 @@
 #include <caml/memory.h>
 #include <caml/fail.h>
 #include <caml/signals.h>
+#include <caml/osdeps.h>
 #include "winworker.h"
 #include <stdio.h>
 #include "windbug.h"
@@ -1020,8 +1021,9 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       && exceptfds == Val_emptylist) {
     DEBUG_PRINT("nothing to do");
     if ( tm_sec > 0.0 ) {
+      const struct timespec req = caml_timespec_of_sec(tm_sec);
       caml_enter_blocking_section();
-      Sleep((DWORD) (tm_sec * MSEC_PER_SEC));
+      caml_win32_nanosleep(&req, NULL);
       caml_leave_blocking_section();
     }
     read_list = write_list = except_list = Val_emptylist;
@@ -1229,7 +1231,8 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       /* Nothing to monitor but some time to wait. */
       else if (!hasStaticData)
         {
-          Sleep(tm_msec);
+          const struct timespec req = caml_timespec_of_sec(tm_sec);
+          caml_win32_nanosleep(&req, NULL);
         }
       caml_leave_blocking_section();
 

--- a/otherlibs/unix/sleep_win32.c
+++ b/otherlibs/unix/sleep_win32.c
@@ -16,13 +16,15 @@
 #define CAML_INTERNALS
 #include <caml/mlvalues.h>
 #include <caml/signals.h>
+#include <caml/osdeps.h>
 #include "caml/unixsupport.h"
+#include <math.h>
 
 CAMLprim value caml_unix_sleep(value sec)
 {
-  DWORD msec = (DWORD) (Double_val(sec) * MSEC_PER_SEC);
+  const struct timespec req = caml_timespec_of_sec(Double_val(sec));
   caml_enter_blocking_section();
-  Sleep(msec);
+  caml_win32_nanosleep(&req, NULL);
   caml_leave_blocking_section();
   return Val_unit;
 }

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -138,6 +138,12 @@ CAMLextern value caml_win32_xdg_defaults(void);
 
 CAMLextern value caml_win32_get_temp_path(void);
 
+CAMLextern int caml_win32_nanosleep(const struct timespec *rqtp,
+                                    struct timespec *rmtp /* no-op */);
+
+CAMLextern void caml_win32_destroy_high_resolution_timer(void);
+CAMLextern void caml_win32_destroy_high_resolution_timers(void);
+
 #endif /* _WIN32 */
 
 /* Returns the current value of a counter that increments once per nanosecond.

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1293,7 +1293,9 @@ static void* domain_thread_func(void* v)
   } else {
     caml_gc_log("Failed to create domain");
   }
-#ifndef _WIN32
+#ifdef _WIN32
+  caml_win32_destroy_high_resolution_timer();
+#else
   caml_free_signal_stack(signal_stack);
 #endif
   return 0;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -484,7 +484,8 @@ unsigned caml_plat_spin_back_off(unsigned sleep_nsec,
                 loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
-  Sleep(sleep_nsec / NSEC_PER_MSEC);
+  const struct timespec req = caml_timespec_of_nsec(sleep_nsec);
+  caml_win32_nanosleep(&req, NULL);
 #elif defined (HAS_NANOSLEEP)
   const struct timespec req = caml_timespec_of_nsec(sleep_nsec);
   nanosleep(&req, NULL);

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -208,6 +208,7 @@ CAMLexport void caml_shutdown(void)
   caml_terminate_signals();
 #if defined(_WIN32) && defined(NATIVE_CODE)
   caml_win32_unregister_overflow_detection();
+  caml_win32_destroy_high_resolution_timers();
 #endif
 
   shutdown_happened = 1;

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1139,6 +1139,118 @@ int caml_num_rows_fd(int fd)
   return -1;
 }
 
+/* High-resolution timer used for sleeping */
+
+struct high_resolution_timer_list {
+  HANDLE timer;
+  struct high_resolution_timer_list *next;
+};
+
+static struct high_resolution_timer_list *_Atomic high_resolution_timers = NULL;
+static CAMLthread_local struct high_resolution_timer_list *
+  high_resolution_timer = NULL;
+
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
+
+static inline HANDLE create_high_resolution_timer(void)
+{
+  return CreateWaitableTimerEx(NULL, NULL,
+                               CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                               SYNCHRONIZE | TIMER_QUERY_STATE
+                               | TIMER_MODIFY_STATE);
+}
+
+static INIT_ONCE have_high_resolution_timer_init_once = INIT_ONCE_STATIC_INIT;
+static BOOL CALLBACK
+have_high_resolution_timer_init_function(PINIT_ONCE InitOnce,
+                                         PVOID Parameter,
+                                         PVOID *lpContext)
+{
+  HANDLE h = create_high_resolution_timer();
+  if ((*((bool *) *lpContext) = (h != NULL)))
+    CloseHandle(h);
+  return TRUE;
+}
+
+void caml_win32_destroy_high_resolution_timers(void)
+{
+  struct high_resolution_timer_list *hd = high_resolution_timer, *next = NULL;
+  while (hd != NULL) {
+    next = hd->next;
+    if (hd->timer)
+      CloseHandle(hd->timer);
+    caml_stat_free(hd);
+    hd = next;
+  }
+}
+
+void caml_win32_destroy_high_resolution_timer(void)
+{
+  if (high_resolution_timer != NULL && high_resolution_timer->timer != NULL) {
+    CloseHandle(high_resolution_timer->timer);
+    high_resolution_timer->timer = NULL;
+  }
+}
+
+int caml_win32_nanosleep(const struct timespec *rqtp,
+                         struct timespec *rmtp)
+{
+  DWORD timeout_msec;
+  (void) rmtp; /* ignored */
+
+  CAMLassert(rmtp == NULL);
+  if (rqtp->tv_nsec < 0 || rqtp->tv_nsec >= 1000000000) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  bool have_high_resolution_timer;
+  InitOnceExecuteOnce(&have_high_resolution_timer_init_once,
+                      have_high_resolution_timer_init_function,
+                      NULL, (LPVOID *) &have_high_resolution_timer);
+
+  if (have_high_resolution_timer && high_resolution_timer == NULL) {
+    high_resolution_timer =
+      caml_stat_alloc_noexc(sizeof(high_resolution_timer));
+    if (high_resolution_timer != NULL) {
+      if (! (high_resolution_timer->timer = create_high_resolution_timer())) {
+        caml_stat_free(high_resolution_timer);
+        high_resolution_timer = NULL;
+      } else {
+        do { high_resolution_timer->next = high_resolution_timers; }
+        while (! atomic_compare_exchange_strong(&high_resolution_timers,
+                                                &high_resolution_timer->next,
+                                                high_resolution_timer));
+      }
+    }
+  }
+
+  /* If the high-resolution timer is available, use it. Otherwise,
+   * fall-back to the low-resolution timer, which doesn't need a
+   * handle. */
+  if (high_resolution_timer != NULL) {
+    /* relative sleep (negative), 100ns units */
+    int64_t timeout_100_nsec =
+      - (int64_t) (rqtp->tv_sec * (NSEC_PER_SEC / 100) + rqtp->tv_nsec / 100);
+
+    SetWaitableTimer(high_resolution_timer->timer,
+                     (LARGE_INTEGER *) &timeout_100_nsec,
+                     0 /* aperiodic */,
+                     NULL, NULL, /* no callback */
+                     FALSE /* do not resume the system */);
+    timeout_msec = INFINITE;
+  } else {
+    /* FIXME: should we wait at least 1 msec? */
+    uint64_t msec = rqtp->tv_sec * MSEC_PER_SEC + rqtp->tv_nsec / NSEC_PER_MSEC;
+    timeout_msec = msec < INFINITE ? (DWORD) msec : INFINITE - 1;
+  }
+
+  WaitForSingleObject(high_resolution_timer->timer, timeout_msec);
+  return 0;
+}
+
 /* UCRT clock function returns wall-clock time */
 CAMLexport clock_t caml_win32_clock(void)
 {


### PR DESCRIPTION
By using a high-resolution timer, available since Windows 10 RS4
(1803), we can attain sleeps with a 100 nanosecond precision.

A handle representing the high-resolution timer is required for a
thread to sleep. In order to avoid paying the cost of creating and
closing the timer, it is re-set (reused). The timer needs to be stored
somewhere: the domain state is not a good fit as the domain state
cannot be accessed once the runtime system is released, which is
typically the case before a sleep. Moreover, multiple systhreads
belonging to a single domain might want to sleep simultanously.
The systhread structure isn't a good fit either, as runtime threads
don't have access to this. Thread-local storage is a viable option.

Timer handles are created on-demand at the first
`caml_win32_nanosleep` call of the thread. The first thread entering
this function tests if timer handles can be created at all (with a
`PINIT_ONCE`, the equivalent of `pthread_once`), as the feature might
not be supported by the Windows host. Other threads then check if
`have_high_resolution_timers` is `true`, and if so, attempt to create
timers.

It seems difficult to precisely know when to close this handle, in
each and every case. To defend against mistakes, we keep a linked list
of these handles. In some cases, threads will close their timer handle
to prevent handle exhaustion when they exit. In the general case, they
will be closed during `caml_shutdown`.

This commit allows more precision in the platform spin-waits, and also
avoids rounding down quirks: `Sleep(0)` will put the process at the
end of the process queue, without sleeping.