### PR TITLE
Improve C11 atomics detection and usage

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -535,27 +535,3 @@ AC_DEFUN([OCAML_QUOTED_STRING_ID], [
     fi
   done
 ])
-
-AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
-  AC_MSG_CHECKING([whether the C compiler supports _Atomic types])
-  saved_LIBS="$LIBS"
-  LIBS="$LIBS $1"
-  AC_LINK_IFELSE([AC_LANG_SOURCE([[
-    #include <stdint.h>
-    #include <stdatomic.h>
-    int main(void)
-    {
-      _Atomic int64_t n;
-      int m;
-      int * _Atomic p = &m;
-      atomic_store_explicit(&n, 123, memory_order_release);
-      * atomic_exchange(&p, 0) = 45;
-      return atomic_load_explicit(&n, memory_order_acquire);
-    }
-    ]])],
-  [cc_supports_atomic=true
-   AC_MSG_RESULT([yes])],
-  [cc_supports_atomic=false
-   AC_MSG_RESULT([no])])
-  LIBS="$saved_LIBS"
-])

--- a/configure
+++ b/configure
@@ -15300,19 +15300,17 @@ esac
 ac_fn_check_decl "$LINENO" "__STDC_NO_ATOMICS__" "ac_cv_have_decl___STDC_NO_ATOMICS__" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
 if test "x$ac_cv_have_decl___STDC_NO_ATOMICS__" = xyes
 then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+  case $ocaml_cv_cc_vendor in #(
+  # MSVC support is still incomplete and guarded, but sufficient
+    msvc-*) :
+    internal_cppflags="$internal_cppflags -U__STDC_NO_ATOMICS__" ;; #(
+  *) :
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
 printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "C11 atomic support is required, use another C compiler
-See \`config.log' for more details" "$LINENO" 5; }
-fi
+See \`config.log' for more details" "$LINENO" 5; } ;;
+esac
 
-OCAML_CC_SUPPORTS_ATOMIC($cclibs)
-if ! $cc_supports_atomic
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "C11 atomic support is required, use another C compiler
-See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 # Full support for C11 __thread variables

--- a/configure
+++ b/configure
@@ -14617,14 +14617,6 @@ then :
 fi
 
 
-ac_fn_c_check_header_compile "$LINENO" "stdatomic.h" "ac_cv_header_stdatomic_h" "$ac_includes_default"
-if test "x$ac_cv_header_stdatomic_h" = xyes
-then :
-  printf "%s\n" "#define HAS_STDATOMIC_H 1" >>confdefs.h
-
-fi
-
-
 ac_fn_c_check_header_compile "$LINENO" "sys/mman.h" "ac_cv_header_sys_mman_h" "$ac_includes_default"
 if test "x$ac_cv_header_sys_mman_h" = xyes
 then :
@@ -15225,42 +15217,96 @@ esac
 fi
 
 # Support for C11 atomic types
-
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports _Atomic types" >&5
-printf %s "checking whether the C compiler supports _Atomic types... " >&6; }
-  saved_LIBS="$LIBS"
-  LIBS="$LIBS $cclibs"
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC options needed to detect all undeclared functions" >&5
+printf %s "checking for $CC options needed to detect all undeclared functions... " >&6; }
+if test ${ac_cv_c_undeclared_builtin_options+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_save_CFLAGS=$CFLAGS
+   ac_cv_c_undeclared_builtin_options='cannot detect'
+   for ac_arg in '' -fno-builtin; do
+     CFLAGS="$ac_save_CFLAGS $ac_arg"
+     # This test program should *not* compile successfully.
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-    #include <stdint.h>
-    #include <stdatomic.h>
-    int main(void)
-    {
-      _Atomic int64_t n;
-      int m;
-      int * _Atomic p = &m;
-      atomic_store_explicit(&n, 123, memory_order_release);
-      * atomic_exchange(&p, 0) = 45;
-      return atomic_load_explicit(&n, memory_order_acquire);
-    }
-
+int
+main (void)
+{
+(void) strchr;
+  ;
+  return 0;
+}
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
+if ac_fn_c_try_compile "$LINENO"
 then :
-  cc_supports_atomic=true
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
-  cc_supports_atomic=false
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-  LIBS="$saved_LIBS"
 
+else $as_nop
+  # This test program should compile successfully.
+        # No library function is consistently available on
+        # freestanding implementations, so test against a dummy
+        # declaration.  Include always-available headers on the
+        # off chance that they somehow elicit warnings.
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <float.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stddef.h>
+extern void ac_decl (int, char *);
+
+int
+main (void)
+{
+(void) ac_decl (0, (char *) 0);
+  (void) ac_decl;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  if test x"$ac_arg" = x
+then :
+  ac_cv_c_undeclared_builtin_options='none needed'
+else $as_nop
+  ac_cv_c_undeclared_builtin_options=$ac_arg
+fi
+          break
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+    done
+    CFLAGS=$ac_save_CFLAGS
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_undeclared_builtin_options" >&5
+printf "%s\n" "$ac_cv_c_undeclared_builtin_options" >&6; }
+  case $ac_cv_c_undeclared_builtin_options in #(
+  'cannot detect') :
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot make $CC report undeclared builtins
+See \`config.log' for more details" "$LINENO" 5; } ;; #(
+  'none needed') :
+    ac_c_undeclared_builtin_options='' ;; #(
+  *) :
+    ac_c_undeclared_builtin_options=$ac_cv_c_undeclared_builtin_options ;;
+esac
+
+ac_fn_check_decl "$LINENO" "__STDC_NO_ATOMICS__" "ac_cv_have_decl___STDC_NO_ATOMICS__" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl___STDC_NO_ATOMICS__" = xyes
+then :
+  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "C11 atomic support is required, use another C compiler
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+OCAML_CC_SUPPORTS_ATOMIC($cclibs)
 if ! $cc_supports_atomic
 then :
   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -16254,86 +16300,6 @@ fi
 fi
 
 ## getentropy
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC options needed to detect all undeclared functions" >&5
-printf %s "checking for $CC options needed to detect all undeclared functions... " >&6; }
-if test ${ac_cv_c_undeclared_builtin_options+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_save_CFLAGS=$CFLAGS
-   ac_cv_c_undeclared_builtin_options='cannot detect'
-   for ac_arg in '' -fno-builtin; do
-     CFLAGS="$ac_save_CFLAGS $ac_arg"
-     # This test program should *not* compile successfully.
-     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-int
-main (void)
-{
-(void) strchr;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-
-else $as_nop
-  # This test program should compile successfully.
-        # No library function is consistently available on
-        # freestanding implementations, so test against a dummy
-        # declaration.  Include always-available headers on the
-        # off chance that they somehow elicit warnings.
-        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <float.h>
-#include <limits.h>
-#include <stdarg.h>
-#include <stddef.h>
-extern void ac_decl (int, char *);
-
-int
-main (void)
-{
-(void) ac_decl (0, (char *) 0);
-  (void) ac_decl;
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  if test x"$ac_arg" = x
-then :
-  ac_cv_c_undeclared_builtin_options='none needed'
-else $as_nop
-  ac_cv_c_undeclared_builtin_options=$ac_arg
-fi
-          break
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    done
-    CFLAGS=$ac_save_CFLAGS
-
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_undeclared_builtin_options" >&5
-printf "%s\n" "$ac_cv_c_undeclared_builtin_options" >&6; }
-  case $ac_cv_c_undeclared_builtin_options in #(
-  'cannot detect') :
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot make $CC report undeclared builtins
-See \`config.log' for more details" "$LINENO" 5; } ;; #(
-  'none needed') :
-    ac_c_undeclared_builtin_options='' ;; #(
-  *) :
-    ac_c_undeclared_builtin_options=$ac_cv_c_undeclared_builtin_options ;;
-esac
-
 ac_fn_c_check_header_compile "$LINENO" "unistd.h" "ac_cv_header_unistd_h" "$ac_includes_default"
 if test "x$ac_cv_header_unistd_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -1122,11 +1122,12 @@ AS_IF([! $arch64],
 
 # Support for C11 atomic types
 AC_CHECK_DECL([__STDC_NO_ATOMICS__],
-  [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
-
-OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
-AS_IF([! $cc_supports_atomic],
-  [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
+  [AS_CASE([$ocaml_cv_cc_vendor],
+    # MSVC support is still incomplete and guarded, but sufficient
+    [msvc-*],
+      [internal_cppflags="$internal_cppflags -U__STDC_NO_ATOMICS__"],
+    [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
+  ])
 
 # Full support for C11 __thread variables
 # macOS and MinGW-64 have problems with __thread variables accessed from DLLs

--- a/configure.ac
+++ b/configure.ac
@@ -1045,8 +1045,6 @@ AC_CHECK_HEADER([dirent.h], [AC_DEFINE([HAS_DIRENT])], [],
 AC_CHECK_HEADER([sys/select.h], [AC_DEFINE([HAS_SYS_SELECT_H])], [],
   [#include <sys/types.h>])
 
-AC_CHECK_HEADER([stdatomic.h], [AC_DEFINE([HAS_STDATOMIC_H])])
-
 AC_CHECK_HEADER([sys/mman.h], [AC_DEFINE([HAS_SYS_MMAN_H])])
 
 # Checks for types
@@ -1123,6 +1121,8 @@ AS_IF([! $arch64],
     [gcc-*], [cclibs="$cclibs -latomic"])])
 
 # Support for C11 atomic types
+AC_CHECK_DECL([__STDC_NO_ATOMICS__],
+  [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 
 OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
 AS_IF([! $cc_supports_atomic],

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -22,7 +22,6 @@
 
 extern "C++" {
 #include <atomic>
-#define ATOMIC_UINTNAT_INIT(x) (x)
 typedef std::atomic<uintnat> atomic_uintnat;
 typedef std::atomic<intnat> atomic_intnat;
 using std::memory_order_relaxed;
@@ -35,7 +34,6 @@ using std::memory_order_seq_cst;
 #elif !defined(__STDC_NO_ATOMICS__)
 
 #include <stdatomic.h>
-#define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
 

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -32,7 +32,7 @@ using std::memory_order_acq_rel;
 using std::memory_order_seq_cst;
 }
 
-#elif defined(HAS_STDATOMIC_H)
+#elif !defined(__STDC_NO_ATOMICS__)
 
 #include <stdatomic.h>
 #define ATOMIC_UINTNAT_INIT(x) (x)
@@ -40,7 +40,7 @@ typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
 
 #else
-#error "C11 atomics are unavailable on this platform. See camlatomic.h"
+#error "C11 atomic support is required, use another C compiler"
 #endif
 
 #endif /* CAML_ATOMIC_H */

--- a/runtime/caml/camlatomic.h
+++ b/runtime/caml/camlatomic.h
@@ -18,12 +18,6 @@
 
 #include "config.h"
 
-/* On platforms supporting C11 atomics, this file just includes <stdatomic.h>.
-
-   On other platforms, this file includes platform-specific stubs for
-   the subset of C11 atomics needed by the OCaml runtime
- */
-
 #ifdef __cplusplus
 
 extern "C++" {
@@ -44,39 +38,6 @@ using std::memory_order_seq_cst;
 #define ATOMIC_UINTNAT_INIT(x) (x)
 typedef _Atomic uintnat atomic_uintnat;
 typedef _Atomic intnat atomic_intnat;
-
-#elif defined(__GNUC__)
-
-/* Support for versions of gcc which have built-in atomics but do not
-   expose stdatomic.h (e.g. gcc 4.8) */
-typedef enum memory_order {
-  memory_order_relaxed = __ATOMIC_RELAXED,
-  memory_order_acquire = __ATOMIC_ACQUIRE,
-  memory_order_release = __ATOMIC_RELEASE,
-  memory_order_acq_rel = __ATOMIC_ACQ_REL,
-  memory_order_seq_cst = __ATOMIC_SEQ_CST
-} memory_order;
-
-#define ATOMIC_UINTNAT_INIT(x) { (x) }
-typedef struct { uintnat repr; } atomic_uintnat;
-typedef struct { intnat repr; } atomic_intnat;
-
-#define atomic_load_explicit(x, m) __atomic_load_n(&(x)->repr, (m))
-#define atomic_load(x) atomic_load_explicit((x), memory_order_seq_cst)
-#define atomic_store_explicit(x, v, m) __atomic_store_n(&(x)->repr, (v), (m))
-#define atomic_store(x, v) atomic_store_explicit((x), (v), memory_order_seq_cst)
-#define atomic_compare_exchange_strong(x, oldv, newv) \
-  __atomic_compare_exchange_n( \
-    &(x)->repr, \
-    (oldv), (newv), 0, \
-    memory_order_seq_cst, memory_order_seq_cst)
-#define atomic_exchange(x, newv) \
-  __atomic_exchange_n(&(x)->repr, (newv), memory_order_seq_cst)
-#define atomic_fetch_add(x, n) \
-  __atomic_fetch_add(&(x)->repr, (n), memory_order_seq_cst)
-#define atomic_fetch_or(x, n) \
-  __atomic_fetch_or(&(x)->repr, (n), memory_order_seq_cst)
-#define atomic_thread_fence __atomic_thread_fence
 
 #else
 #error "C11 atomics are unavailable on this platform. See camlatomic.h"

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -78,8 +78,6 @@
 
 #undef HAS_ISSETUGID
 
-#undef HAS_STDATOMIC_H
-
 #undef HAS_SYS_MMAN_H
 
 /* 2. For the Unix library. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -202,14 +202,14 @@ static struct {
 
   caml_domain_state* participating[Max_domains];
 } stw_request = {
-  ATOMIC_UINTNAT_INIT(0),
-  ATOMIC_UINTNAT_INIT(0),
+  0,
+  0,
   NULL,
   NULL,
   NULL,
   NULL,
   0,
-  ATOMIC_UINTNAT_INIT(0),
+  0,
   { 0 },
 };
 

--- a/runtime/fail_nat.c
+++ b/runtime/fail_nat.c
@@ -199,7 +199,7 @@ CAMLexport value caml_raise_if_exception(value res)
    for the ccall to [caml_array_bound_error]).  */
 static value array_bound_exn(void)
 {
-  static atomic_uintnat exn_cache = ATOMIC_UINTNAT_INIT(0);
+  static atomic_uintnat exn_cache = 0;
   const value* exn = (const value*)atomic_load_acquire(&exn_cache);
   if (!exn) {
     exn = caml_named_value("Pervasives.array_bound_error");


### PR DESCRIPTION
This PR overhauls how we detect C11 atomics, and some pattern of their usage.

1. We were already requiring at least GCC 4.9 during configure. GCC 4.9 introduced the support for C11 atomics. The GCC pre-4.9 stubs are thus not necessary. (fix issue 12725).
2. A standard compliant compiler has to define `__STDC_NO_ATOMICS__` if it doesn't support atomics, meaning that it doesn't provide the `_Atomic` type specifier, nor the `<stdatomic.h>` header. Using this allows us to have nice portable code in OCaml, without compiler-specific code. Granted, a non-compliant compiler not furnishing atomics might forget to define `__STDC_NO_ATOMICS__`, and we'll get a lot less nicer error message.
3. The `ATOMIC_UINTNAT_INIT` macro is a no-op. The standard macro `ATOMIC_VAR_INIT` from which it was probably inspired has been removed in C17. Let's remove our macro.
4. WIP: MSVC has incomplete support for atomics, hidden behind a feature flag and the `__STDC_NO_ATOMICS__` macro. The support is however sufficient (but buggy) for OCaml. We can *internally* using *compilation flags* disable this warning to force support, and have the headers stay simple, without any special cases for MSVC.