### PR TITLE
🚀 Simplify `CAMLalign` and use C11 `max_align_t`

### DIFF
--- a/Changes
+++ b/Changes
@@ -36,6 +36,10 @@ _______________
 - #11779, #13117: Improve logic for fiber stack alignment.
   (Miod Vallat, report by Damien Doligez, review by Gabriel Scherer)
 
+- #?????: Simplify CAMLalign to always use C23/C++11 alignas or C11
+  _Alignas.
+  (Antonin Décimo, review by ?????)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -94,14 +94,6 @@ AC_DEFUN([OCAML_SIGNAL_HANDLERS_SEMANTICS], [
   )
 ])
 
-AC_DEFUN([OCAML_CC_SUPPORTS_ALIGNED], [
-  AC_MSG_CHECKING([whether the C compiler supports __attribute__((aligned(n)))])
-  AC_COMPILE_IFELSE(
-    [AC_LANG_SOURCE([typedef struct {__attribute__((aligned(8))) int t;} t;])],
-    [AC_DEFINE([SUPPORTS_ALIGNED_ATTRIBUTE])
-    AC_MSG_RESULT([yes])],
-    [AC_MSG_RESULT([no])])])
-
 AC_DEFUN([OCAML_CC_SUPPORTS_TREE_VECTORIZE], [
   AC_MSG_CHECKING(
  [whether the C compiler supports __attribute__((optimize("tree-vectorize")))])

--- a/configure
+++ b/configure
@@ -15477,6 +15477,17 @@ fi
 esac
 fi
 
+ac_fn_c_check_type "$LINENO" "max_align_t" "ac_cv_type_max_align_t" "#include <stddef.h>
+"
+if test "x$ac_cv_type_max_align_t" = xyes
+then :
+
+printf "%s\n" "#define HAVE_MAX_ALIGN_T 1" >>confdefs.h
+
+
+fi
+
+
 # Atomics library
 
 if ! $arch64

--- a/configure
+++ b/configure
@@ -15974,25 +15974,6 @@ fi
      ;;
 esac
 
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports __attribute__((aligned(n)))" >&5
-printf %s "checking whether the C compiler supports __attribute__((aligned(n)))... " >&6; }
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-typedef struct {__attribute__((aligned(8))) int t;} t;
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  printf "%s\n" "#define SUPPORTS_ALIGNED_ATTRIBUTE 1" >>confdefs.h
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-
 ## Check whether __attribute__((optimize("tree-vectorize")))) is supported
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports __attribute__((optimize(\"tree-vectorize\")))" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1375,8 +1375,6 @@ AS_CASE(["$ocaml_cc_vendor,$host"],
       [internal_cflags="$internal_cflags -fno-tree-vrp"], [],
       [$warn_error_flag])])
 
-OCAML_CC_SUPPORTS_ALIGNED
-
 ## Check whether __attribute__((optimize("tree-vectorize")))) is supported
 OCAML_CC_SUPPORTS_TREE_VECTORIZE
 

--- a/configure.ac
+++ b/configure.ac
@@ -1213,6 +1213,8 @@ AS_IF([! $arch64],
       [AC_DEFINE([ARCH_ALIGN_INT64], [1])])])
     ])])
 
+AC_CHECK_TYPES([max_align_t], [], [], [[#include <stddef.h>]])
+
 # Atomics library
 
 AS_IF([! $arch64],

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -141,17 +141,11 @@ CAMLdeprecated_typedef(addr, char *);
 /* by ocamlopt makes direct references into the domain state structure,*/
 /* which is stored in a register on many platforms. For this to work, */
 /* we need to be able to compute the exact offset of each member. */
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
-#define CAMLalign(n) _Alignas(n)
-#elif defined(__cplusplus) \
-   && (__cplusplus >= 201103L || defined(_MSC_VER) && _MSC_VER >= 1900)
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
+    defined(__cplusplus)
 #define CAMLalign(n) alignas(n)
-#elif defined(SUPPORTS_ALIGNED_ATTRIBUTE)
-#define CAMLalign(n) __attribute__((aligned(n)))
-#elif defined(_MSC_VER)
-#define CAMLalign(n) __declspec(align(n))
 #else
-#error "How do I align values on this platform?"
+#define CAMLalign(n) _Alignas(n)
 #endif
 
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -307,3 +307,5 @@
 #undef HAS_BSD_GETAFFINITY_NP
 
 #undef HAS_ZSTD
+
+#undef HAVE_MAX_ALIGN_T

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -488,18 +488,8 @@ CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
    the implementation from the user.
 */
 
-#ifndef HAVE_MAX_ALIGN_T
-/* A type with the most strict alignment requirements */
-typedef union {
-  char c;
-  short s;
-  long l;
-  int i;
-  float f;
-  double d;
-  void *v;
-  void (*q)(void);
-} max_align_t;
+#if !defined(HAVE_MAX_ALIGN_T) && defined(_MSC_VER)
+typedef double max_align_t;
 #endif
 
 struct pool_block {

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -488,8 +488,9 @@ CAMLexport value caml_alloc_shr_noexc(mlsize_t wosize, tag_t tag) {
    the implementation from the user.
 */
 
+#ifndef HAVE_MAX_ALIGN_T
 /* A type with the most strict alignment requirements */
-union max_align {
+typedef union {
   char c;
   short s;
   long l;
@@ -498,7 +499,8 @@ union max_align {
   double d;
   void *v;
   void (*q)(void);
-};
+} max_align_t;
+#endif
 
 struct pool_block {
 #ifdef DEBUG
@@ -506,7 +508,7 @@ struct pool_block {
 #endif
   struct pool_block *next;
   struct pool_block *prev;
-  union max_align data[];  /* not allocated, used for alignment purposes */
+  max_align_t data[]; /* not allocated, used for alignment purposes */
 };
 
 #define SIZEOF_POOL_BLOCK sizeof(struct pool_block)


### PR DESCRIPTION
Some cleanups removing checks and workarounds for older compilers, assuming that the compiler supports C11 or C++11 out of the box. We may use [`_Alignas` (since C11) or `alignas` (since C23)](https://en.cppreference.com/w/c/language/_Alignas) directly, and use the [`max_align_t`](https://en.cppreference.com/w/c/types/max_align_t) type.

```c
typedef struct {
  long long ll CAMLalign(CAMLalignof(long long));
  long double ld CAMLalign(CAMLalignof(long double));
} max_align_t;
```