### PR TITLE
Allow building with clang-cl

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -20,11 +20,15 @@ jobs:
 
     timeout-minutes: 60
 
-    name: ${{ matrix.x86_64 && 'MSVC 64 bits' || 'MSVC 32 bits' }}
+    name: ${{ matrix.cc == 'cl' && 'MSVC' || 'clang-cl' }} ${{ matrix.x86_64 && '64 bits' || '32 bits' }}
 
     strategy:
       matrix:
         x86_64: [true, false]
+        cc: [cl, clang-cl]
+        exclude:
+          - cc: clang-cl
+            x86_64: false
 
     steps:
       - name: Save pristine PATH
@@ -71,9 +75,10 @@ jobs:
         shell: bash -e {0}
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
+          CC: ${{ matrix.cc }}
         run: >-
           eval $(tools/msvs-promote-path) ;
-          ./configure --host=$HOST ;
+          ./configure --host=$HOST CC=$CC;
           make ;
           runtime/ocamlrun ocamlc -config ;
 

--- a/Changes
+++ b/Changes
@@ -9,6 +9,9 @@ _______________
   (David Allsopp, Antonin Décimo, Samuel Hym, and Miod Vallat, review by Nicolás
    Ojeda Bär)
 
+- #?????: Allow building the MSVC port with clang-cl
+  (Antonin Décimo, review by ???)
+
 ### Language features:
 
 ### Runtime system:

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -549,8 +549,10 @@ AC_DEFUN([OCAML_QUOTED_STRING_ID], [
 
 AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
   AC_MSG_CHECKING([whether the C compiler supports _Atomic types])
-  saved_LIBS="$LIBS"
-  LIBS="$LIBS $1"
+  OCAML_CC_SAVE_VARIABLES
+  AS_IF([test -n "$1"],[CFLAGS="$CFLAGS $1"])
+  AS_IF([test -n "$2"],[LIBS="$LIBS $2"])
+
   AC_LINK_IFELSE([AC_LANG_SOURCE([[
     #include <stdint.h>
     #include <stdatomic.h>
@@ -568,5 +570,6 @@ AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
    AC_MSG_RESULT([yes])],
   [cc_supports_atomic=false
    AC_MSG_RESULT([no])])
-  LIBS="$saved_LIBS"
+
+  OCAML_CC_RESTORE_VARIABLES
 ])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -144,19 +144,6 @@ AC_DEFUN([OCAML_CC_HAS_DEBUG_PREFIX_MAP], [
   CFLAGS="$saved_CFLAGS"
 ])
 
-AC_DEFUN([OCAML_CL_HAS_VOLATILE_METADATA], [
-  AC_MSG_CHECKING([whether the C compiler supports -d2VolatileMetadata-])
-  saved_CFLAGS="$CFLAGS"
-  CFLAGS="-d2VolatileMetadata- $CFLAGS"
-  AC_COMPILE_IFELSE(
-    [AC_LANG_SOURCE([int main() { return 0; }])],
-    [cl_has_volatile_metadata=true
-    AC_MSG_RESULT([yes])],
-    [cl_has_volatile_metadata=false
-    AC_MSG_RESULT([no])])
-  CFLAGS="$saved_CFLAGS"
-])
-
 # Save C compiler related variables
 AC_DEFUN([OCAML_CC_SAVE_VARIABLES], [
   saved_CC="$CC"

--- a/configure
+++ b/configure
@@ -14009,7 +14009,7 @@ case $ocaml_cc_vendor in #(
     common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
-    internal_cppflags='-DUNICODE -D_UNICODE'
+    internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
     as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-d2VolatileMetadata-" | $as_tr_sh`
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -d2VolatileMetadata-" >&5
 printf %s "checking whether C compiler accepts -d2VolatileMetadata-... " >&6; }

--- a/configure
+++ b/configure
@@ -14006,10 +14006,10 @@ case $ocaml_cc_vendor in #(
     # No C11 atomics support
     as_fn_error 69 "This version of MSVC is too old. Please use Visual Studio version 17.8 or above." "$LINENO" 5 ;; #(
   msvc-*) :
-    common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
+    common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cppflags='-DUNICODE -D_UNICODE'
-    internal_cflags='-experimental:c11atomics -std:c11'
+    internal_cflags="$cc_warnings -experimental:c11atomics -std:c11"
     CFLAGS="$CFLAGS -experimental:c11atomics -std:c11"
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -d2VolatileMetadata-" >&5

--- a/configure
+++ b/configure
@@ -14009,7 +14009,8 @@ case $ocaml_cc_vendor in #(
     common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
-    internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
+    internal_cppflags="-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS \
+-D_WINSOCK_DEPRECATED_NO_WARNINGS"
     as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-d2VolatileMetadata-" | $as_tr_sh`
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -d2VolatileMetadata-" >&5
 printf %s "checking whether C compiler accepts -d2VolatileMetadata-... " >&6; }

--- a/configure
+++ b/configure
@@ -14008,9 +14008,8 @@ case $ocaml_cc_vendor in #(
   msvc-*) :
     common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
+    internal_cflags="$cc_warnings"
     internal_cppflags='-DUNICODE -D_UNICODE'
-    internal_cflags="$cc_warnings -experimental:c11atomics -std:c11"
-    CFLAGS="$CFLAGS -experimental:c11atomics -std:c11"
     as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-d2VolatileMetadata-" | $as_tr_sh`
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -d2VolatileMetadata-" >&5
 printf %s "checking whether C compiler accepts -d2VolatileMetadata-... " >&6; }
@@ -15458,11 +15457,32 @@ fi
 
 # Support for C11 atomic types
 
+case $ocaml_cc_vendor in #(
+  msvc-*) :
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports _Atomic types" >&5
 printf %s "checking whether the C compiler supports _Atomic types... " >&6; }
+
+  saved_CC="$CC"
+  saved_CFLAGS="$CFLAGS"
+  saved_CPPFLAGS="$CPPFLAGS"
   saved_LIBS="$LIBS"
-  LIBS="$LIBS $cclibs"
+  saved_ac_ext="$ac_ext"
+  saved_ac_compile="$ac_compile"
+  # Move the content of confdefs.h to another file so it does not
+  # get included
+  mv confdefs.h confdefs.h.bak
+  touch confdefs.h
+
+  if test -n ""
+then :
+  CFLAGS="$CFLAGS "
+fi
+  if test -n ""
+then :
+  LIBS="$LIBS "
+fi
+
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -15491,8 +15511,225 @@ printf "%s\n" "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext conftest.$ac_ext
+
+
+  # Restore the content of confdefs.h
+  mv confdefs.h.bak confdefs.h
+  ac_compile="$saved_ac_compile"
+  ac_ext="$saved_ac_ext"
+  CPPFLAGS="$saved_CPPFLAGS"
+  CFLAGS="$saved_CFLAGS"
+  CC="$saved_CC"
   LIBS="$saved_LIBS"
 
+
+     if ! $cc_supports_atomic
+then :
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports _Atomic types" >&5
+printf %s "checking whether the C compiler supports _Atomic types... " >&6; }
+
+  saved_CC="$CC"
+  saved_CFLAGS="$CFLAGS"
+  saved_CPPFLAGS="$CPPFLAGS"
+  saved_LIBS="$LIBS"
+  saved_ac_ext="$ac_ext"
+  saved_ac_compile="$ac_compile"
+  # Move the content of confdefs.h to another file so it does not
+  # get included
+  mv confdefs.h confdefs.h.bak
+  touch confdefs.h
+
+  if test -n "-std:c11"
+then :
+  CFLAGS="$CFLAGS -std:c11"
+fi
+  if test -n ""
+then :
+  LIBS="$LIBS "
+fi
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <stdint.h>
+    #include <stdatomic.h>
+    int main(void)
+    {
+      _Atomic int64_t n;
+      int m;
+      int * _Atomic p = &m;
+      atomic_store_explicit(&n, 123, memory_order_release);
+      * atomic_exchange(&p, 0) = 45;
+      return atomic_load_explicit(&n, memory_order_acquire);
+    }
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  cc_supports_atomic=true
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
+  cc_supports_atomic=false
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+
+  # Restore the content of confdefs.h
+  mv confdefs.h.bak confdefs.h
+  ac_compile="$saved_ac_compile"
+  ac_ext="$saved_ac_ext"
+  CPPFLAGS="$saved_CPPFLAGS"
+  CFLAGS="$saved_CFLAGS"
+  CC="$saved_CC"
+  LIBS="$saved_LIBS"
+
+
+        if $cc_supports_atomic
+then :
+  common_cflags="$common_cflags -std:c11"
+else $as_nop
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports _Atomic types" >&5
+printf %s "checking whether the C compiler supports _Atomic types... " >&6; }
+
+  saved_CC="$CC"
+  saved_CFLAGS="$CFLAGS"
+  saved_CPPFLAGS="$CPPFLAGS"
+  saved_LIBS="$LIBS"
+  saved_ac_ext="$ac_ext"
+  saved_ac_compile="$ac_compile"
+  # Move the content of confdefs.h to another file so it does not
+  # get included
+  mv confdefs.h confdefs.h.bak
+  touch confdefs.h
+
+  if test -n "-std:c11 -experimental:c11atomics"
+then :
+  CFLAGS="$CFLAGS -std:c11 -experimental:c11atomics"
+fi
+  if test -n ""
+then :
+  LIBS="$LIBS "
+fi
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <stdint.h>
+    #include <stdatomic.h>
+    int main(void)
+    {
+      _Atomic int64_t n;
+      int m;
+      int * _Atomic p = &m;
+      atomic_store_explicit(&n, 123, memory_order_release);
+      * atomic_exchange(&p, 0) = 45;
+      return atomic_load_explicit(&n, memory_order_acquire);
+    }
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  cc_supports_atomic=true
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
+  cc_supports_atomic=false
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+
+  # Restore the content of confdefs.h
+  mv confdefs.h.bak confdefs.h
+  ac_compile="$saved_ac_compile"
+  ac_ext="$saved_ac_ext"
+  CPPFLAGS="$saved_CPPFLAGS"
+  CFLAGS="$saved_CFLAGS"
+  CC="$saved_CC"
+  LIBS="$saved_LIBS"
+
+
+           if $cc_supports_atomic
+then :
+  common_cflags="$common_cflags -std:c11 -experimental:c11atomics"
+fi
+
+fi
+fi ;; #(
+  *) :
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports _Atomic types" >&5
+printf %s "checking whether the C compiler supports _Atomic types... " >&6; }
+
+  saved_CC="$CC"
+  saved_CFLAGS="$CFLAGS"
+  saved_CPPFLAGS="$CPPFLAGS"
+  saved_LIBS="$LIBS"
+  saved_ac_ext="$ac_ext"
+  saved_ac_compile="$ac_compile"
+  # Move the content of confdefs.h to another file so it does not
+  # get included
+  mv confdefs.h confdefs.h.bak
+  touch confdefs.h
+
+  if test -n ""
+then :
+  CFLAGS="$CFLAGS "
+fi
+  if test -n "$cclibs"
+then :
+  LIBS="$LIBS $cclibs"
+fi
+
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+    #include <stdint.h>
+    #include <stdatomic.h>
+    int main(void)
+    {
+      _Atomic int64_t n;
+      int m;
+      int * _Atomic p = &m;
+      atomic_store_explicit(&n, 123, memory_order_release);
+      * atomic_exchange(&p, 0) = 45;
+      return atomic_load_explicit(&n, memory_order_acquire);
+    }
+
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  cc_supports_atomic=true
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else $as_nop
+  cc_supports_atomic=false
+   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+
+
+  # Restore the content of confdefs.h
+  mv confdefs.h.bak confdefs.h
+  ac_compile="$saved_ac_compile"
+  ac_ext="$saved_ac_ext"
+  CPPFLAGS="$saved_CPPFLAGS"
+  CFLAGS="$saved_CFLAGS"
+  CC="$saved_CC"
+  LIBS="$saved_LIBS"
+
+ ;;
+esac
 if ! $cc_supports_atomic
 then :
   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5

--- a/configure
+++ b/configure
@@ -13974,6 +13974,20 @@ case $enable_warn_error,true in #(
      ;;
 esac
 
+case $host in #(
+  *-*-mingw32*|*-pc-windows) :
+    case $WINDOWS_UNICODE_MODE in #(
+  ansi) :
+    windows_unicode=0 ;; #(
+  compatible|"") :
+    windows_unicode=1 ;; #(
+  *) :
+    as_fn_error $? "unexpected windows unicode mode" "$LINENO" 5 ;;
+esac ;; #(
+  *) :
+    windows_unicode=0 ;;
+esac
+
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)
 # - strict no-overflow conditions on signed integer arithmetic
@@ -13998,8 +14012,7 @@ case $ocaml_cc_vendor in #(
     # TODO: see whether the code can be fixed to avoid -Wno-unused
     common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
     internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
-    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE=$windows_unicode" ;; #(
   mingw-*) :
     as_fn_error $? "Unsupported C compiler for a MinGW-w64 build" "$LINENO" 5 ;; #(
   msvc-0*|msvc-1[0-8]*|msvc-19[012]*|msvc-193[0-7]) :
@@ -14051,8 +14064,7 @@ else $as_nop
   :
 fi
 
-    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE=$windows_unicode" ;; #(
   xlc-*) :
     common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
     internal_cflags="$cc_warnings" ;; #(
@@ -20810,20 +20822,6 @@ if test x"$mandir" = x'${datarootdir}/man'
 then :
   mandir='${prefix}/man'
 fi
-
-case $host in #(
-  *-*-mingw32*|*-pc-windows) :
-    case $WINDOWS_UNICODE_MODE in #(
-  ansi) :
-    windows_unicode=0 ;; #(
-  compatible|"") :
-    windows_unicode=1 ;; #(
-  *) :
-    as_fn_error $? "unexpected windows unicode mode" "$LINENO" 5 ;;
-esac ;; #(
-  *) :
-    windows_unicode=0 ;;
-esac
 
 # Define default prefix correctly for the different Windows ports
 if test x"$prefix" = "xNONE"

--- a/configure
+++ b/configure
@@ -3692,7 +3692,12 @@ esac
 
 case $host in #(
   *-pc-windows) :
-    CC=cl
+    case $CC in #(
+  cl|cl.exe|clang-cl|clang-cl.exe) :
+     ;; #(
+  *) :
+    CC=cl ;;
+esac
     ccomptype=msvc
     S=asm
     SO=dll

--- a/configure
+++ b/configure
@@ -14011,32 +14011,46 @@ case $ocaml_cc_vendor in #(
     internal_cppflags='-DUNICODE -D_UNICODE'
     internal_cflags="$cc_warnings -experimental:c11atomics -std:c11"
     CFLAGS="$CFLAGS -experimental:c11atomics -std:c11"
+    as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-d2VolatileMetadata-" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether C compiler accepts -d2VolatileMetadata-" >&5
+printf %s "checking whether C compiler accepts -d2VolatileMetadata-... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler supports -d2VolatileMetadata-" >&5
-printf %s "checking whether the C compiler supports -d2VolatileMetadata-... " >&6; }
-  saved_CFLAGS="$CFLAGS"
-  CFLAGS="-d2VolatileMetadata- $CFLAGS"
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag -d2VolatileMetadata-"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-int main() { return 0; }
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
-  cl_has_volatile_metadata=true
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+  eval "$as_CACHEVAR=yes"
 else $as_nop
-  cl_has_volatile_metadata=false
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  eval "$as_CACHEVAR=no"
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  CFLAGS="$saved_CFLAGS"
-
-    if test "x$cl_has_volatile_metadata" = "xtrue"
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
 then :
   internal_cflags="$internal_cflags -d2VolatileMetadata-"
+else $as_nop
+  :
 fi
+
     internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
     internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)" ;; #(
   xlc-*) :

--- a/configure
+++ b/configure
@@ -13747,7 +13747,7 @@ case $ocaml_cc_vendor in #(
     CPP="$CC -E -Qn" # suppress generation of Sun PRO ident string
     ocamltest_CPP="$CPP" ;; #(
   msvc-*) :
-    CPP="$CC -nologo -EP"
+    CPP="$CC -nologo -EP -TC"
     ocamltest_CPP="$CPP 2> nul" ;; #(
   *) :
     CPP="$CC -E -P"

--- a/configure
+++ b/configure
@@ -14145,12 +14145,12 @@ else $as_nop
   flexmsg=''
     case $target in #(
   *-*-cygwin*|*-w64-mingw32*|*-pc-windows) :
-                                             if test x"$with_flexdll" = 'x' || test x"$with_flexdll" = 'xflexdll'
+                               if test x"$with_flexdll" = 'x' || test x"$with_flexdll" = 'xflexdll'
 then :
   if test -f 'flexdll/flexdll.h'
 then :
   flexdll_source_dir=flexdll
-          iflexdir='$(ROOTDIR)/flexdll'
+          iflexdir="$ocamlsrcdir\flexdll"
           with_flexdll="$iflexdir"
 else $as_nop
   if test x"$with_flexdll" != 'x'
@@ -14167,7 +14167,7 @@ then :
   mkdir -p flexdll-sources
           cp -r "$with_flexdll"/* flexdll-sources/
           flexdll_source_dir='flexdll-sources'
-          iflexdir='$(ROOTDIR)/flexdll-sources'
+          iflexdir="$ocamlsrcdir\\flexdll-sources"
           flexmsg=" (from $with_flexdll)"
 else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -311,7 +311,7 @@ If your host is 64 bits, you can try with './configure CC="gcc -m64"' \
 
 AS_CASE([$host],
   [*-pc-windows],
-    [CC=cl
+    [AS_CASE([$CC], [cl|cl.exe|clang-cl|clang-cl.exe], [], [CC=cl])
     ccomptype=msvc
     S=asm
     SO=dll

--- a/configure.ac
+++ b/configure.ac
@@ -675,7 +675,7 @@ AS_CASE([$ocaml_cc_vendor],
     [CPP="$CC -E -Qn" # suppress generation of Sun PRO ident string
     ocamltest_CPP="$CPP"],
   [msvc-*],
-    [CPP="$CC -nologo -EP"
+    [CPP="$CC -nologo -EP -TC"
     ocamltest_CPP="$CPP 2> nul"],
   [CPP="$CC -E -P"
   ocamltest_CPP="$CPP"])

--- a/configure.ac
+++ b/configure.ac
@@ -865,9 +865,9 @@ AS_CASE([$ocaml_cc_vendor],
     internal_cppflags='-DUNICODE -D_UNICODE'
     internal_cflags="$cc_warnings -experimental:c11atomics -std:c11"
     CFLAGS="$CFLAGS -experimental:c11atomics -std:c11"
-    OCAML_CL_HAS_VOLATILE_METADATA
-    AS_IF([test "x$cl_has_volatile_metadata" = "xtrue"],
-          [internal_cflags="$internal_cflags -d2VolatileMetadata-"])
+    AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
+      [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
+      [$warn_error_flag])
     internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
     internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
   [xlc-*],

--- a/configure.ac
+++ b/configure.ac
@@ -860,10 +860,10 @@ AS_CASE([$ocaml_cc_vendor],
     [AC_MSG_ERROR(m4_normalize([This version of MSVC is too old.
     Please use Visual Studio version 17.8 or above.]), 69)],
   [msvc-*],
-    [common_cflags="-nologo -O2 -Gy- -MD $cc_warnings"
+    [common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cppflags='-DUNICODE -D_UNICODE'
-    internal_cflags='-experimental:c11atomics -std:c11'
+    internal_cflags="$cc_warnings -experimental:c11atomics -std:c11"
     CFLAGS="$CFLAGS -experimental:c11atomics -std:c11"
     OCAML_CL_HAS_VOLATILE_METADATA
     AS_IF([test "x$cl_has_volatile_metadata" = "xtrue"],

--- a/configure.ac
+++ b/configure.ac
@@ -942,14 +942,12 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
       [dnl When bootstrapping from the git submodule (flexdll directory), just
        dnl use that, however if another directory has been specified with
        dnl --with-flexdll=<path> then copy the contents of <path> to
-       dnl flexdll-sources. This allows us to guarantee that flexdll is always
-       dnl built at one directory level below the root, so we can specify
-       dnl ROOTDIR=..
+       dnl flexdll-sources.
       AS_IF([m4_normalize([test x"$with_flexdll" = 'x'
                             || test x"$with_flexdll" = 'xflexdll'])],
         [AS_IF([test -f 'flexdll/flexdll.h'],
           [flexdll_source_dir=flexdll
-          iflexdir='$(ROOTDIR)/flexdll'
+          iflexdir="$ocamlsrcdir\flexdll"
           with_flexdll="$iflexdir"],
           [AS_IF([test x"$with_flexdll" != 'x'],
             [AC_MSG_RESULT([requested but not available])
@@ -959,7 +957,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
           [mkdir -p flexdll-sources
           cp -r "$with_flexdll"/* flexdll-sources/
           flexdll_source_dir='flexdll-sources'
-          iflexdir='$(ROOTDIR)/flexdll-sources'
+          iflexdir="$ocamlsrcdir\\flexdll-sources"
           flexmsg=" (from $with_flexdll)"],
           [AC_MSG_RESULT([requested but not available])
           AC_MSG_ERROR([exiting])])])

--- a/configure.ac
+++ b/configure.ac
@@ -863,7 +863,7 @@ AS_CASE([$ocaml_cc_vendor],
     [common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
-    internal_cppflags='-DUNICODE -D_UNICODE'
+    internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
     AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
       [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
       [$warn_error_flag])

--- a/configure.ac
+++ b/configure.ac
@@ -862,9 +862,8 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
+    internal_cflags="$cc_warnings"
     internal_cppflags='-DUNICODE -D_UNICODE'
-    internal_cflags="$cc_warnings -experimental:c11atomics -std:c11"
-    CFLAGS="$CFLAGS -experimental:c11atomics -std:c11"
     AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
       [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
       [$warn_error_flag])
@@ -1212,7 +1211,18 @@ AS_IF([! $arch64],
 
 # Support for C11 atomic types
 
-OCAML_CC_SUPPORTS_ATOMIC([$cclibs])
+AS_CASE([$ocaml_cc_vendor],
+  [msvc-*],
+    [OCAML_CC_SUPPORTS_ATOMIC
+     AS_IF([! $cc_supports_atomic],
+       [OCAML_CC_SUPPORTS_ATOMIC([-std:c11])
+        AS_IF([$cc_supports_atomic],
+          [common_cflags="$common_cflags -std:c11"],
+          [OCAML_CC_SUPPORTS_ATOMIC([-std:c11 -experimental:c11atomics])
+           AS_IF([$cc_supports_atomic],
+             [common_cflags="$common_cflags -std:c11 -experimental:c11atomics"])
+    ])])],
+  [OCAML_CC_SUPPORTS_ATOMIC([], [$cclibs])])
 AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -863,7 +863,8 @@ AS_CASE([$ocaml_cc_vendor],
     [common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
-    internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
+    internal_cppflags="-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS \
+-D_WINSOCK_DEPRECATED_NO_WARNINGS"
     AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
       [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
       [$warn_error_flag])

--- a/configure.ac
+++ b/configure.ac
@@ -826,6 +826,16 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
+AS_CASE([$host],
+  [*-*-mingw32*|*-pc-windows],
+    [AS_CASE([$WINDOWS_UNICODE_MODE],
+      [ansi],
+        [windows_unicode=0],
+      [compatible|""],
+        [windows_unicode=1],
+      [AC_MSG_ERROR([unexpected windows unicode mode])])],
+  [windows_unicode=0])
+
 # We select high optimization levels, provided we can turn off:
 # - strict type-based aliasing analysis (too risky for the OCaml runtime)
 # - strict no-overflow conditions on signed integer arithmetic
@@ -851,8 +861,7 @@ AS_CASE([$ocaml_cc_vendor],
     # TODO: see whether the code can be fixed to avoid -Wno-unused
     common_cflags="-O2 -fno-strict-aliasing -fwrapv -mms-bitfields"
     internal_cppflags='-D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE'
-    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE=$windows_unicode"],
   [mingw-*],
     [AC_MSG_ERROR([Unsupported C compiler for a MinGW-w64 build])],
   [msvc-0*|msvc-1[[0-8]]*|msvc-19[[012]]*|msvc-193[[0-7]]],
@@ -868,8 +877,7 @@ AS_CASE([$ocaml_cc_vendor],
     AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
       [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
       [$warn_error_flag])
-    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE="
-    internal_cppflags="${internal_cppflags}\$(WINDOWS_UNICODE)"],
+    internal_cppflags="$internal_cppflags -DWINDOWS_UNICODE=$windows_unicode"],
   [xlc-*],
     [common_cflags="-O5 -qtune=balanced -qnoipa -qinline";
     internal_cflags="$cc_warnings"],
@@ -2624,16 +2632,6 @@ AS_IF([test x"$libdir" = x'${exec_prefix}/lib'],
 
 AS_IF([test x"$mandir" = x'${datarootdir}/man'],
   [mandir='${prefix}/man'])
-
-AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
-    [AS_CASE([$WINDOWS_UNICODE_MODE],
-      [ansi],
-        [windows_unicode=0],
-      [compatible|""],
-        [windows_unicode=1],
-      [AC_MSG_ERROR([unexpected windows unicode mode])])],
-  [windows_unicode=0])
 
 # Define default prefix correctly for the different Windows ports
 AS_IF([test x"$prefix" = "xNONE"],

--- a/testsuite/tests/embedded/cmstub.c
+++ b/testsuite/tests/embedded/cmstub.c
@@ -11,6 +11,7 @@
 /*                                                                     */
 /***********************************************************************/
 
+#define _CRT_NONSTDC_NO_WARNINGS  /* for strdup */
 #include <string.h>
 #include <caml/mlvalues.h>
 #include <caml/callback.h>

--- a/testsuite/tests/runtime-C-exceptions/stub_test.c
+++ b/testsuite/tests/runtime-C-exceptions/stub_test.c
@@ -1,3 +1,4 @@
+#define _CRT_NONSTDC_NO_WARNINGS  /* for strdup */
 #include <string.h>
 #include "caml/memory.h"
 #include "caml/alloc.h"


### PR DESCRIPTION
> [clang-cl](https://clang.llvm.org/docs/UsersManual.html#clang-cl) is an alternative command-line interface to Clang, designed for compatibility with the Visual C/C++ compiler, `cl.exe`.

clang-cl is ABI and (mostly) command-line compatible with cl, providing a drop-in replacement. Users may prefer it to MSVC as it's based on [LLVM/clang](https://llvm.org/), a free software compiler toolchain,

> which aims to deliver amazingly fast compiles, extremely useful error and warning messages and to provide a platform for building great source level tools.

I've added a job to the CI matrix to test OCaml with clang-cl on Windows x86_64. To test this PR locally, follow [Clang/LLVM support in Visual Studio projects](https://learn.microsoft.com/en-us/cpp/build/clang-support-msbuild?view=msvc-170), then configure OCaml with:

```
./configure --host=x86_64-pc-windows CC=clang-cl
```

Having another compilers' opinion on Windows and MSVC (by opposition to MinGW-w64) specific code paths can only benefit the quality of the C code in OCaml. In the future, this could also allow cross-compiling OCaml for native Windows from any host running clang, after installing Windows headers.

This PR accounts for some (in)compatibility quirks of cl and clang-cl CLI, and fixes little Autoconf bugs introduced in the MSVC restoration effort.

