### PR TITLE
Update debugger network code

### DIFF
--- a/Changes
+++ b/Changes
@@ -71,6 +71,10 @@ _______________
   (Olivier Nicole, suggested by Sébastien Hinderer and David Allsopp, review by
    Gabriel Scherer)
 
+* #?????: Support ocamldebug remote debugging over IPv6 on all
+  platforms, and over Unix domain sockets on Windows.
+  (Antonin Décimo, review by ???)
+
 ### Toplevel:
 
 - #12891: Improved styling for initial prompt

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -45,7 +45,7 @@ let control_connection pid fd =
 
 (* Accept a connection from another process. *)
 let accept_connection continue fd =
-  let (sock, _) = accept fd.io_fd in
+  let (sock, _) = accept ~cloexec:true fd.io_fd in
   let io_chan = io_channel_of_descr sock in
   let pid = input_binary_int io_chan.io_in in
   if pid = -1 then begin
@@ -67,7 +67,7 @@ let open_connection address continue =
         (match addr_info with
          | { ai_addr = ADDR_UNIX file; _} -> Some file
          | _ -> None);
-      let sock = socket addr_info.ai_family addr_info.ai_socktype
+      let sock = socket ~cloexec:true addr_info.ai_family addr_info.ai_socktype
                    addr_info.ai_protocol in
         (try
            bind sock addr_info.ai_addr;

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -78,7 +78,7 @@ let open_connection address continue =
            connection_opened := true
          with x -> cleanup x @@ fun () -> close sock)
   with
-    Failure _ -> raise Toplevel
+    Failure e -> prerr_endline e; raise Toplevel
   | (Unix_error _) as err -> report_error err; raise Toplevel
 
 (* Close the socket. *)

--- a/debugger/program_management.ml
+++ b/debugger/program_management.ml
@@ -62,16 +62,15 @@ let accept_connection continue fd =
 (* Initialize the socket. *)
 let open_connection address continue =
   try
-    let (sock_domain, sock_address) = convert_address address in
+    let addr_info = convert_address address in
       file_name :=
-        (match sock_address with
-           ADDR_UNIX file ->
-             Some file
-         | _ ->
-             None);
-      let sock = socket sock_domain SOCK_STREAM 0 in
+        (match addr_info with
+         | { ai_addr = ADDR_UNIX file; _} -> Some file
+         | _ -> None);
+      let sock = socket addr_info.ai_family addr_info.ai_socktype
+                   addr_info.ai_protocol in
         (try
-           bind sock sock_address;
+           bind sock addr_info.ai_addr;
            setsockopt sock SO_REUSEADDR true;
            listen sock 3;
            connection := io_channel_of_descr sock;

--- a/debugger/unix_tools.ml
+++ b/debugger/unix_tools.ml
@@ -22,24 +22,23 @@ open Unix
 
 (*** Convert a socket name into a socket address. ***)
 let convert_address address =
-  try
-    let n = String.index address ':' in
-      let host = String.sub address 0 n
-      and port = String.sub address (n + 1) (String.length address - n - 1)
-      in
-        (PF_INET,
-         ADDR_INET
-           ((try inet_addr_of_string host with Failure _ ->
-               try (gethostbyname host).h_addr_list.(0) with Not_found ->
-                 prerr_endline ("Unknown host: " ^ host);
-                 failwith "Can't convert address"),
-            (try int_of_string port with Failure _ ->
-               prerr_endline "The port number should be an integer";
-               failwith "Can't convert address")))
-  with Not_found ->
-    match Sys.os_type with
-      "Win32" -> failwith "Unix sockets not supported"
-    | _ -> (PF_UNIX, ADDR_UNIX address)
+  match String.index address ':' with
+  | exception Not_found ->
+     if Sys.win32 then failwith "Unix sockets not supported";
+     { ai_family = PF_UNIX; ai_socktype = SOCK_STREAM; ai_protocol = 0;
+       ai_addr = ADDR_UNIX address; ai_canonname = ""; }
+  | n ->
+     let host = String.sub address 0 n
+     and port = String.(sub address (n + 1) (length address - n - 1)) in
+     (try ignore (int_of_string port) with Failure _ ->
+        prerr_endline "The port number should be an integer";
+        failwith "Can't convert address");
+     let hints = [AI_FAMILY PF_INET; AI_SOCKTYPE SOCK_STREAM] in
+     match getaddrinfo host port hints with
+     | addr_info :: _ -> addr_info
+     | [] ->
+        prerr_endline ("Unknown host: " ^ host);
+        failwith "Can't convert address"
 
 (*** Report a unix error. ***)
 let report_error = function

--- a/debugger/unix_tools.ml
+++ b/debugger/unix_tools.ml
@@ -31,14 +31,12 @@ let convert_address address =
      let host = String.sub address 0 n
      and port = String.(sub address (n + 1) (length address - n - 1)) in
      (try ignore (int_of_string port) with Failure _ ->
-        prerr_endline "The port number should be an integer";
-        failwith "Can't convert address");
+        failwith "Can't convert address: the port number should be an integer");
      let hints = [AI_FAMILY PF_INET; AI_SOCKTYPE SOCK_STREAM] in
      match getaddrinfo host port hints with
      | addr_info :: _ -> addr_info
-     | [] ->
-        prerr_endline ("Unknown host: " ^ host);
-        failwith "Can't convert address"
+     | [] -> Printf.ksprintf failwith
+               "Can't convert address: unknown host %s port %s" host port
 
 (*** Report a unix error. ***)
 let report_error = function

--- a/debugger/unix_tools.mli
+++ b/debugger/unix_tools.mli
@@ -19,7 +19,7 @@
 open Unix
 
 (* Convert a socket name into a socket address. *)
-val convert_address : string -> socket_domain * sockaddr
+val convert_address : string -> addr_info
 
 (* Report an unix error. *)
 val report_error : exn -> unit

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -125,7 +125,11 @@ static void open_connection(void)
   dbg_socket = _open_osfhandle(sock, 0);
   if (dbg_socket == -1)
 #else
+#if defined(SOCK_CLOEXEC)
+  dbg_socket = socket(sock_domain, SOCK_STREAM | SOCK_CLOEXEC, 0);
+#else
   dbg_socket = socket(sock_domain, SOCK_STREAM, 0);
+#endif
   if (dbg_socket == -1 ||
       connect(dbg_socket, (struct sockaddr *)&sock_addr, sock_addr_len) == -1)
 #endif

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -170,7 +170,7 @@ void caml_debugger_init(void)
 {
   char * address;
   char_os * a;
-  char * port, * p;
+  char * port;
   value flags;
 
   flags = caml_alloc(2, Tag_cons);
@@ -199,10 +199,7 @@ void caml_debugger_init(void)
   (void)atexit(winsock_cleanup);
 #endif
   /* Parse the address */
-  port = NULL;
-  for (p = address; *p != 0; p++) {
-    if (*p == ':') { *p = 0; port = p+1; break; }
-  }
+  port = strchr(address, ':');
   if (port == NULL) {
     /* Unix domain */
     struct sockaddr_un *s_unix = (struct sockaddr_un *)&sock_addr;
@@ -227,6 +224,7 @@ void caml_debugger_init(void)
     hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
 
+    *port++ = 0;
     int ret = getaddrinfo(address, port, &hints, &host);
     if (ret != 0) {
       char buffer[512];

--- a/runtime/debugger.c
+++ b/runtime/debugger.c
@@ -17,9 +17,6 @@
 
 /* Interface with the byte-code debugger */
 
-/* Remove when gethostbyname replaced with getaddrinfo */
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-
 #ifdef _WIN32
 #include <io.h>
 #endif /* _WIN32 */
@@ -71,6 +68,7 @@ CAMLexport void caml_debugger_cleanup_fork(void)
 #else
 #define ATOM ATOM_WS
 #include <winsock2.h>
+#include <ws2tcpip.h>
 #undef ATOM
 /* Code duplication with otherlibs/unix/socketaddr.h is inevitable
  * because pulling winsock2.h creates many naming conflicts. */
@@ -177,9 +175,7 @@ void caml_debugger_init(void)
   char * address;
   char_os * a;
   char * port, * p;
-  struct hostent * host;
   value flags;
-  int n;
 
   flags = caml_alloc(2, Tag_cons);
   Store_field(flags, 0, Val_int(1)); /* Marshal.Closures */
@@ -231,20 +227,40 @@ void caml_debugger_init(void)
         + a_len;
   } else {
     /* Internet domain */
-    sock_domain = PF_INET;
-    for (p = (char *) &sock_addr.s_inet, n = sizeof(sock_addr.s_inet);
-         n > 0; n--) *p++ = 0;
-    sock_addr.s_inet.sin_family = AF_INET;
-    sock_addr.s_inet.sin_addr.s_addr = inet_addr(address);
-    if (sock_addr.s_inet.sin_addr.s_addr == -1) {
-      host = gethostbyname(address);
-      if (host == NULL)
-        caml_fatal_error("unknown debugging host %s", address);
-      memmove(&sock_addr.s_inet.sin_addr,
-              host->h_addr_list[0], host->h_length);
+    struct addrinfo hints;
+    struct addrinfo *host;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    int ret = getaddrinfo(address, port, &hints, &host);
+    if (ret != 0) {
+      char buffer[512];
+      const char *err;
+#ifdef _WIN32
+      DWORD error = WSAGetLastError();
+      if (FormatMessageA(
+            FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,
+            error, 0, buffer, sizeof(buffer), NULL))
+        caml_fatal_error("cannot connect to debugger at %s port %s\nerror: %u",
+                         address, port, error);
+      err = buffer;
+#else
+      err = ret != EAI_SYSTEM ? gai_strerror(ret)
+          : caml_strerror(errno, buffer, sizeof(buffer));
+#endif
+      caml_fatal_error("cannot connect to debugger at %s port %s\nerror: %s",
+                       address, port, err);
     }
-    sock_addr.s_inet.sin_port = htons(atoi(port));
-    sock_addr_len = sizeof(sock_addr.s_inet);
+    if (host == NULL)
+      caml_fatal_error("unknown debugging host %s port %s", address, port);
+
+    sock_domain = host->ai_family;
+    memcpy(&sock_addr, host->ai_addr, host->ai_addrlen);
+    sock_addr_len = host->ai_addrlen;
+
+    freeaddrinfo(host);
   }
   open_connection();
   caml_debugger_in_use = 1;


### PR DESCRIPTION
The OCaml debugger sets up a socket between the debugger and the runtime of the process being debugged. The user has some control over the socket: she can specify an IPv4 address or host, or a path to a Unix domain socket with `ocamldebug` `-s` option, and with the `CAML_DEBUG_SOCKET` environment variable to the remotely debugged process.

With some warnings enabled, C compilers now complain that some network functions are deprecated (e.g., `gethostbyname` is replaced by `getaddrinfo`), because they don't support IPv6.

This PR:
- replaces uses of `gethostbyname` with `getaddrinfo` in the runtime and in ocamldebug;
- allows using IPv6 addresses using the bracketed syntax `[::1]:8080` and IPv6 hosts;
- allows using Unix domain socket on Windows;
- modernizes and cleans up the network code.
