### PR TITLE
Fix MSVC (`-W2`) and clang-cl (`-W4`) warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -95,6 +95,10 @@ _______________
   with MSVC or clang-cl.
   (Antonin Décimo, review by Miod Vallat)
 
+- #13243: Enable C compiler warnings internally when building with
+  clang-cl or MSVC. Provide fixes too.
+  (Antonin Décimo, review by ???)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/Changes
+++ b/Changes
@@ -91,6 +91,10 @@ _______________
   extension to enable threaded code interpretation.
   (Antonin Décimo, review by Miod Vallat)
 
+- #13238: Enable software prefetching on x86 and x86_64 when building
+  with MSVC or clang-cl.
+  (Antonin Décimo, review by Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/Changes
+++ b/Changes
@@ -87,6 +87,10 @@ _______________
   (Antonin Décimo, review by Nick Barnes, Xavier Leroy, Gabriel Scherer,
    and Miod Vallat)
 
+- #13239: Check whether the compiler supports the labels as values
+  extension to enable threaded code interpretation.
+  (Antonin Décimo, review by Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/Makefile
+++ b/Makefile
@@ -1309,7 +1309,8 @@ runtime/caml/opnames.h : runtime/caml/instruct.h
 	    -e 's/{$$/[] = {/' \
 	    -e 's/\([[:upper:]][[:upper:]_0-9]*\)/"\1"/g' > $@
 
-# runtime/caml/jumptbl.h is required only if you have GCC 2.0 or later
+# runtime/caml/jumptbl.h is required only if the C compiler supports
+# the labels as values extension.
 runtime/caml/jumptbl.h : runtime/caml/instruct.h
 	$(V_GEN)tr -d '\r' < $< | \
 	sed -n -e '/^  /s/ \([A-Z]\)/ \&\&lbl_\1/gp' \

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -434,7 +434,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
   OCAML_RUN_IFELSE(
     [AC_LANG_PROGRAM([[#include <math.h>]],[[
   /* Tests 264-266 from testsuite/tests/fma/fma.ml. These tests trigger the
-     broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
+     broken implementations of Cygwin64 and mingw-w64 (x86_64).
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
   volatile double t264, t265, t266;
@@ -466,11 +466,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
       [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin*], [hard_error=false],
-      [AS_CASE([$ocaml_cc_vendor],
-        [msvc-*], [AS_IF([test "${ocaml_cc_vendor#msvc-}" -lt 1920 ],
-          [hard_error=false],
-          [hard_error=true])],
-        [hard_error=true])])
+      [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
         fma does not work, enable emulation with

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -536,3 +536,22 @@ AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
 
   OCAML_CC_RESTORE_VARIABLES
 ])
+
+AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
+  AC_CACHE_CHECK([whether $CC supports the labels as values extension],
+    [ocaml_cv_prog_cc_labels_as_values],
+    [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [[
+  void *ptr;
+  ptr = &&foo;
+  goto *ptr;
+  return 1;
+  foo:
+     ]])],
+       [ocaml_cv_prog_cc_labels_as_values=yes],
+       [ocaml_cv_prog_cc_labels_as_values=no])
+  ])
+  if test "x$ocaml_cv_prog_cc_labels_as_values" = xyes; then
+    AC_DEFINE([HAVE_LABELS_AS_VALUES], [1],
+      [Define if the C compiler supports the labels as values extension.])
+  fi
+])

--- a/configure
+++ b/configure
@@ -13914,11 +13914,12 @@ case $ocaml_cc_vendor in #(
     outputobj='-Fo'
     case $ocaml_cc_vendor in #(
   msvc-*-clang-*) :
-    warn_error_flag='-WX' ;; #(
+    cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+         warn_error_flag='-WX' ;; #(
   *) :
-    warn_error_flag='-WX -options:strict' ;;
-esac
-    cc_warnings='' ;; #(
+    cc_warnings='-W2'
+       warn_error_flag='-WX -options:strict' ;;
+esac ;; #(
   *) :
     outputobj='-o '
   warn_error_flag='-Werror'

--- a/configure
+++ b/configure
@@ -16056,6 +16056,49 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
   CFLAGS="$saved_CFLAGS"
 
 
+# Check whether the C compiler supports the labels as values extension.
+
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports the labels as values extension" >&5
+printf %s "checking whether $CC supports the labels as values extension... " >&6; }
+if test ${ocaml_cv_prog_cc_labels_as_values+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  void *ptr;
+  ptr = &&foo;
+  goto *ptr;
+  return 1;
+  foo:
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ocaml_cv_prog_cc_labels_as_values=yes
+else $as_nop
+  ocaml_cv_prog_cc_labels_as_values=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_cc_labels_as_values" >&5
+printf "%s\n" "$ocaml_cv_prog_cc_labels_as_values" >&6; }
+  if test "x$ocaml_cv_prog_cc_labels_as_values" = xyes; then
+
+printf "%s\n" "#define HAVE_LABELS_AS_VALUES 1" >>confdefs.h
+
+  fi
+
+
 # Configure the native-code compiler
 
 arch=none

--- a/configure
+++ b/configure
@@ -16695,8 +16695,8 @@ fi
   cross_compiling="$old_cross_compiling"
 
 
-  # Check whether fma works (regressed in mingw-w64 8.0.0; present, but broken,
-  # in VS2013-2017 and present but unimplemented in Cygwin64)
+  # Check whether fma works (regressed in mingw-w64 8.0.0; and present but
+  # unimplemented in Cygwin64)
 
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether fma works" >&5
 printf %s "checking whether fma works... " >&6; }
@@ -16727,7 +16727,7 @@ main (void)
 {
 
   /* Tests 264-266 from testsuite/tests/fma/fma.ml. These tests trigger the
-     broken implementations of Cygwin64, mingw-w64 (x86_64) and VS2013-2017.
+     broken implementations of Cygwin64 and mingw-w64 (x86_64).
      The static volatile variables aim to thwart GCC's constant folding. */
   static volatile double x, y, z;
   volatile double t264, t265, t266;
@@ -16773,17 +16773,7 @@ printf "%s\n" "no" >&6; }
   *,x86_64-w64-mingw32*|*,x86_64-*-cygwin*) :
     hard_error=false ;; #(
   *) :
-    case $ocaml_cc_vendor in #(
-  msvc-*) :
-    if test "${ocaml_cc_vendor#msvc-}" -lt 1920
-then :
-  hard_error=false
-else $as_nop
-  hard_error=true
-fi ;; #(
-  *) :
     hard_error=true ;;
-esac ;;
 esac
     if test x"$hard_error" = "xtrue"
 then :
@@ -16803,26 +16793,7 @@ fi
 else $as_nop
   if test x"$enable_imprecise_c99_float_ops" != "xyes"
 then :
-  case $enable_imprecise_c99_float_ops,$ocaml_cc_vendor in #(
-  no,*) :
-    hard_error=true ;; #(
-  ,msvc-*) :
-    if test "${ocaml_cc_vendor#msvc-}" -lt 1800
-then :
-  hard_error=false
-else $as_nop
-  hard_error=true
-fi ;; #(
-  *) :
-    hard_error=true ;;
-esac
-     if test x"$hard_error" = 'xtrue'
-then :
   as_fn_error $? "C99 float ops unavailable, enable replacements with --enable-imprecise-c99-float-ops" "$LINENO" 5
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: C99 float ops unavailable, replacements enabled (ancient Visual Studio)" >&5
-printf "%s\n" "$as_me: WARNING: C99 float ops unavailable, replacements enabled (ancient Visual Studio)" >&2;}
-fi
 fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -807,9 +807,11 @@ AS_CASE([$ocaml_cc_vendor],
   [msvc-*],
     [outputobj='-Fo'
     AS_CASE([$ocaml_cc_vendor],
-      [msvc-*-clang-*], [warn_error_flag='-WX'],
-      [warn_error_flag='-WX -options:strict'])
-    cc_warnings=''],
+      [msvc-*-clang-*],
+        [cc_warnings='-W4 -Wno-unused-parameter -Wno-sign-compare -Wundef'
+         warn_error_flag='-WX'],
+      [cc_warnings='-W2'
+       warn_error_flag='-WX -options:strict'])],
   [outputobj='-o '
   warn_error_flag='-Werror'
   cc_warnings="-Wall -Wint-conversion -Wstrict-prototypes \

--- a/configure.ac
+++ b/configure.ac
@@ -1645,23 +1645,12 @@ AS_IF([$has_c99_float_ops],
   [AC_DEFINE([HAS_C99_FLOAT_OPS], [1])
   # Check whether round works (known bug in mingw-w64)
   OCAML_C99_CHECK_ROUND
-  # Check whether fma works (regressed in mingw-w64 8.0.0; present, but broken,
-  # in VS2013-2017 and present but unimplemented in Cygwin64)
+  # Check whether fma works (regressed in mingw-w64 8.0.0; and present but
+  # unimplemented in Cygwin64)
   OCAML_C99_CHECK_FMA],
   [AS_IF([test x"$enable_imprecise_c99_float_ops" != "xyes" ],
-    [AS_CASE([$enable_imprecise_c99_float_ops,$ocaml_cc_vendor],
-      [no,*], [hard_error=true],
-      [,msvc-*], [AS_IF([test "${ocaml_cc_vendor#msvc-}" -lt 1800 ],
-        [hard_error=false],
-        [hard_error=true])],
-      [hard_error=true])
-     AS_IF([test x"$hard_error" = 'xtrue'],
-       [AC_MSG_ERROR(m4_normalize([
-         C99 float ops unavailable, enable replacements
-         with --enable-imprecise-c99-float-ops]))],
-       [AC_MSG_WARN(m4_normalize([
-         C99 float ops unavailable, replacements enabled
-         (ancient Visual Studio)]))])])])
+    [AC_MSG_ERROR(m4_normalize([C99 float ops unavailable, enable replacements
+    with --enable-imprecise-c99-float-ops]))])])
 
 ## getentropy
 AC_CHECK_FUNC([getentropy], [AC_DEFINE([HAS_GETENTROPY], [1])])

--- a/configure.ac
+++ b/configure.ac
@@ -1375,6 +1375,9 @@ OCAML_CC_SUPPORTS_ALIGNED
 ## Check whether __attribute__((optimize("tree-vectorize")))) is supported
 OCAML_CC_SUPPORTS_TREE_VECTORIZE
 
+# Check whether the C compiler supports the labels as values extension.
+OCAML_CC_SUPPORTS_LABELS_AS_VALUES
+
 # Configure the native-code compiler
 
 arch=none

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -42,7 +42,7 @@ static void report_error(
 {
   WCHAR windows_error_message[1024];
   DWORD error = GetLastError();
-  char *caml_error_message, buf[256];
+  char *caml_error_message;
   if (FormatMessage(
     FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
     NULL, error, 0, windows_error_message,
@@ -273,7 +273,6 @@ int run_command(const command_settings *settings)
   WCHAR *commandline = NULL;
 
   LPVOID environment = NULL;
-  LPCWSTR current_directory = NULL;
   STARTUPINFO startup_info;
   PROCESS_INFORMATION process_info;
   BOOL wait_result;

--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -102,7 +102,6 @@ CAMLprim value caml_unix_inchannel_of_filedescr(value handle)
   CAMLlocal1(vchan);
   int flags = 0;
   int fd;
-  struct channel * chan;
   DWORD err;
 
   err = check_stream_semantics(handle);
@@ -123,7 +122,6 @@ CAMLprim value caml_unix_outchannel_of_filedescr(value handle)
   CAMLlocal1(vchan);
   int fd;
   int flags = 0;
-  struct channel * chan;
   DWORD err;
 
   err = check_stream_semantics(handle);

--- a/otherlibs/unix/createprocess.c
+++ b/otherlibs/unix/createprocess.c
@@ -154,8 +154,7 @@ CAMLprim value caml_unix_create_process(value * argv, int argn)
 
 static int has_console(void)
 {
-  HANDLE h, log;
-  int i;
+  HANDLE h;
 
   h = CreateFile(L"CONOUT$", GENERIC_WRITE, FILE_SHARE_WRITE, NULL,
                  OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);

--- a/otherlibs/unix/gettimeofday_win32.c
+++ b/otherlibs/unix/gettimeofday_win32.c
@@ -25,7 +25,7 @@
 double caml_unix_gettimeofday_unboxed(value unit)
 {
   CAML_ULONGLONG_FILETIME utime;
-  double tm;
+  ULONGLONG tm;
   GetSystemTimeAsFileTime(&utime.ft);
   tm = utime.ul - CAML_NT_EPOCH_100ns_TICKS;
   return (tm * 1e-7);  /* tm is in 100ns */

--- a/otherlibs/unix/mmap_win32.c
+++ b/otherlibs/unix/mmap_win32.c
@@ -44,8 +44,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   intnat dim[CAML_BA_MAX_NUM_DIMS];
   __int64 startpos, data_size;
   LARGE_INTEGER file_size;
-  uintnat array_size, page, delta;
-  char c;
+  uintnat array_size, delta;
   void * addr;
   LARGE_INTEGER li;
   SYSTEM_INFO sysinfo;

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -61,8 +61,6 @@ static void handle_set_init (LPSELECTHANDLESET hds, LPHANDLE lpHdl, DWORD max)
 
 static void handle_set_add (LPSELECTHANDLESET hds, HANDLE hdl)
 {
-  LPSELECTHANDLESET res;
-
   if (hds->nLast < hds->nMax)
   {
     hds->lpHdl[hds->nLast] = hdl;
@@ -189,7 +187,6 @@ static LPSELECTDATA select_data_new (LPSELECTDATA lpSelectData,
 {
   /* Allocate the data structure */
   LPSELECTDATA res;
-  DWORD        i;
 
   res = (LPSELECTDATA)caml_stat_alloc(sizeof(SELECTDATA));
 
@@ -216,8 +213,6 @@ static LPSELECTDATA select_data_new (LPSELECTDATA lpSelectData,
 /* Free select data */
 static void select_data_free (LPSELECTDATA lpSelectData)
 {
-  DWORD i;
-
   DEBUG_PRINT("Freeing data of %x", lpSelectData);
 
   /* Free APC related data, if they exists */
@@ -1003,9 +998,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   /* Is there static select data */
   BOOL  hasStaticData = FALSE;
 
-  /* Wait return */
-  DWORD waitRet;
-
   /* Set of handle */
   SELECTHANDLESET hds;
   DWORD           hdsMax;
@@ -1073,7 +1065,6 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       iterSelectData = NULL;
       iterResult     = NULL;
       hasStaticData  = 0;
-      waitRet        = 0;
       readfds_len    = caml_list_length(readfds);
       writefds_len   = caml_list_length(writefds);
       exceptfds_len  = caml_list_length(exceptfds);

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -1074,7 +1074,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       if (tm >= 0.0)
         {
-          milliseconds = 1000 * tm;
+          milliseconds = (DWORD)(1000 * tm);
           DEBUG_PRINT("Will wait %d ms", milliseconds);
         }
       else

--- a/otherlibs/unix/sleep_win32.c
+++ b/otherlibs/unix/sleep_win32.c
@@ -19,9 +19,9 @@
 
 CAMLprim value caml_unix_sleep(value t)
 {
-  double d = Double_val(t);
+  DWORD ms = (DWORD)(Double_val(t) * 1e3);
   caml_enter_blocking_section();
-  Sleep(d * 1e3);
+  Sleep(ms);
   caml_leave_blocking_section();
   return Val_unit;
 }

--- a/otherlibs/unix/startup.c
+++ b/otherlibs/unix/startup.c
@@ -25,7 +25,6 @@ value caml_win32_process_id;
 CAMLprim value caml_unix_startup(value unit)
 {
   WSADATA wsaData;
-  int i;
   HANDLE h;
 
   (void) WSAStartup(MAKEWORD(2, 0), &wsaData);

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -166,7 +166,6 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
 {
   BY_HANDLE_FILE_INFORMATION info;
   wchar_t* ptr;
-  char c;
   HANDLE h;
   unsigned short mode;
   int is_symlink = 0;
@@ -391,7 +390,6 @@ CAMLprim value caml_unix_lstat_64(value path)
 
 static value do_fstat(value handle, int use_64)
 {
-  int ret;
   struct _stat64 buf;
   __int64 st_ino;
   HANDLE h;

--- a/otherlibs/unix/unixsupport_win32.c
+++ b/otherlibs/unix/unixsupport_win32.c
@@ -98,7 +98,7 @@ void caml_win32_maperr(DWORD win32err)
   } else {
     /* Not found: save original error code, negated so that we can
        recognize it in caml_unix_error_message */
-    errno = -win32err;
+    errno = -(int)win32err;
   }
 }
 

--- a/otherlibs/unix/windbug.c
+++ b/otherlibs/unix/windbug.c
@@ -17,10 +17,10 @@
 
 int caml_win32_debug_test (void)
 {
-  static int debug_init = 0;
   static int debug = 0;
 
 #ifdef DEBUG
+  static int debug_init = 0;
   if (!debug_init)
   {
     debug = (getenv("OCAMLDEBUG") != NULL);

--- a/otherlibs/unix/winworker.c
+++ b/otherlibs/unix/winworker.c
@@ -238,8 +238,6 @@ void caml_win32_worker_push(LPWORKER lpWorker)
 
 void caml_win32_worker_init (void)
 {
-  int i = 0;
-
   /* Init a shared variable. The only way to ensure that no other
      worker will be at the same point is to use a critical section.
      */

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -78,13 +78,13 @@ CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 /* Copy the values to be preserved to a different array.
    The original vals array never escapes, generating better code in
    the fast path. */
-#define Enter_gc_preserve_vals(dom_st, wosize) do {         \
-    CAMLparam0();                                           \
-    CAMLlocalN(vals_copy, (wosize));                        \
-    for (i = 0; i < (wosize); i++) vals_copy[i] = vals[i];  \
-    Alloc_small_enter_GC(dom_st, wosize);                   \
-    for (i = 0; i < (wosize); i++) vals[i] = vals_copy[i];  \
-    CAMLdrop;                                               \
+#define Enter_gc_preserve_vals(dom_st, wosize) do {                     \
+    CAMLparam0();                                                       \
+    CAMLlocalN(vals_copy, (wosize));                                    \
+    for (mlsize_t j = 0; j < (wosize); j++) vals_copy[j] = vals[j];     \
+    Alloc_small_enter_GC(dom_st, wosize);                               \
+    for (mlsize_t j = 0; j < (wosize); j++) vals[j] = vals_copy[j];     \
+    CAMLdrop;                                                           \
   } while (0)
 
 /* This has to be done with a macro, rather than an inline function, since
@@ -95,12 +95,11 @@ CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
   Caml_check_caml_state();                              \
   value v;                                              \
   value vals[wosize] = {__VA_ARGS__};                   \
-  mlsize_t i;                                           \
   CAMLassert ((tag) < 256);                             \
                                                         \
   Alloc_small(v, wosize, tag, Enter_gc_preserve_vals);  \
-  for (i = 0; i < (wosize); i++) {                      \
-    Field(v, i) = vals[i];                              \
+  for (mlsize_t j = 0; j < (wosize); j++) {             \
+    Field(v, j) = vals[j];                              \
   }                                                     \
   return v;                                             \
 }

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -40,11 +40,7 @@
 /* No longer used in the codebase, but kept because it was exported */
 #define INT64_LITERAL(s) s ## LL
 
-#if defined(_MSC_VER) && !defined(__cplusplus)
-#define Caml_inline static __inline
-#else
 #define Caml_inline static inline
-#endif
 
 #ifndef CAML_CONFIG_H_NO_TYPEDEFS
 
@@ -70,7 +66,7 @@
   #define __USE_MINGW_ANSI_STDIO 0
 #endif
 
-#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER < 1800)
+#if defined(__MINGW32__)
 #define ARCH_SIZET_PRINTF_FORMAT "I"
 #else
 #define ARCH_SIZET_PRINTF_FORMAT "z"

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -161,10 +161,9 @@ typedef uint64_t uintnat;
 #endif
 
 
-/* We use threaded code interpretation if the compiler provides labels
-   as first-class values (GCC 2.x). */
-
-#if defined(__GNUC__) && __GNUC__ >= 2 && !defined(DEBUG)
+/* We use threaded code interpretation if the C compiler supports the labels as
+   values extension. */
+#if defined(HAVE_LABELS_AS_VALUES) && !defined(DEBUG)
 #define THREADED_CODE
 #endif
 

--- a/runtime/caml/frame_descriptors.h
+++ b/runtime/caml/frame_descriptors.h
@@ -100,7 +100,7 @@ Caml_inline bool frame_has_debug(frame_descr *d) {
 /* Used to compute offsets in frame tables.
    ty must have power-of-2 size */
 #define Align_to(p, ty) \
-  (void*)(((uintnat)(p) + sizeof(ty) - 1) & -sizeof(ty))
+  (void*)(((uintnat)(p) + sizeof(ty) - 1) & ~(sizeof(ty) - 1))
 
 #define Hash_retaddr(addr, mask)                          \
   (((uintnat)(addr) >> 3) & (mask))

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -411,7 +411,7 @@ extern double caml_log1p(double);
 #define unlink_os _wunlink
 #define rename_os caml_win32_rename
 #define chdir_os _wchdir
-#define mkdir_os(path, perm) _wmkdir(path)
+#define mkdir_os(path, perm) ((void) (perm), _wmkdir(path))
 #define getcwd_os _wgetcwd
 #define system_os _wsystem
 #define rmdir_os _wrmdir

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -199,13 +199,18 @@ CAMLdeprecated_typedef(addr, char *);
      CAMLunused_start foo CAMLunused_end;
    which supports both GCC/Clang and MSVC.
 */
-#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 7))
-  #define CAMLunused_start __attribute__ ((unused))
+#if __has_c_attribute(maybe_unused)                     \
+    || defined(__cplusplus) && __cplusplus >= 201703L
+  #define CAMLunused [[maybe_unused]]
+  #define CAMLunused_start CAMLunused
   #define CAMLunused_end
+#elif __has_attribute(unused) || defined(__GNUC__)
   #define CAMLunused __attribute__ ((unused))
+  #define CAMLunused_start CAMLunused
+  #define CAMLunused_end
 #elif defined(_MSC_VER)
-  #define CAMLunused_start  __pragma( warning (push) )           \
-    __pragma( warning (disable:4189 ) )
+  #define CAMLunused_start __pragma( warning (push) )   \
+          __pragma( warning (disable:4189 ) )
   #define CAMLunused_end __pragma( warning (pop))
   #define CAMLunused
 #else

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -29,7 +29,7 @@
 
 #include "camlatomic.h"
 
-/* Detection of available C attributes */
+/* Detection of available C attributes and compiler extensions */
 
 #ifndef __has_c_attribute
 #define __has_c_attribute(x) 0
@@ -37,6 +37,10 @@
 
 #ifndef __has_attribute
 #define __has_attribute(x) 0
+#endif
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
 #endif
 
 /* Deprecation warnings */
@@ -174,9 +178,15 @@ CAMLdeprecated_typedef(addr, char *);
 /* Prefetching */
 
 #ifdef CAML_INTERNALS
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#if (__has_builtin(__builtin_prefetch) || defined(__GNUC__)) && \
+    (defined(__i386__) || defined(__x86_64__) || \
+     defined(_M_IX86) || defined(_M_AMD64))
 #define caml_prefetch(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
+#elif defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_AMD64))
+#include <intrin.h>
+#define caml_prefetch(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
+/* PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, p) */
 #else
 #define caml_prefetch(p)
 #endif
@@ -328,14 +338,6 @@ CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
 #endif
 ;
 
-/* Detection of available C built-in functions, the Clang way. */
-
-#ifdef __has_builtin
-#define Caml_has_builtin(x) __has_builtin(x)
-#else
-#define Caml_has_builtin(x) 0
-#endif
-
 /* Integer arithmetic with overflow detection.
    The functions return 0 if no overflow, 1 if overflow.
    The result of the operation is always stored at [*res].
@@ -345,7 +347,7 @@ CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
 
 Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_add_overflow)
+#if __has_builtin(__builtin_add_overflow) || defined(__GNUC__) && __GNUC__ >= 5
   return __builtin_add_overflow(a, b, res);
 #else
   uintnat c = a + b;
@@ -356,7 +358,7 @@ Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 
 Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_sub_overflow)
+#if __has_builtin(__builtin_sub_overflow) || defined(__GNUC__) && __GNUC__ >= 5
   return __builtin_sub_overflow(a, b, res);
 #else
   uintnat c = a - b;
@@ -365,7 +367,7 @@ Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 #endif
 }
 
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow)
+#if __has_builtin(__builtin_mul_overflow) || defined(__GNUC__) && __GNUC__ >= 5
 Caml_inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
   return __builtin_mul_overflow(a, b, res);

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -67,8 +67,8 @@ Caml_inline void cpu_relax(void) {
 
 /* Atomic read-modify-write instructions, with full fences */
 
-Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, uintnat v) {
-  uintnat result = atomic_fetch_add(p,v);
+Caml_inline uintnat atomic_fetch_sub_verify_ge0(atomic_uintnat* p, uintnat v) {
+  uintnat result = atomic_fetch_sub(p,v);
   CAMLassert ((intnat)result > 0);
   return result;
 }

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -313,3 +313,9 @@
 #undef HAS_BSD_GETAFFINITY_NP
 
 #undef HAS_ZSTD
+
+/* 3. Language extensions. */
+
+#undef HAVE_LABELS_AS_VALUES
+
+/* Define if the C compiler supports the labels as values extension. */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -107,7 +107,7 @@ CAMLprim value caml_gc_counters(value v)
 
   /* get a copy of these before allocating anything... */
   double minwords = caml_gc_minor_words_unboxed();
-  double prowords = Caml_state->stat_promoted_words;
+  double prowords = (double)Caml_state->stat_promoted_words;
   double majwords = Caml_state->stat_major_words +
                     (double) Caml_state->allocated_words;
 

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -604,7 +604,7 @@ CAMLprim value caml_int64_of_string(value s)
       if (res >  (uint64_t)1 << 63) caml_failwith(INT64_ERRMSG);
     }
   }
-  if (sign < 0) res = - res;
+  if (sign < 0) res = ~res + 1;
   return caml_copy_int64(res);
 }
 

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -677,10 +677,10 @@ static void update_major_slice_work(intnat howmuch,
   */
   heap_size = caml_heap_size(dom_st->shared_heap);
   heap_words = (double)Wsize_bsize(heap_size);
-  heap_sweep_words = heap_words;
+  heap_sweep_words = (uintnat)heap_words;
 
   total_cycle_work =
-    heap_sweep_words + (heap_words * 100 / (100 + caml_percent_free));
+    heap_sweep_words + (uintnat)(heap_words * 100 / (100 + caml_percent_free));
 
   if (heap_words > 0) {
     double alloc_ratio =

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -696,7 +696,7 @@ static void update_major_slice_work(intnat howmuch,
     double dependent_ratio =
       total_cycle_work
       * (100 + caml_percent_free)
-      / dom_st-> dependent_size / caml_percent_free;
+        / (double)dom_st->dependent_size / (double)caml_percent_free;
     dependent_work = (intnat) (my_dependent_count * dependent_ratio);
   }else{
     dependent_work = 0;
@@ -1393,8 +1393,8 @@ static void cycle_major_heap_from_stw_single(
          space_overhead@N =
          100.0 * (heap_words@N - live_words@N) / live_words@N
       */
-      double live_words_last_cycle =
-        caml_stat_space_overhead.not_garbage_words_last_cycle - swept_words;
+      double live_words_last_cycle = (double)
+        (caml_stat_space_overhead.not_garbage_words_last_cycle - swept_words);
       double space_overhead =
         100.0 * (double)(caml_stat_space_overhead.heap_words_last_cycle
                          - live_words_last_cycle) / live_words_last_cycle;

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -730,7 +730,7 @@ CAMLexport caml_stat_string caml_stat_strdup(const char *s)
 
 CAMLexport wchar_t * caml_stat_wcsdup(const wchar_t *s)
 {
-  int slen = wcslen(s);
+  size_t slen = wcslen(s);
   wchar_t* result = caml_stat_alloc((slen + 1)*sizeof(wchar_t));
   if (result == NULL)
     caml_raise_out_of_memory();

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1101,7 +1101,7 @@ Caml_inline float log_approx(uint32_t y)
 {
   union { float f; int32_t i; } u;
   u.f = y + 0.5f;
-  float exp = u.i >> 23;
+  float exp = (float)(u.i >> 23);
   u.i = (u.i & 0x7FFFFF) | 0x3F800000;
   float x = u.f;
   return (-111.70172433407f +

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -210,7 +210,8 @@ void caml_ext_table_free(struct ext_table * tbl, int free_entries)
 
 /* Integer arithmetic with overflow detection */
 
-#if ! (__GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow))
+#if ! (__has_builtin(__builtin_mul_overflow) || \
+       defined(__GNUC__) && __GNUC__ >= 5)
 CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #define HALF_SIZE (sizeof(uintnat) * 4)

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -15,16 +15,6 @@
 
 #define CAML_INTERNALS
 
-#if defined(_MSC_VER) && _MSC_VER >= 1400 && _MSC_VER < 1700
-/* Microsoft introduced a regression in Visual Studio 2005 (technically it's
-   not present in the Windows Server 2003 SDK which has a pre-release version)
-   and the abort function ceased to be declared __declspec(noreturn). This was
-   fixed in Visual Studio 2012. Trick stdlib.h into not defining abort (this
-   means exit and _exit are not defined either, but they aren't required). */
-#define _CRT_TERMINATE_DEFINED
-__declspec(noreturn) void __cdecl abort(void);
-#endif
-
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -378,7 +378,7 @@ uintnat caml_mem_round_up_pages(uintnat size)
 #define Is_page_aligned(size) ((size & (caml_plat_pagesize - 1)) == 0)
 
 #ifdef DEBUG
-static struct lf_skiplist mmap_blocks = {NULL};
+static struct lf_skiplist mmap_blocks;
 #endif
 
 #ifndef _WIN32

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -240,11 +240,11 @@ void caml_runtime_events_destroy(void) {
 static void runtime_events_create_from_stw_single(void) {
   /* Don't initialise runtime_events twice */
   if (!atomic_load_acquire(&runtime_events_enabled)) {
-    int ret, ring_headers_length, ring_data_length;
+    int ring_headers_length, ring_data_length;
 #ifdef _WIN32
     DWORD pid = GetCurrentProcessId();
 #else
-    int ring_fd;
+    int ring_fd, ret;
     long int pid = getpid();
 #endif
 

--- a/runtime/sak.c
+++ b/runtime/sak.c
@@ -28,18 +28,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifdef _WIN32
-#define strncmp_os wcsncmp
-#define toupper_os towupper
-#define printf_os wprintf
-#else
-#define strncmp_os strncmp
-/* NOTE: See CAVEATS section in https://man.netbsd.org/ctype.3 */
-/* and NOTE section in https://man7.org/linux/man-pages/man3/toupper.3.html */
-#define toupper_os(x) toupper((unsigned char)x)
-#define printf_os printf
-#endif
-
 /* Operations
    - encode-C-literal. Used for the OCAML_STDLIB_DIR macro in
      runtime/build_config.h to ensure the LIBDIR make variable is correctly
@@ -51,7 +39,7 @@
      `L"C:\\OCaml\xd83d\xdc2b\\lib"`
  */
 
-void usage(void)
+static void usage(void)
 {
   printf(
     "OCaml Build System Swiss Army Knife\n"
@@ -63,7 +51,7 @@ void usage(void)
 
 /* Converts the supplied path (UTF-8 on Unix and UCS-2ish on Windows) to a valid
    C string literal. On Windows, this is always a wchar_t* (L"..."). */
-void encode_C_literal(char_os *path)
+static void encode_C_literal(const char_os * path)
 {
   char_os c;
 

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -505,7 +505,7 @@ static const int posix_signals[] = {
 
 CAMLexport int caml_convert_signal_number(int signo)
 {
-  if (signo < 0 && signo >= -(sizeof(posix_signals) / sizeof(int)))
+  if (signo < 0 && signo >= -(int)(sizeof(posix_signals) / sizeof(int)))
     return posix_signals[-signo-1];
   else
     return signo;
@@ -513,8 +513,7 @@ CAMLexport int caml_convert_signal_number(int signo)
 
 CAMLexport int caml_rev_convert_signal_number(int signo)
 {
-  int i;
-  for (i = 0; i < sizeof(posix_signals) / sizeof(int); i++)
+  for (int i = 0; i < (int)(sizeof(posix_signals) / sizeof(int)); i++)
     if (signo == posix_signals[i]) return -i - 1;
   return signo;
 }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -363,7 +363,7 @@ static void expand_argument(wchar_t * arg)
 
 static void expand_pattern(wchar_t * pat)
 {
-  wchar_t * prefix, * p, * name;
+  wchar_t * prefix, * name;
   intptr_t handle;
   struct _wfinddata_t ffblk;
   size_t i;
@@ -1097,7 +1097,6 @@ CAMLexport clock_t caml_win32_clock(void)
 {
   FILETIME _creation, _exit;
   CAML_ULONGLONG_FILETIME stime, utime;
-  ULARGE_INTEGER tmp;
   ULONGLONG clocks_per_sec;
 
   if (!(GetProcessTimes(GetCurrentProcess(), &_creation, &_exit,

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -73,7 +73,7 @@ unsigned short caml_win32_minor = 0;
 unsigned short caml_win32_build = 0;
 unsigned short caml_win32_revision = 0;
 
-static CAMLnoret void caml_win32_sys_error(int errnum)
+CAMLnoret static void caml_win32_sys_error(int errnum)
 {
   wchar_t buffer[512];
   value msg;

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -106,7 +106,7 @@ static void write_console(HANDLE hOut, WCHAR *wstr)
   }
 }
 
-static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
+CAMLnoret static __inline void run_runtime(wchar_t * runtime,
          wchar_t * const cmdline)
 {
   wchar_t path[MAX_PATH];

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -31,20 +31,14 @@
 #endif
 #endif
 
-static
-#ifdef _MSC_VER
-__forceinline
-#else
-__inline
-#endif
-unsigned long read_size(const char * const ptr)
+Caml_inline unsigned long read_size(const char * const ptr)
 {
   const unsigned char * const p = (const unsigned char * const) ptr;
   return ((unsigned long) p[0] << 24) | ((unsigned long) p[1] << 16) |
          ((unsigned long) p[2] << 8) | p[3];
 }
 
-static __inline char * read_runtime_path(HANDLE h)
+Caml_inline char * read_runtime_path(HANDLE h)
 {
   char buffer[TRAILER_SIZE];
   static char runtime_path[MAX_PATH];
@@ -106,7 +100,7 @@ static void write_console(HANDLE hOut, WCHAR *wstr)
   }
 }
 
-CAMLnoret static __inline void run_runtime(wchar_t * runtime,
+CAMLnoret Caml_inline void run_runtime(wchar_t * runtime,
          wchar_t * const cmdline)
 {
   wchar_t path[MAX_PATH];
@@ -121,9 +115,6 @@ CAMLnoret static __inline void run_runtime(wchar_t * runtime,
     write_console(errh, runtime);
     write_console(errh, L"\r\n");
     ExitProcess(2);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
   }
   /* Need to ignore ctrl-C and ctrl-break, otherwise we'll die and take
      the underlying OCaml program with us! */
@@ -144,18 +135,12 @@ CAMLnoret static __inline void run_runtime(wchar_t * runtime,
     write_console(errh, runtime);
     write_console(errh, L"\r\n");
     ExitProcess(2);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
   }
   CloseHandle(procinfo.hThread);
   WaitForSingleObject(procinfo.hProcess , INFINITE);
   GetExitCodeProcess(procinfo.hProcess , &retcode);
   CloseHandle(procinfo.hProcess);
   ExitProcess(retcode);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
 }
 
 int wmain(void)
@@ -176,18 +161,9 @@ int wmain(void)
     write_console(errh, truename);
     write_console(errh, L" not found or is not a bytecode executable file\r\n");
     ExitProcess(2);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
   }
   CloseHandle(h);
   MultiByteToWideChar(CP, 0, runtime_path, -1, wruntime_path,
                       sizeof(wruntime_path)/sizeof(wchar_t));
   run_runtime(wruntime_path , cmdline);
-#ifdef _MSC_VER
-    __assume(0); /* Not reached */
-#endif
-#ifdef __MINGW32__
-    return 0;
-#endif
 }


### PR DESCRIPTION
Battling the well-known dislike of C programmers for compiler warnings, I'm opening a PR that enables MSVC and clang-cl basic warnings, and fixes them.

This PR fixes warnings raised by MSVC at level 2, and clang-cl at level 4 (minus unused parameters and sign-compare). It should be rather uneventful. MSVC really likes to warn when an assignment of two different ranges, like float to int, is made without an explicit cast.

If the warnings C4244 and C4146 are too annoying, they could also be disabled.

Clang-cl `-Wall` is equivalent to clang `-Weverything`, which is *really* to noisy, and enables some C++ warnings. Levels above 2 for MSVC are also noisy, and some warnings are even checking for C++ things in C. Someone with spare time might revisit this later…

