### PR TITLE
Force MSVC in C11 mode by default

### DIFF
--- a/configure
+++ b/configure
@@ -3699,6 +3699,7 @@ case $host in #(
     if test -z "$CC"
 then :
   CC=cl
+        : ${CFLAGS=-std:c11}
 fi
     ccomptype=msvc
     S=asm
@@ -15580,9 +15581,9 @@ case $cc_supports_atomic,$ocaml_cc_vendor in #(
 
 
   opts=""
-  if test -n "-std:c11"
+  if test -n "-experimental:c11atomics"
 then :
-  CFLAGS="$CFLAGS -std:c11"; opts="-std:c11"
+  CFLAGS="$CFLAGS -experimental:c11atomics"; opts="-experimental:c11atomics"
 fi
   if test -n ""
 then :
@@ -15639,7 +15640,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 
      if $cc_supports_atomic
 then :
-  common_cflags="$common_cflags -std:c11"
+  common_cflags="$common_cflags -experimental:c11atomics"
 else $as_nop
 
 
@@ -15717,8 +15718,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 then :
   common_cflags="$common_cflags -std:c11 -experimental:c11atomics"
 fi
-
-fi ;; #(
+fi
+ ;; #(
   *) :
      ;;
 esac

--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,9 @@ If your host is 64 bits, you can try with './configure CC="gcc -m64"' \
 
 AS_CASE([$host],
   [*-pc-windows],
-    [AS_IF([test -z "$CC"], [CC=cl])
+    [AS_IF([test -z "$CC"],
+       [CC=cl
+        : ${CFLAGS=-std:c11 -Zc:__STDC__}])
     ccomptype=msvc
     S=asm
     SO=dll
@@ -874,7 +876,7 @@ AS_CASE([$ocaml_cc_vendor],
     [common_cflags='-nologo -O2 -Gy- -MD'
     common_cppflags="-D_CRT_SECURE_NO_DEPRECATE"
     internal_cflags="$cc_warnings"
-    internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_NONSTDC_NO_WARNINGS'
+    internal_cppflags='-DUNICODE -D_UNICODE -D_CRT_DECLARE_NONSTDC_NAMES'
     AX_CHECK_COMPILE_FLAG([-d2VolatileMetadata-],
       [internal_cflags="$internal_cflags -d2VolatileMetadata-"], [],
       [$warn_error_flag])
@@ -1224,13 +1226,13 @@ AS_IF([! $arch64],
 OCAML_CC_SUPPORTS_ATOMIC([], [$cclibs])
 AS_CASE([$cc_supports_atomic,$ocaml_cc_vendor],
   [false,msvc-*],
-    [OCAML_CC_SUPPORTS_ATOMIC([-std:c11])
+    [OCAML_CC_SUPPORTS_ATOMIC([-experimental:c11atomics])
      AS_IF([$cc_supports_atomic],
-       [common_cflags="$common_cflags -std:c11"],
+       [common_cflags="$common_cflags -experimental:c11atomics"],
        [OCAML_CC_SUPPORTS_ATOMIC([-std:c11 -experimental:c11atomics])
         AS_IF([$cc_supports_atomic],
-          [common_cflags="$common_cflags -std:c11 -experimental:c11atomics"])
-])])
+          [common_cflags="$common_cflags -std:c11 -experimental:c11atomics"])])
+])
 AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 


### PR DESCRIPTION
Autoconf, through the [`AC_PROG_CC`][] macro (called by libtool's [`LT_INIT`][]), tries to detect whether the C compiler needs options to enable C11 support (we require a C11 compiler).

Autoconf development branch now understand hows to enable MSVC C11 support ([bug report][1], [patch][2]), which defaults to a C99 dialect. clang-cl defaults to C17.

It would be unfair to use Autoconf tests for missing or buggy C11 features if MSVC is in C99 mode, so we have to add `-std:c11` or `-std:c17` to `CFLAGS`. Our Autoconf tests can now expect a C11 compiler by default.

[`AC_PROG_CC`]: https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/C-Compiler.html#index-AC_005fPROG_005fCC-1
[`LT_INIT`]: https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
[1]: https://lists.gnu.org/archive/html/autoconf/2024-04/msg00001.html
[2]: http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=e9fee73dba5d2156abc48734b5a9faff89dcdc11