### PR TITLE
gha: use all available cores when building MSVC

### DIFF
--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -97,7 +97,7 @@ jobs:
           rm -rf config.cache ;
           ./configure --cache-file=config.cache --host=$HOST CC=$CC ;
           fi ;
-          make ;
+          make -j$NUMBER_OF_PROCESSORS ;
           runtime/ocamlrun ocamlc -config ;
           # Don't add indentation or comments, it breaks Bash on
           # Windows when the yaml text block scalar is processed as a
@@ -129,4 +129,4 @@ jobs:
         shell: bash
         run: >-
           eval $(tools/msvs-promote-path) ;
-          make tests ;
+          make -j$NUMBER_OF_PROCESSORS tests ;

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -72,7 +72,7 @@ jobs:
           key: cygwin-packages
 
       - name: Build OCaml
-        shell: bash -e {0}
+        shell: bash
         env:
           HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
           CC: ${{ matrix.cc }}
@@ -83,7 +83,7 @@ jobs:
           runtime/ocamlrun ocamlc -config ;
 
       - name: Assemble backend with MinGW GASM and compare
-        shell: bash -e {0}
+        shell: bash
         run: >-
           x86_64-w64-mingw32-gcc -c -I./runtime  -I ./flexdll -D__USE_MINGW_ANSI_STDIO=0 -DUNICODE -D_UNICODE -DWINDOWS_UNICODE=1 -DCAMLDLLIMPORT= -DIN_CAML_RUNTIME -DNATIVE_CODE -DTARGET_amd64 -DMODEL_default -DSYS_mingw64 -o runtime/amd64.o runtime/amd64.S ;
           dumpbin /disasm:nobytes runtime/amd64nt.obj > runtime/amd64nt.dump ;
@@ -98,7 +98,7 @@ jobs:
         if: matrix.x86_64
 
       - name: Run the test suite
-        shell: bash -e {0}
+        shell: bash
         run: >-
           eval $(tools/msvs-promote-path) ;
           make tests ;

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -71,6 +71,21 @@ jobs:
             C:\cygwin-packages
           key: cygwin-packages
 
+      - name: Compute a key to cache configure results
+        shell: bash
+        env:
+          HOST: ${{ matrix.x86_64 && 'x86_64-pc-windows' || 'i686-pc-windows' }}
+          CC: ${{ matrix.cc }}
+        run: >-
+          echo "AUTOCONF_CACHE_KEY=$HOST-$CC-$({ cat configure; uname; } | sha1sum | cut -c 1-7)" >> $GITHUB_ENV
+
+      - name: Restore Autoconf cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            config.cache
+          key: ${{ env.AUTOCONF_CACHE_KEY }}
+
       - name: Build OCaml
         shell: bash
         env:
@@ -78,9 +93,22 @@ jobs:
           CC: ${{ matrix.cc }}
         run: >-
           eval $(tools/msvs-promote-path) ;
-          ./configure --host=$HOST CC=$CC;
+          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC ; then
+          rm -rf config.cache ;
+          ./configure --cache-file=config.cache --host=$HOST CC=$CC ;
+          fi ;
           make ;
           runtime/ocamlrun ocamlc -config ;
+          # Don't add indentation or comments, it breaks Bash on
+          # Windows when the yaml text block scalar is processed as a
+          # single line.
+
+      - name: Save Autoconf cache
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            config.cache
+          key: ${{ env.AUTOCONF_CACHE_KEY }}
 
       - name: Assemble backend with MinGW GASM and compare
         shell: bash


### PR DESCRIPTION
This is similar to what we already do in AppVeyor for MinGW-w64 builds.
A comparison of the "Build OCaml" task, sequential versus parallel. According to [the docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), the runner have 4 CPUs. "cached" means that the configure script results have been cached.

|                  | sequential | parallel, `-j4` | parallel, `-j4`, cached | parallel, `-j`, cached |
|------------------|:----------:|:---------------:|:-----------------------:|:----------------------:|
| MSVC 64 bits     |   13m 26s  |      6m 21s     |          6m 19s         |          6m 5s         |
| clang-cl 64 bits |   14m 58s  |      8m 17s     |          7m 21s         |          7m 4s         |
| MSVC 32 bits     |   8m 28s   |      4m 31s     |          4m 35s         |         3m 56s         |