### PR TITLE
Runtime robustness 2024 1

### DIFF
--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -66,7 +66,8 @@ caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
 
-  CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
+  CAMLassert(0 <= num_dims);
+  CAMLassert(num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) < CAML_BA_FIRST_UNIMPLEMENTED_KIND);
   for (i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -916,7 +916,7 @@ static value find_handle(LPSELECTRESULT iterResult, value readfds,
       list = exceptfds;
       break;
     case SELECT_MODE_NONE:
-      CAMLassert(0);
+      CAMLunreachable();
   };
 
   for(i=0; list != Val_unit && i < iterResult->lpOrigIdx; ++i )
@@ -1281,7 +1281,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
                       except_list = l;
                       break;
                     case SELECT_MODE_NONE:
-                      CAMLassert(0);
+                      CAMLunreachable();
                     }
                 }
               /* We try to only process the first error, bypass other errors */

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -233,7 +233,8 @@ CAMLprim value caml_array_make(value len, value init)
         CAML_EV_COUNTER (EV_C_FORCE_MINOR_MAKE_VECT, 1);
         caml_minor_collection ();
       }
-      CAMLassert(!(Is_block(init) && Is_young(init)));
+      CAMLassert(!(Is_block(init)));
+      CAMLassert(Is_young(init));
       res = caml_alloc_shr(size, 0);
       /* We now know that [init] is not in the minor heap, so there is
          no need to call [caml_initialize]. */

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -302,7 +302,7 @@ CAMLexport void caml_ba_finalize(value v)
     /* Bigarrays for mapped files use a different finalization method */
     /* fallthrough */
   default:
-    CAMLassert(0);
+    CAMLunreachable();
   }
 }
 
@@ -386,8 +386,7 @@ CAMLexport int caml_ba_compare(value v1, value v2)
   case CAML_BA_NATIVE_INT:
     DO_INTEGER_COMPARISON(intnat);
   default:
-    CAMLassert(0);
-    return 0;                   /* should not happen */
+    CAMLunreachable();          /* should not happen */
   }
 #undef DO_INTEGER_COMPARISON
 #undef DO_FLOAT_COMPARISON
@@ -727,8 +726,6 @@ value caml_ba_get_N(value vb, volatile value * vind, int nind)
   offset = caml_ba_offset(b, index);
   /* Perform read */
   switch ((b->flags) & CAML_BA_KIND_MASK) {
-  default:
-    CAMLassert(0);
   case CAML_BA_FLOAT16:
     return caml_copy_double(
       (double) caml_float16_to_float(((uint16 *) b->data)[offset]));
@@ -760,6 +757,8 @@ value caml_ba_get_N(value vb, volatile value * vind, int nind)
       return copy_two_doubles(p[0], p[1]); }
   case CAML_BA_CHAR:
     return Val_int(((unsigned char *) b->data)[offset]);
+  default:
+    CAMLunreachable();
   }
 }
 
@@ -872,8 +871,6 @@ static value caml_ba_set_aux(value vb, volatile value * vind,
   offset = caml_ba_offset(b, index);
   /* Perform write */
   switch (b->flags & CAML_BA_KIND_MASK) {
-  default:
-    CAMLassert(0);
   case CAML_BA_FLOAT16:
     ((uint16 *) b->data)[offset] =
       caml_float_to_float16(Double_val(newval)); break;
@@ -906,6 +903,8 @@ static value caml_ba_set_aux(value vb, volatile value * vind,
       p[0] = Double_flat_field(newval, 0);
       p[1] = Double_flat_field(newval, 1);
       break; }
+  default:
+    CAMLunreachable();
   }
   return Val_unit;
 }
@@ -1288,8 +1287,6 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
   intnat num_elts = caml_ba_num_elts(b);
 
   switch (b->flags & CAML_BA_KIND_MASK) {
-  default:
-    CAMLassert(0);
   case CAML_BA_FLOAT16: {
     uint16 init = caml_float_to_float16(Double_val(vinit));
     uint16 * p;
@@ -1361,6 +1358,8 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
     FILL_COMPLEX_LOOP;
     break;
   }
+  default:
+    CAMLunreachable();
   }
   CAMLreturn (Val_unit);
 }

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -230,7 +230,8 @@ caml_ba_alloc(int flags, int num_dims, void * data, intnat * dim)
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
 
-  CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
+  CAMLassert(0 >= num_dims);
+  CAMLassert(num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) < CAML_BA_FIRST_UNIMPLEMENTED_KIND);
   for (i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   num_elts = 1;

--- a/runtime/blake2.c
+++ b/runtime/blake2.c
@@ -171,7 +171,8 @@ CAMLexport void
 caml_BLAKE2Final(struct BLAKE2_context * s,
                  size_t hashlen, unsigned char * hash)
 {
-  CAMLassert (0 < hashlen && hashlen <= 64);
+  CAMLassert(0 < hashlen);
+  CAMLassert(hashlen <= 64);
   /* The final block is composed of the remaining data padded with zeros. */
   memset(s->buffer + s->numbytes, 0, BLAKE2_BLOCKSIZE - s->numbytes);
   caml_BLAKE2Compress(s, s->buffer, s->numbytes, 1);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -248,6 +248,24 @@ CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
 #else
 #define __OSFILE__ __FILE__
 #endif
+
+#define CAMLunreachable() abort()
+
+#else
+
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
+    defined(__cplusplus)
+#define CAMLunreachable() unreachable()
+#elif defined(__GNUC__) || defined(__clang__)
+#define CAMLunreachable() (__builtin_unreachable())
+#elif defined(_MSC_VER)
+#define CAMLunreachable() (__assume(0))
+#endif
+
+#endif
+
+#ifndef CAMLunreachable
+#define CAMLunreachable() ((void) 0)
 #endif
 
 #ifdef DEBUG

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -235,7 +235,8 @@ typedef char char_os;
 
 /* Assertions */
 
-#ifdef DEBUG
+#if defined (DEBUG) || !defined(CAML_NO_CHECK)
+CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
 
 #ifdef UNICODE
 /* See https://msdn.microsoft.com/ja-jp/library/b0084kay(v=vs.71).aspx
@@ -247,12 +248,20 @@ typedef char char_os;
 #else
 #define __OSFILE__ __FILE__
 #endif
+#endif
 
+#ifdef DEBUG
 #define CAMLassert(x) \
   (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
-CAMLnoret CAMLextern void caml_failed_assert (char *, char_os *, int);
 #else
 #define CAMLassert(x) ((void) 0)
+#endif
+
+#ifndef CAML_NO_CHECK
+#define CAMLcheck(x)                                                    \
+    (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
+#else
+#define CAMLcheck(x) ((void) 0)
 #endif
 
 #ifdef __GNUC__

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -948,7 +948,8 @@ void caml_init_domains(uintnat minor_heap_wsz) {
 }
 
 void caml_init_domain_self(int domain_id) {
-  CAMLassert (domain_id >= 0 && domain_id < Max_domains);
+  CAMLassert(0 <= domain_id);
+  CAMLassert(domain_id < Max_domains);
   domain_self = &all_domains[domain_id];
   caml_state = domain_self->state;
 }

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -725,7 +725,7 @@ static void extern_code_pointer(struct caml_extern_state* s, char * codeptr)
     digest = (const char *) caml_digest_of_code_fragment(cf);
     if (digest == NULL)
       extern_invalid_argument(s, "output_value: private function");
-    CAMLassert(cf == caml_find_code_fragment_by_digest((unsigned char*)digest));
+    CAMLcheck(cf == caml_find_code_fragment_by_digest((unsigned char*)digest));
     writecode32(s, CODE_CODEPOINTER, codeptr - cf->code_start);
     writeblock(s, digest, 16);
   } else {
@@ -756,7 +756,7 @@ Caml_inline mlsize_t extern_closure_up_to_env(struct caml_extern_state* s,
       extern_code_pointer(s, (char *) Field(v, i++));
     }
   } while (i < startenv);
-  CAMLassert(i == startenv);
+  CAMLcheck(i == startenv);
   return startenv;
 }
 

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -20,6 +20,8 @@
 /* The interface of this file is "caml/intext.h" */
 
 #include <string.h>
+#include <assert.h>
+
 #include "caml/alloc.h"
 #include "caml/codefrag.h"
 #include "caml/config.h"
@@ -821,7 +823,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
       break;
     }
     case Double_tag: {
-      CAMLassert(sizeof(double) == 8);
+      static_assert(sizeof(double) == 8, "");
       extern_double(s, v);
       s->size_32 += 1 + 2;
       s->size_64 += 1 + 1;
@@ -830,7 +832,7 @@ static void extern_rec(struct caml_extern_state* s, value v)
     }
     case Double_array_tag: {
       mlsize_t nfloats;
-      CAMLassert(sizeof(double) == 8);
+      static_assert(sizeof(double) == 8, "");
       nfloats = Wosize_val(v) / Double_wosize;
       extern_double_array(s, v, nfloats);
       s->size_32 += 1 + nfloats * 2;

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -622,7 +622,8 @@ CAMLprim value caml_continuation_use_noexc (value cont)
 
   fiber_debug_log("cont: is_block(%d) tag_val(%ul) is_young(%d)",
                   Is_block(cont), Tag_val(cont), Is_young(cont));
-  CAMLassert(Is_block(cont) && Tag_val(cont) == Cont_tag);
+  CAMLassert(Is_block(cont));
+  CAMLassert(Tag_val(cont) == Cont_tag);
 
   /* this forms a barrier between execution and any other domains
      that might be marking this continuation */

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <float.h>
 #include <limits.h>
+#include <assert.h>
 
 #include "caml/alloc.h"
 #include "caml/fail.h"
@@ -85,7 +86,7 @@ CAMLexport double caml_Double_val(value val)
 {
   union { value v[2]; double d; } buffer;
 
-  CAMLassert(sizeof(double) == 2 * sizeof(value));
+  static_assert(sizeof(double) == 2 * sizeof(value), "");
   buffer.v[0] = Field(val, 0);
   buffer.v[1] = Field(val, 1);
   return buffer.d;
@@ -95,7 +96,7 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
 {
   union { value v[2]; double d; } buffer;
 
-  CAMLassert(sizeof(double) == 2 * sizeof(value));
+  static_assert(sizeof(double) == 2 * sizeof(value), "");
   buffer.d = dbl;
   Field(val, 0) = buffer.v[0];
   Field(val, 1) = buffer.v[1];

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -230,7 +230,8 @@ static void intern_init(struct caml_intern_state* s, const void * src,
   /* This is asserted at the beginning of demarshaling primitives.
      If it fails, it probably means that an exception was raised
      without calling intern_cleanup() during the previous demarshaling. */
-  CAMLassert (s->intern_input == NULL && s->intern_obj_table == NULL);
+  CAMLassert(s->intern_input == NULL);
+  CAMLassert(s->intern_obj_table == NULL);
   s->intern_src = src;
   s->intern_input = input;
 }

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -727,7 +727,7 @@ static void intern_rec(struct caml_intern_state* s,
   *dest = v;
   break;
   default:
-    CAMLassert(0);
+    CAMLunreachable();
   }
   }
   /* We are done. Cleanup the stack and leave the function */

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -226,12 +226,12 @@ Caml_inline void readblock(struct caml_intern_state* s,
 static void intern_init(struct caml_intern_state* s, const void * src,
                         void * input)
 {
-  CAMLassert (s);
+  CAMLcheck (s);
   /* This is asserted at the beginning of demarshaling primitives.
      If it fails, it probably means that an exception was raised
      without calling intern_cleanup() during the previous demarshaling. */
-  CAMLassert(s->intern_input == NULL);
-  CAMLassert(s->intern_obj_table == NULL);
+  CAMLcheck(s->intern_input == NULL);
+  CAMLcheck(s->intern_obj_table == NULL);
   s->intern_src = src;
   s->intern_input = input;
 }
@@ -391,7 +391,7 @@ static void intern_alloc_storage(struct caml_intern_state* s, mlsize_t whsize,
   value v;
 
   if (whsize == 0) {
-    CAMLassert (s->intern_obj_table == NULL);
+    CAMLcheck (s->intern_obj_table == NULL);
     return;
   }
   wosize = Wosize_whsize(whsize);
@@ -402,7 +402,7 @@ static void intern_alloc_storage(struct caml_intern_state* s, mlsize_t whsize,
     Alloc_small(v, wosize, String_tag, Alloc_small_enter_GC_no_track);
     s->intern_dest = (header_t *) Hp_val(v);
   } else {
-    CAMLassert (s->intern_dest == NULL);
+    CAMLcheck (s->intern_dest == NULL);
   }
   s->obj_counter = 0;
   if (num_objects > 0) {
@@ -413,7 +413,7 @@ static void intern_alloc_storage(struct caml_intern_state* s, mlsize_t whsize,
       caml_raise_out_of_memory();
     }
   } else {
-    CAMLassert(s->intern_obj_table == NULL);
+    CAMLcheck(s->intern_obj_table == NULL);
   }
 
   return;
@@ -425,7 +425,7 @@ static value intern_alloc_obj(struct caml_intern_state* s, caml_domain_state* d,
   void* p;
 
   if (s->intern_dest) {
-    CAMLassert ((value*)s->intern_dest >= d->young_start &&
+    CAMLcheck ((value*)s->intern_dest >= d->young_start &&
                 (value*)s->intern_dest < d->young_end);
     p = s->intern_dest;
     *s->intern_dest = Make_header (wosize, tag, 0);
@@ -510,7 +510,7 @@ static void intern_rec(struct caml_intern_state* s,
           s->intern_obj_table[s->obj_counter++] = v;
         /* For objects, we need to freshen the oid */
         if (tag == Object_tag) {
-          CAMLassert(size >= 2);
+          CAMLcheck(size >= 2);
           /* Request to read rest of the elements of the block */
           ReadItems(s, &Field(v, 2), size - 2);
           /* Request freshing OID */
@@ -565,8 +565,8 @@ static void intern_rec(struct caml_intern_state* s,
         ofs = read8u(s);
       read_shared:
         if (!s->compressed) ofs = s->obj_counter - ofs;
-        CAMLassert (ofs < s->obj_counter);
-        CAMLassert (s->intern_obj_table != NULL);
+        CAMLcheck (ofs < s->obj_counter);
+        CAMLcheck (s->intern_obj_table != NULL);
         v = s->intern_obj_table[ofs];
         break;
       case CODE_SHARED16:
@@ -887,7 +887,7 @@ value caml_input_val(struct channel *chan)
     hlen = 20; break;
   }
   /* Read the remainder of the header */
-  CAMLassert (hlen > 5);
+  CAMLcheck (hlen > 5);
   if (caml_really_getblock(chan, header + 5, hlen - 5) < hlen - 5)
     caml_failwith("input_value: truncated object");
   /* Parse the full header */

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -329,7 +329,8 @@ int caml_lf_skiplist_insert(struct lf_skiplist *sk, uintnat key, uintnat data) {
   struct lf_skipcell *preds[NUM_LEVELS];
   struct lf_skipcell *succs[NUM_LEVELS];
 
-  CAMLassert(key > 0 && key < UINTNAT_MAX);
+  CAMLassert(0 < key);
+  CAMLassert(key < UINTNAT_MAX);
 
   while (1) {
     /* We first try to find a node with [key] in the skip list. If it exists

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -251,7 +251,8 @@ Caml_inline void pb_fill_mode(prefetch_buffer_t *pb)
 
 Caml_inline void pb_push(prefetch_buffer_t* pb, value v)
 {
-  CAMLassert(Is_block(v) && !Is_young(v));
+  CAMLassert(Is_block(v));
+  CAMLassert(!Is_young(v));
   CAMLassert(v != Debug_free_major);
   CAMLassert(pb->enqueued < pb->dequeued + PREFETCH_BUFFER_SIZE);
 
@@ -889,7 +890,8 @@ static intnat mark_stack_push_block(struct mark_stack* stk, value block)
   }
 
   CAMLassert(Has_status_val(block, caml_global_heap_state.MARKED));
-  CAMLassert(Is_block(block) && !Is_young(block));
+  CAMLassert(Is_block(block));
+  CAMLassert(!Is_young(block));
   CAMLassert(Tag_val(block) != Infix_tag);
   CAMLassert(Tag_val(block) < No_scan_tag);
   CAMLassert(Tag_val(block) != Cont_tag);
@@ -1186,7 +1188,9 @@ static scanning_action_flags darken_scanning_flags = 0;
 
 void caml_darken_cont(value cont)
 {
-  CAMLassert(Is_block(cont) && !Is_young(cont) && Tag_val(cont) == Cont_tag);
+  CAMLassert(Is_block(cont));
+  CAMLassert(!Is_young(cont));
+  CAMLassert(Tag_val(cont) == Cont_tag);
   {
     SPIN_WAIT {
       header_t hd = atomic_load_relaxed(Hp_atomic_val(cont));

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -603,7 +603,8 @@ CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
 {
   char *raw_mem;
   uintnat aligned_mem;
-  CAMLassert (0 <= modulo && modulo < Page_size);
+  CAMLassert(0 <= modulo);
+  CAMLassert(modulo < Page_size);
   raw_mem = (char *) caml_stat_alloc_noexc(sz + Page_size);
   if (raw_mem == NULL) return NULL;
   *b = raw_mem;

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1165,7 +1165,8 @@ static uintnat rand_geom(memprof_domain_t domain)
   if (domain->rand_pos == RAND_BLOCK_SIZE)
     rand_batch(domain);
   res = domain->rand_geom_buff[domain->rand_pos++];
-  CAMLassert(1 <= res && res <= Max_long);
+  CAMLassert(1 <= res);
+  CAMLassert(res <= Max_long);
   return res;
 }
 
@@ -1768,7 +1769,9 @@ static value run_callback_exn(memprof_thread_t thread,
     entry_delete(es, i);
   } else {
     /* Callback returned [Some _]. Store the value in [user_data]. */
-    CAMLassert(Is_block(res) && Tag_val(res) == 0 && Wosize_val(res) == 1);
+    CAMLassert(Is_block(res));
+    CAMLassert(Tag_val(res) == 0);
+    CAMLassert(Wosize_val(res) == 1);
     e->user_data = Field(res, 0);
     if (Is_block(e->user_data) && Is_young(e->user_data) &&
         i < es->young)
@@ -1972,8 +1975,8 @@ void caml_memprof_set_trigger(caml_domain_state *state)
     }
   }
 
-  CAMLassert((trigger >= state->young_start) &&
-             (trigger <= state->young_ptr));
+  CAMLassert(trigger >= state->young_start);
+  CAMLassert(trigger <= state->young_ptr);
   state->memprof_young_trigger = trigger;
 }
 
@@ -2030,9 +2033,9 @@ void caml_memprof_sample_young(uintnat wosize, int from_caml,
   }
 
   /* The memprof trigger lies in (young_ptr, young_ptr + whsize] */
-  CAMLassert(Caml_state->young_ptr < Caml_state->memprof_young_trigger &&
-             Caml_state->memprof_young_trigger <=
-               Caml_state->young_ptr + whsize);
+  CAMLassert(Caml_state->young_ptr < Caml_state->memprof_young_trigger);
+  CAMLassert(Caml_state->memprof_young_trigger <=
+             Caml_state->young_ptr + whsize);
 
   /* Trigger offset from the base of the combined allocation. We
    * reduce this for each sample in this comballoc. Signed so it can

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -273,7 +273,8 @@ static void oldify_one (void* st_v, value v, volatile value *p)
 
   if (tag == Cont_tag) {
     value stack_value = Field(v, 0);
-    CAMLassert(Wosize_hd(hd) == 2 && infix_offset == 0);
+    CAMLassert(Wosize_hd(hd) == 2);
+    CAMLassert(infix_offset == 0);
     result = alloc_shared(st->domain, 2, Cont_tag, Reserved_hd(hd));
     if( try_update_object_header(v, p, result, 0) ) {
       struct stack_info* stk = Ptr_val(stack_value);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -45,7 +45,7 @@ _Atomic caml_timing_hook caml_minor_gc_end_hook = (caml_timing_hook)NULL;
 _Atomic caml_timing_hook caml_finalise_begin_hook = (caml_timing_hook)NULL;
 _Atomic caml_timing_hook caml_finalise_end_hook = (caml_timing_hook)NULL;
 
-#ifdef DEBUG
+#if defined (DEBUG) || !defined(CAML_NO_CHECK)
 
 void caml_failed_assert (char * expr, char_os * file_os, int line)
 {

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -300,8 +300,7 @@ CAMLprim value caml_parse_engine(value vtables, value venv,
     goto loop;
 
   default:                      /* Should not happen */
-    CAMLassert(0);
-    return RAISE_PARSE_ERROR;   /* Keeps gcc -Wall happy */
+    CAMLunreachable();
   }
 
 }

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -1370,8 +1370,8 @@ static void verify_swept (struct caml_heap_state* local) {
   CAMLassert(local->next_to_sweep == NUM_SIZECLASSES);
   for (i = 0; i < NUM_SIZECLASSES; i++) {
     pool* p;
-    CAMLassert(local->unswept_avail_pools[i] == NULL &&
-               local->unswept_full_pools[i] == NULL);
+    CAMLassert(local->unswept_avail_pools[i] == NULL);
+    CAMLassert(local->unswept_full_pools[i] == NULL);
     for (p = local->avail_pools[i]; p; p = p->next)
       verify_pool(p, i, &pool_stats);
     for (p = local->full_pools[i]; p; p = p->next) {

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -57,7 +57,9 @@ void caml_garbage_collection(void)
   { /* Find the frame descriptor for the current allocation */
     d = caml_find_frame_descr(fds, retaddr);
     /* Must be an allocation frame */
-    CAMLassert(d && !frame_return_to_C(d) && frame_has_allocs(d));
+    CAMLassert(d);
+    CAMLassert(!frame_return_to_C(d));
+    CAMLassert(frame_has_allocs(d));
   }
 
   { /* Compute the total allocation size at this point,


### PR DESCRIPTION
TODO:
- what to do about the `CAMLassert(0)` in `caml_plat_mem_unmap` on Windows and Unix? Turn it into `CAMLunreachable` too?
- turn `__assume(0)` or `__assume(false)` (MSVC specific) into `CAMLunreachable`.
- inspect all `CAMLassert` calls.