### PR TITLE
Force and assume that MSVC uses in C11 mode by default

### DIFF
--- a/configure
+++ b/configure
@@ -13750,6 +13750,29 @@ case $ocaml_cc_vendor in #(
   ocamltest_CPP="$CPP" ;;
 esac
 
+# Check that we're using C11 or later.
+# Autoconf C11 and MSVC detection will be fixed in 2.73.
+case $ocaml_cc_vendor in #(
+  msvc-*) :
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 201112L
+#error "No C11 support"
+#endif
+
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"
+then :
+
+else $as_nop
+  CFLAGS="$CFLAGS -std:c11"
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext ;; #(
+  *) :
+     ;;
+esac
+
 # Absolute path to the toplevel source directory
 
 # A sentinel character (X) is added at the end of the directory name

--- a/configure
+++ b/configure
@@ -15581,9 +15581,9 @@ case $cc_supports_atomic,$ocaml_cc_vendor in #(
 
 
   opts=""
-  if test -n "-std:c11"
+  if test -n "-experimental:c11atomics"
 then :
-  CFLAGS="$CFLAGS -std:c11"; opts="-std:c11"
+  CFLAGS="$CFLAGS -experimental:c11atomics"; opts="-experimental:c11atomics"
 fi
   if test -n ""
 then :
@@ -15640,85 +15640,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 
      if $cc_supports_atomic
 then :
-  common_cflags="$common_cflags -std:c11"
-else $as_nop
-
-
-  saved_CC="$CC"
-  saved_CFLAGS="$CFLAGS"
-  saved_CPPFLAGS="$CPPFLAGS"
-  saved_LIBS="$LIBS"
-  saved_ac_ext="$ac_ext"
-  saved_ac_compile="$ac_compile"
-  # Move the content of confdefs.h to another file so it does not
-  # get included
-  mv confdefs.h confdefs.h.bak
-  touch confdefs.h
-
-
-  opts=""
-  if test -n "-std:c11 -experimental:c11atomics"
-then :
-  CFLAGS="$CFLAGS -std:c11 -experimental:c11atomics"; opts="-std:c11 -experimental:c11atomics"
-fi
-  if test -n ""
-then :
-  LIBS="$LIBS "; opts="${opts:+$opts }"
-fi
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC supports _Atomic types with ${opts:-no additional options}" >&5
-printf %s "checking if $CC supports _Atomic types with ${opts:-no additional options}... " >&6; }
-
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <stdint.h>
-#include <stdatomic.h>
-
-int
-main (void)
-{
-
-  _Atomic int64_t n;
-  int m;
-  int * _Atomic p = &m;
-  atomic_store_explicit(&n, 123, memory_order_release);
-  * atomic_exchange(&p, 0) = 45;
-  if (atomic_load_explicit(&n, memory_order_acquire))
-    return 1;
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  cc_supports_atomic=true
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
-  cc_supports_atomic=false
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-
-
-  # Restore the content of confdefs.h
-  mv confdefs.h.bak confdefs.h
-  ac_compile="$saved_ac_compile"
-  ac_ext="$saved_ac_ext"
-  CPPFLAGS="$saved_CPPFLAGS"
-  CFLAGS="$saved_CFLAGS"
-  CC="$saved_CC"
-  LIBS="$saved_LIBS"
-
-
-        if $cc_supports_atomic
-then :
-  common_cflags="$common_cflags -std:c11 -experimental:c11atomics"
-fi
-
+  common_cflags="$common_cflags -experimental:c11atomics"
 fi ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -676,6 +676,16 @@ AS_CASE([$ocaml_cc_vendor],
   [CPP="$CC -E -P"
   ocamltest_CPP="$CPP"])
 
+# Check that we're using C11 or later.
+# Autoconf C11 and MSVC detection will be fixed in 2.73.
+AS_CASE([$ocaml_cc_vendor],
+  [msvc-*],
+    [AC_PREPROC_IFELSE([AC_LANG_SOURCE([[
+#if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 201112L
+#error "No C11 support"
+#endif
+    ]])], [], [CFLAGS="$CFLAGS -std:c11"])])
+
 # Absolute path to the toplevel source directory
 
 # A sentinel character (X) is added at the end of the directory name

--- a/configure.ac
+++ b/configure.ac
@@ -1222,13 +1222,9 @@ AS_IF([! $arch64],
 OCAML_CC_SUPPORTS_ATOMIC([], [$cclibs])
 AS_CASE([$cc_supports_atomic,$ocaml_cc_vendor],
   [false,msvc-*],
-    [OCAML_CC_SUPPORTS_ATOMIC([-std:c11])
+    [OCAML_CC_SUPPORTS_ATOMIC([-experimental:c11atomics])
      AS_IF([$cc_supports_atomic],
-       [common_cflags="$common_cflags -std:c11"],
-       [OCAML_CC_SUPPORTS_ATOMIC([-std:c11 -experimental:c11atomics])
-        AS_IF([$cc_supports_atomic],
-          [common_cflags="$common_cflags -std:c11 -experimental:c11atomics"])
-])])
+       [common_cflags="$common_cflags -experimental:c11atomics"])])
 AS_IF([! $cc_supports_atomic],
   [AC_MSG_FAILURE([C11 atomic support is required, use another C compiler])])
 


### PR DESCRIPTION
Autoconf, through the [`AC_PROG_CC`][] macro (called by libtool's [`LT_INIT`][]), tries to detect whether the C compiler needs options to enable C11 support (we require a C11 compiler).

Autoconf development branch now understand hows to enable MSVC C11 support ([bug report][1], [patch][2]), which defaults to a C99 dialect. Note that clang-cl defaults to C17.

It would be unfair to use Autoconf tests for missing or buggy C11 features if MSVC is in C99 mode, so we have to add `-std:c11` or `-std:c17` to `CFLAGS`.

We can already re-organize our tests to assume C11, and, until Autoconf 2.73 is used, we can enable MSVC' C11 support by default. As it is still possible for the user to mess up the `CFLAGS`, we can keep a convenience fallback re-enabling C11 in case it was disabled. I'm tempted to remove this fallback altogether (for instance, if the user inadvertently disables C11, Autoconf tests will use the C99 compiler until the fallback re-enabling C11 is reached…).

The first and last commit should be reverted once we'll use Autoconf 2.73.

[`AC_PROG_CC`]: https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/C-Compiler.html#index-AC_005fPROG_005fCC-1
[`LT_INIT`]: https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
[1]: https://lists.gnu.org/archive/html/autoconf/2024-04/msg00001.html
[2]: http://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=e9fee73dba5d2156abc48734b5a9faff89dcdc11

No change entry needed.