### PR TITLE
Use WinAPI concurrency primitives on Windows ports (remove `winpthreads`)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "flexdll"]
     path = flexdll
     url = https://github.com/ocaml/flexdll.git
-[submodule "winpthreads"]
-    path = winpthreads
-    url = https://github.com/ocaml/winpthreads.git

--- a/Changes
+++ b/Changes
@@ -7,6 +7,14 @@ Working version
 
 ### Runtime system:
 
+- #13352: Concurrency refactors and cleanups.
+  (Antonin Décimo, review by Gabriel Scherer, David Allsopp,
+   and Miod Vallat)
+
+- #13416: Implement concurrency primitives using WinAPI instead of
+  winpthreads on Windows.
+  (Antonin Décimo, review by Samuel Hym)
+
 ### Code generation and optimizations:
 
 ### Standard library:
@@ -164,10 +172,6 @@ ___________
 - #13242: Define and use unreachable and trap annotation, and clean-up some
   runtime assertions.
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
-
-- #13352: Concurrency refactors and cleanups.
-  (Antonin Décimo, review by Gabriel Scherer, David Allsopp,
-   and Miod Vallat)
 
 ### Code generation and optimizations:
 

--- a/Changes
+++ b/Changes
@@ -134,6 +134,10 @@ _______________
   runtime assertions.
   (Antonin Décimo, review by Miod Vallat, Gabriel Scherer, and David Allsopp)
 
+- #13352: Concurrency refactors and cleanups.
+  (Antonin Décimo, review by Gabriel Scherer, David Allsopp,
+   and Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -215,7 +215,6 @@ has excellent documentation.
   toplevel/::             interactive system
   typing/::               typechecking -- see link:typing/HACKING.adoc[]
   utils/::                utility libraries
-  winpthreads/::          winpthreads submodule -- see <<winpthreads,further>>
   yacc/::                 parser generator
 
 [#tips]
@@ -696,37 +695,5 @@ OCAML_JOBS=10
 If you would like to receive email notifications of all commits made to the main
 git repository, you can subscribe to the caml-commits@inria.fr mailing list by
 visiting https://sympa.inria.fr/sympa/info/caml-commits[its web page.]
-
-[#winpthreads]
-=== The `winpthreads` library for the MSVC port
-
-The `winpthreads` library is used to emulate `pthread` for the MSVC
-port. Upstream bundles it along with all the MinGW libraries so our
-`winpthreads` submodule points to `git subtree` repository rather than
-upstream directly.
-
-To recreate the `winpthreads` repository from upstream, you can do:
-
-----
-git clone -o upstream https://git.code.sf.net/p/mingw-w64/mingw-w64 winpthreads
-cd winpthreads
-git checkout upstream/master
-git branch -D master
-git subtree -P mingw-w64-libraries/winpthreads split -b master
-----
-
-As subtree splitting is deterministic, repeating these operations later will
-allow to update `master`, for instance by:
-
-----
-git fetch upstream
-git checkout upstream/master
-git subtree -P mingw-w64-libraries/winpthreads split -b tmp
-git checkout master
-git merge --ff-only tmp
-git branch -d tmp
-----
-
-and then go on updating the `winpthreads` submodule in the `ocaml` repository.
 
 Happy Hacking!

--- a/Makefile
+++ b/Makefile
@@ -1169,15 +1169,6 @@ partialclean::
 
 ## Lists of source files
 
-ifneq "$(WINPTHREADS_SOURCE_DIR)" ""
-winpthreads_SOURCES = cond.c misc.c mutex.c rwlock.c sched.c spinlock.c thread.c
-
-winpthreads_OBJECTS = \
-  $(addprefix runtime/winpthreads/, $(winpthreads_SOURCES:.c=.$(O)))
-else
-winpthreads_OBJECTS =
-endif
-
 runtime_COMMON_C_SOURCES = \
   addrmap \
   afl \
@@ -1299,35 +1290,32 @@ endif
 
 
 libcamlrun_OBJECTS = \
-  $(runtime_BYTECODE_C_SOURCES:.c=.b.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_BYTECODE_C_SOURCES:.c=.b.$(O))
 
 libcamlrun_non_shared_OBJECTS = \
   $(subst $(UNIX_OR_WIN32).b.$(O),$(UNIX_OR_WIN32)_non_shared.b.$(O), \
           $(libcamlrun_OBJECTS))
 
 libcamlrund_OBJECTS = $(runtime_BYTECODE_C_SOURCES:.c=.bd.$(O)) \
-  $(winpthreads_OBJECTS) runtime/instrtrace.bd.$(O)
+  runtime/instrtrace.bd.$(O)
 
 libcamlruni_OBJECTS = \
-  $(runtime_BYTECODE_C_SOURCES:.c=.bi.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_BYTECODE_C_SOURCES:.c=.bi.$(O))
 
 libcamlrunpic_OBJECTS = \
-  $(runtime_BYTECODE_C_SOURCES:.c=.bpic.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_BYTECODE_C_SOURCES:.c=.bpic.$(O))
 
 libasmrun_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.n.$(O)) $(runtime_ASM_OBJECTS) \
-  $(winpthreads_OBJECTS)
+  $(runtime_NATIVE_C_SOURCES:.c=.n.$(O)) $(runtime_ASM_OBJECTS)
 
 libasmrund_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.nd.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.d.$(O)) \
-  $(winpthreads_OBJECTS)
+  $(runtime_NATIVE_C_SOURCES:.c=.nd.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.d.$(O))
 
 libasmruni_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.ni.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.i.$(O)) \
-  $(winpthreads_OBJECTS)
+  $(runtime_NATIVE_C_SOURCES:.c=.ni.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.i.$(O))
 
 libasmrunpic_OBJECTS = $(runtime_NATIVE_C_SOURCES:.c=.npic.$(O)) \
-  $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O)) $(winpthreads_OBJECTS)
+  $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
 
 libcomprmarsh_OBJECTS = runtime/zstd.npic.$(O)
 
@@ -1521,15 +1509,6 @@ endif # ifeq "$(COMPUTE_DEPS)" "true"
 	  $$(OUTPUTOBJ)$$@ -c $$<
 endef
 
-runtime/winpthreads/%.$(O): $(WINPTHREADS_SOURCE_DIR)/src/%.c \
-                            $(wildcard $(WINPTHREADS_SOURCE_DIR)/include/*.h) \
-                              | runtime/winpthreads
-	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
-	  $(OUTPUTOBJ)$@ -c $<
-
-runtime/winpthreads:
-	$(MKDIR) $@
-
 $(DEPDIR)/runtime:
 	$(MKDIR) $@
 
@@ -1616,7 +1595,7 @@ clean::
 	rm -f runtime/primitives runtime/primitives*.new runtime/prims.c \
 	  $(runtime_BUILT_HEADERS)
 	rm -f runtime/domain_state.inc
-	rm -rf $(DEPDIR) runtime/winpthreads
+	rm -rf $(DEPDIR)
 	rm -f stdlib/libcamlrun.a stdlib/libcamlrun.lib
 
 .PHONY: runtimeopt
@@ -2644,7 +2623,7 @@ endif
 	      boot/flexdll_*.o boot/flexdll_*.obj \
 	      boot/*.cm* boot/libcamlrun.a boot/libcamlrun.lib boot/ocamlc.opt
 	rm -f Makefile.config Makefile.build_config
-	rm -rf autom4te.cache winpthreads-sources flexdll-sources \
+	rm -rf autom4te.cache flexdll-sources \
          $(BYTE_BUILD_TREE) $(OPT_BUILD_TREE)
 	rm -f config.log config.status libtool
 

--- a/Makefile
+++ b/Makefile
@@ -2070,11 +2070,11 @@ ocamltest/ocamltest.html: ocamltest/ocamltest.org
 # The extra libraries
 
 .PHONY: otherlibraries
-otherlibraries: ocamltools
+otherlibraries: ocamltools dynlink-all
 	$(MAKE) -C otherlibs all
 
 .PHONY: otherlibrariesopt
-otherlibrariesopt:
+otherlibrariesopt: dynlink-allopt
 	$(MAKE) -C otherlibs allopt
 
 otherlibs/unix/unix.cmxa: otherlibrariesopt

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -84,7 +84,7 @@ OC_NATIVE_CFLAGS = @oc_native_cflags@
 
 # The submodules should be searched *before* any other external -I paths
 OC_INCLUDES = $(addprefix -I $(ROOTDIR)/, \
-  runtime @flexdll_source_dir@ @winpthreads_source_include_dir@)
+  runtime @flexdll_source_dir@)
 OC_CPPFLAGS = $(OC_INCLUDES) @oc_cppflags@
 
 OC_BYTECODE_CPPFLAGS = $(OC_INCLUDES) @oc_bytecode_cppflags@
@@ -118,10 +118,6 @@ DOCUMENTATION_TOOL_CMD=@documentation_tool_cmd@
 # Git submodule)
 FLEXDLL_SOURCE_DIR=@flexdll_source_dir@
 BOOTSTRAPPING_FLEXDLL=@bootstrapping_flexdll@
-
-# The location of the Winpthreads sources to use (usually provided as the
-# winpthreads Git submodule)
-WINPTHREADS_SOURCE_DIR=@winpthreads_source_dir@
 
 ### Where to install documentation
 PACKAGE_TARNAME = @PACKAGE_TARNAME@

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -359,16 +359,6 @@ EOF
   OCAML_CC_RESTORE_VARIABLES
 ])
 
-AC_DEFUN([OCAML_TEST_WINPTHREADS_PTHREAD_H], [
-  OCAML_CC_SAVE_VARIABLES
-
-  AS_IF([test -n "$1"],[CPPFLAGS="-I $1 $CPPFLAGS"])
-  AC_CHECK_HEADER([pthread.h],[],
-    [AC_MSG_ERROR([cannot find or use pthread.h from winpthreads])])
-
-  OCAML_CC_RESTORE_VARIABLES
-])
-
 AC_DEFUN([OCAML_HOST_IS_EXECUTABLE], [
   AC_MSG_CHECKING([whether host executables can be run in the build])
   old_cross_compiling="$cross_compiling"

--- a/configure
+++ b/configure
@@ -858,8 +858,6 @@ supports_shared_libraries
 mklib
 AR
 shebangscripts
-winpthreads_source_include_dir
-winpthreads_source_dir
 flexdll_dir
 bootstrapping_flexdll
 flexdll_source_dir
@@ -1019,7 +1017,6 @@ enable_function_sections
 enable_mmap_map_stack
 with_afl
 with_flexdll
-with_winpthreads_msvc
 with_zstd
 enable_shared
 enable_static
@@ -1734,8 +1731,6 @@ Optional Packages:
   --with-target-sh        location of Posix sh on the target system
   --with-afl              use the AFL fuzzer
   --with-flexdll          bootstrap FlexDLL from the given sources
-  --with-winpthreads-msvc build winpthreads (only for the MSVC port) from the
-                          given sources
   --without-zstd          disable compression of compilation artefacts
   --with-pic[=PKGS]       try to use only PIC/non-PIC objects [default=use
                           both]
@@ -3469,8 +3464,6 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 
 
 
-
-
  # TODO: rename this variable
 
 
@@ -4159,17 +4152,6 @@ then :
   withval=$with_flexdll; if test x"$withval" = 'xyes'
 then :
   with_flexdll=flexdll
-fi
-fi
-
-
-
-# Check whether --with-winpthreads-msvc was given.
-if test ${with_winpthreads_msvc+y}
-then :
-  withval=$with_winpthreads_msvc; if test x"$withval" = 'xyes'
-then :
-  with_winpthreads_msvc=winpthreads
 fi
 fi
 
@@ -14645,104 +14627,6 @@ esac
   *) :
      ;;
 esac
-
-# Winpthreads emulation library for the MSVC port
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for winpthreads sources" >&5
-printf %s "checking for winpthreads sources... " >&6; }
-if test x"$with_winpthreads_msvc" = "xno"
-then :
-  winpthreads_source_dir=''
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: disabled" >&5
-printf "%s\n" "disabled" >&6; }
-else $as_nop
-  winpthreadmsg=''
-  case $target in #(
-  *-pc-windows) :
-                       if test x"$with_winpthreads_msvc" = 'x' || test x"$with_winpthreads_msvc" = x'winpthreads'
-then :
-  if test -f 'winpthreads/src/winpthread_internal.h'
-then :
-  winpthreads_source_dir=winpthreads
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: required but not available (uninitialized submodule?)" >&5
-printf "%s\n" "required but not available (uninitialized submodule?)" >&6; }
-        as_fn_error $? "exiting" "$LINENO" 5
-fi
-else $as_nop
-  rm -rf winpthreads-sources
-      if test -f "$with_winpthreads_msvc/src/winpthread_internal.h"
-then :
-  mkdir -p winpthreads-sources/src winpthreads-sources/include
-        cp "$with_winpthreads_msvc"/src/*.c winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
-        winpthreads_source_dir='winpthreads-sources'
-        winpthreadsmsg=" (from $with_winpthreads_msvc)"
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not available" >&5
-printf "%s\n" "requested but not available" >&6; }
-        as_fn_error $? "exiting" "$LINENO" 5
-fi
-fi
-    if test x"$winpthreads_source_dir" = 'x'
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $winpthreads_source_dir$winpthreadsmsg" >&5
-printf "%s\n" "$winpthreads_source_dir$winpthreadsmsg" >&6; }
-      winpthreads_source_include_dir="$winpthreads_source_dir/include"
-
-
-  saved_CC="$CC"
-  saved_CFLAGS="$CFLAGS"
-  saved_CPPFLAGS="$CPPFLAGS"
-  saved_LIBS="$LIBS"
-  saved_ac_ext="$ac_ext"
-  saved_ac_compile="$ac_compile"
-  # Move the content of confdefs.h to another file so it does not
-  # get included
-  mv confdefs.h confdefs.h.bak
-  touch confdefs.h
-
-
-  if test -n "$winpthreads_source_include_dir"
-then :
-  CPPFLAGS="-I $winpthreads_source_include_dir $CPPFLAGS"
-fi
-  ac_fn_c_check_header_compile "$LINENO" "pthread.h" "ac_cv_header_pthread_h" "$ac_includes_default"
-if test "x$ac_cv_header_pthread_h" = xyes
-then :
-
-else $as_nop
-  as_fn_error $? "cannot find or use pthread.h from winpthreads" "$LINENO" 5
-fi
-
-
-
-  # Restore the content of confdefs.h
-  mv confdefs.h.bak confdefs.h
-  ac_compile="$saved_ac_compile"
-  ac_ext="$saved_ac_ext"
-  CPPFLAGS="$saved_CPPFLAGS"
-  CFLAGS="$saved_CFLAGS"
-  CC="$saved_CC"
-  LIBS="$saved_LIBS"
-
-
-fi ;; #(
-  *) :
-    if test x"$with_winpthreads_msvc" != 'x'
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: requested but not supported" >&5
-printf "%s\n" "requested but not supported" >&6; }
-      as_fn_error $? "exiting" "$LINENO" 5
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: skipping on that platform" >&5
-printf "%s\n" "skipping on that platform" >&6; }
-fi ;;
-esac
-fi
 
 ## Program to use to install files
 

--- a/configure.ac
+++ b/configure.ac
@@ -180,8 +180,6 @@ AC_SUBST([bytecode_cppflags])
 AC_SUBST([flexdll_source_dir])
 AC_SUBST([bootstrapping_flexdll])
 AC_SUBST([flexdll_dir])
-AC_SUBST([winpthreads_source_dir])
-AC_SUBST([winpthreads_source_include_dir])
 AC_SUBST([shebangscripts])
 AC_SUBST([AR])
 AC_SUBST([mklib])
@@ -571,11 +569,6 @@ AC_ARG_WITH([flexdll],
   [AS_HELP_STRING([--with-flexdll],
     [bootstrap FlexDLL from the given sources])],
   [AS_IF([test x"$withval" = 'xyes'],[with_flexdll=flexdll])])
-
-AC_ARG_WITH([winpthreads-msvc],
-  [AS_HELP_STRING([--with-winpthreads-msvc],
-    [build winpthreads (only for the MSVC port) from the given sources])],
-  [AS_IF([test x"$withval" = 'xyes'], [with_winpthreads_msvc=winpthreads])])
 
 AC_ARG_WITH([zstd],
   [AS_HELP_STRING([--without-zstd],
@@ -1104,44 +1097,6 @@ AS_CASE([$ocaml_cc_vendor,$host],
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [gcc-*,powerpc-*-linux*],
     [oc_ldflags="-mbss-plt"])
-
-# Winpthreads emulation library for the MSVC port
-AC_MSG_CHECKING([for winpthreads sources])
-AS_IF([test x"$with_winpthreads_msvc" = "xno"],
-  [winpthreads_source_dir=''
-  AC_MSG_RESULT([disabled])],
-  [winpthreadmsg=''
-  AS_CASE([$target],
-    [*-pc-windows],
-    [dnl When bootstrapping from the git submodule (winpthreads directory),
-     dnl just use that, however if another directory has been specified with
-     dnl --with-winpthreads-msvc=<path> then copy the contents of <path> to
-     dnl winpthreads-sources.
-    AS_IF([m4_normalize([test x"$with_winpthreads_msvc" = 'x'
-                          || test x"$with_winpthreads_msvc" = x'winpthreads'])],
-      [AS_IF([test -f 'winpthreads/src/winpthread_internal.h'],
-        [winpthreads_source_dir=winpthreads],
-        [AC_MSG_RESULT([required but not available (uninitialized submodule?)])
-        AC_MSG_ERROR([exiting])])],
-      [rm -rf winpthreads-sources
-      AS_IF([test -f "$with_winpthreads_msvc/src/winpthread_internal.h"],
-        [mkdir -p winpthreads-sources/src winpthreads-sources/include
-        cp "$with_winpthreads_msvc"/src/*.c winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/src/*.h winpthreads-sources/src
-        cp "$with_winpthreads_msvc"/include/*.h winpthreads-sources/include
-        winpthreads_source_dir='winpthreads-sources'
-        winpthreadsmsg=" (from $with_winpthreads_msvc)"],
-        [AC_MSG_RESULT([requested but not available])
-        AC_MSG_ERROR([exiting])])])
-    AS_IF([test x"$winpthreads_source_dir" = 'x'],
-      [AC_MSG_RESULT([no])],
-      [AC_MSG_RESULT([$winpthreads_source_dir$winpthreadsmsg])
-      winpthreads_source_include_dir="$winpthreads_source_dir/include"
-      OCAML_TEST_WINPTHREADS_PTHREAD_H([$winpthreads_source_include_dir])])],
-    [AS_IF([test x"$with_winpthreads_msvc" != 'x'],
-      [AC_MSG_RESULT([requested but not supported])
-      AC_MSG_ERROR([exiting])],
-      [AC_MSG_RESULT([skipping on that platform])])])])
 
 ## Program to use to install files
 AC_PROG_INSTALL

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -70,7 +70,7 @@ value caml_thread_sigmask(value cmd, value sigs)
   caml_enter_blocking_section();
   retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Thread.sigmask");
+  caml_check_error(retcode, "Thread.sigmask");
   /* Run any handlers for just-unmasked pending signals */
   caml_process_pending_actions();
   return st_encode_sigset(&oldset);
@@ -86,7 +86,7 @@ value caml_wait_signal(value sigs)
   caml_enter_blocking_section();
   retcode = sigwait(&set, &signo);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Thread.wait_signal");
+  caml_check_error(retcode, "Thread.wait_signal");
   return Val_int(caml_rev_convert_signal_number(signo));
 #else
   caml_invalid_argument("Thread.wait_signal not implemented");

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -45,8 +45,6 @@ static int st_thread_create(st_thread_id * res,
   return rc;
 }
 
-#define ST_THREAD_FUNCTION void *
-
 /* Thread termination */
 
 static void st_thread_join(st_thread_id thr)

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -28,12 +28,6 @@
 
 typedef int st_retcode;
 
-/* OS-specific initialization */
-static int st_initialize(void)
-{
-  return 0;
-}
-
 typedef pthread_t st_thread_id;
 
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -17,6 +17,11 @@
 
 #include <stdbool.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#include <process.h>
+#endif
+
 #include "caml/alloc.h"
 #include "caml/backtrace.h"
 #include "caml/backtrace_prim.h"
@@ -643,7 +648,8 @@ static void thread_init_current(caml_thread_t th)
 /* Create a thread */
 
 /* the thread lock is not held when entering */
-static void * caml_thread_start(void * v)
+static CAML_THREAD_FUNCTION
+caml_thread_start(void * v)
 {
   caml_thread_t th = (caml_thread_t) v;
   int dom_id = th->domain_id;
@@ -668,7 +674,7 @@ struct caml_thread_tick_args {
 };
 
 /* The tick thread: interrupt the domain periodically to force preemption  */
-static void * caml_thread_tick(void * arg)
+static CAML_THREAD_FUNCTION caml_thread_tick(void * arg)
 {
   struct caml_thread_tick_args* tick_thread_args =
     (struct caml_thread_tick_args*) arg;
@@ -685,7 +691,7 @@ static void * caml_thread_tick(void * arg)
     atomic_store_release(&domain->requested_external_interrupt, 1);
     caml_interrupt_self();
   }
-  return NULL;
+  return 0;
 }
 
 static st_retcode create_tick_thread(void)

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -15,20 +15,6 @@
 
 #define CAML_INTERNALS
 
-#if defined(_WIN32) && !defined(NATIVE_CODE) && !defined(_MSC_VER)
-/* Ensure that pthread.h marks symbols __declspec(dllimport) so that they can be
-   picked up from the runtime (which will have linked winpthreads statically).
-   mingw-w64 11.0.0 introduced WINPTHREADS_USE_DLLIMPORT to do this explicitly;
-   prior versions co-opted this on the internal DLL_EXPORT, but this is ignored
-   in 11.0 and later unless IN_WINPTHREAD is also defined, so we can safely
-   define both to support both versions.
-   When compiling with MSVC, we currently link directly the winpthreads objects
-   into our runtime, so we do not want to mark its symbols with
-   __declspec(dllimport). */
-#define WINPTHREADS_USE_DLLIMPORT
-#define DLL_EXPORT
-#endif
-
 #include <stdbool.h>
 
 #include "caml/alloc.h"

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -284,6 +284,13 @@ static void caml_thread_enter_blocking_section(void)
 
 static void caml_thread_leave_blocking_section(void)
 {
+#ifdef _WIN32
+  /* TlsGetValue (called in This_thread) calls SetLastError which will
+     mask any error which occurred prior to the
+     caml_thread_leave_blocking_section call. EnterCriticalSection
+     does not do this. */
+  DWORD error = GetLastError();
+#endif
   caml_thread_t th = This_thread;
   /* Wait until the runtime is free */
   thread_lock_acquire(th->domain_id);
@@ -291,6 +298,9 @@ static void caml_thread_leave_blocking_section(void)
      corresponding to the thread currently executing and restore the
      runtime state */
   restore_runtime_state(th);
+#ifdef _WIN32
+  SetLastError(error);
+#endif
 }
 
 /* Create and setup a new thread info block.

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -492,8 +492,6 @@ static void caml_thread_domain_initialize_hook(void)
   caml_thread_t new_thread;
 
   atomic_store_release(&Tick_thread_stop, 0);
-  /* OS-specific initialization */
-  st_initialize();
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
   caml_check_error(ret, "caml_thread_domain_initialize_hook");

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -438,7 +438,7 @@ static void caml_thread_reinitialize(void)
      the effective owner of the lock. So there is no need to run
      st_masterlock_acquire (busy = 1) */
   st_masterlock *m = Thread_lock(Caml_state->id);
-  m->init = 0; /* force reinitialization */
+  m->init = false; /* force reinitialization */
   /* Note: initializing an already-initialized mutex and cond variable
      is UB (especially mutexes that are locked). This is best
      effort. */

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -52,8 +52,6 @@
 #include "caml/sys.h"
 #include "caml/memprof.h"
 
-#include "../../runtime/sync_posix.h"
-
 /* "caml/threads.h" is *not* included since it contains the _external_
    declarations for the caml_c_thread_register and caml_c_thread_unregister
    functions. */
@@ -498,7 +496,7 @@ static void caml_thread_domain_initialize_hook(void)
   st_initialize();
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
-  sync_check_error(ret, "caml_thread_domain_initialize_hook");
+  caml_check_error(ret, "caml_thread_domain_initialize_hook");
 
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
@@ -696,7 +694,7 @@ CAMLprim value caml_thread_new(value clos)
      Because of PR#4666, we start the tick thread late, only when we create
      the first additional thread in the current process */
   st_retcode err = create_tick_thread();
-  sync_check_error(err, "Thread.create");
+  caml_check_error(err, "Thread.create");
 
   /* Create a thread info block */
   caml_thread_t th = thread_alloc_and_add();
@@ -708,7 +706,7 @@ CAMLprim value caml_thread_new(value clos)
   if (err != 0) {
     /* Creation failed, remove thread info block from list of threads */
     caml_thread_remove_and_free(th);
-    sync_check_error(err, "Thread.create");
+    caml_check_error(err, "Thread.create");
   }
 
   CAMLreturn(th->descr);
@@ -836,7 +834,7 @@ CAMLprim value caml_thread_yield(value unit)
 CAMLprim value caml_thread_join(value th)
 {
   st_retcode rc = caml_threadstatus_wait(Terminated(th));
-  sync_check_error(rc, "Thread.join");
+  caml_check_error(rc, "Thread.join");
   return Val_unit;
 }
 
@@ -871,7 +869,7 @@ static value caml_threadstatus_new (void)
 {
   st_event ts = NULL;           /* suppress warning */
   value wrapper;
-  sync_check_error(st_event_create(&ts), "Thread.create");
+  caml_check_error(st_event_create(&ts), "Thread.create");
   wrapper = caml_alloc_custom(&caml_threadstatus_ops,
                               sizeof(st_event *),
                               0, 1);

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -24,7 +24,241 @@ Caml_inline void st_msleep(int msec)
   Sleep(msec);
 }
 
-#include "st_pthreads.h"
+/* POSIX thread implementation of the "st" interface */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <signal.h>
+#include <time.h>
+#ifdef HAS_UNISTD
+#include <unistd.h>
+#endif
+
+
+typedef pthread_t st_thread_id;
+
+
+/* Thread creation. Created in detached mode if [res] is NULL. */
+static int st_thread_create(st_thread_id * res,
+                            void * (*fn)(void *), void * arg)
+{
+  pthread_t thr;
+  pthread_attr_t attr;
+  int rc;
+
+  pthread_attr_init(&attr);
+  if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+  rc = pthread_create(&thr, &attr, fn, arg);
+  if (res != NULL) *res = thr;
+  return rc;
+}
+
+#define ST_THREAD_FUNCTION void *
+
+/* Thread termination */
+
+static void st_thread_join(st_thread_id thr)
+{
+  pthread_join(thr, NULL);
+  /* best effort: ignore errors */
+}
+
+/* Thread-specific state */
+
+typedef pthread_key_t st_tlskey;
+
+static int st_tls_newkey(st_tlskey * res)
+{
+  return pthread_key_create(res, NULL);
+}
+
+Caml_inline void * st_tls_get(st_tlskey k)
+{
+  return pthread_getspecific(k);
+}
+
+Caml_inline void st_tls_set(st_tlskey k, void * v)
+{
+  pthread_setspecific(k, v);
+}
+
+/* The master lock.  This is a mutex that is held most of the time,
+   so we implement it in a slightly convoluted way to avoid
+   all risks of busy-waiting.  Also, we count the number of waiting
+   threads. */
+
+typedef struct {
+  bool init;                      /* have the mutex and the cond been
+                                     initialized already? */
+  pthread_mutex_t lock;           /* to protect contents */
+  bool busy;                      /* false = free, true = taken */
+  atomic_uintnat waiters;         /* number of threads waiting on master lock */
+  pthread_cond_t is_free;         /* signaled when free */
+} st_masterlock;
+
+/* Returns non-zero on failure */
+static int st_masterlock_init(st_masterlock * m)
+{
+  int rc;
+  if (!m->init) {
+    rc = pthread_mutex_init(&m->lock, NULL);
+    if (rc != 0) goto out_err;
+    rc = pthread_cond_init(&m->is_free, NULL);
+    if (rc != 0) goto out_err2;
+    m->init = true;
+  }
+  m->busy = true;
+  atomic_store_release(&m->waiters, 0);
+  return 0;
+
+ out_err2:
+  pthread_mutex_destroy(&m->lock);
+ out_err:
+  return rc;
+}
+
+static uintnat st_masterlock_waiters(st_masterlock * m)
+{
+  return atomic_load_acquire(&m->waiters);
+}
+
+static void st_masterlock_acquire(st_masterlock *m)
+{
+  pthread_mutex_lock(&m->lock);
+  while (m->busy) {
+    atomic_fetch_add(&m->waiters, +1);
+    pthread_cond_wait(&m->is_free, &m->lock);
+    atomic_fetch_add(&m->waiters, -1);
+  }
+  m->busy = true;
+  st_bt_lock_acquire();
+  pthread_mutex_unlock(&m->lock);
+
+  return;
+}
+
+static void st_masterlock_release(st_masterlock * m)
+{
+  pthread_mutex_lock(&m->lock);
+  m->busy = false;
+  st_bt_lock_release(st_masterlock_waiters(m) == 0);
+  pthread_cond_signal(&m->is_free);
+  pthread_mutex_unlock(&m->lock);
+
+  return;
+}
+
+/* Scheduling hints */
+
+/* This is mostly equivalent to release(); acquire(), but better. In particular,
+   release(); acquire(); leaves both us and the waiter we signal() racing to
+   acquire the lock. Calling yield or sleep helps there but does not solve the
+   problem. Sleeping ourselves is much more reliable--and since we're handing
+   off the lock to a waiter we know exists, it's safe, as they'll certainly
+   re-wake us later.
+*/
+Caml_inline void st_thread_yield(st_masterlock * m)
+{
+  pthread_mutex_lock(&m->lock);
+  /* We must hold the lock to call this. */
+
+  /* We already checked this without the lock, but we might have raced--if
+     there's no waiter, there's nothing to do and no one to wake us if we did
+     wait, so just keep going. */
+  uintnat waiters = st_masterlock_waiters(m);
+
+  if (waiters == 0) {
+    pthread_mutex_unlock(&m->lock);
+    return;
+  }
+
+  m->busy = false;
+  atomic_fetch_add(&m->waiters, +1);
+  pthread_cond_signal(&m->is_free);
+  /* releasing the domain lock but not triggering bt messaging
+     messaging the bt should not be required because yield assumes
+     that a thread will resume execution (be it the yielding thread
+     or a waiting thread */
+  caml_release_domain_lock();
+
+  do {
+    /* Note: the POSIX spec prevents the above signal from pairing with this
+       wait, which is good: we'll reliably continue waiting until the next
+       yield() or enter_blocking_section() call (or we see a spurious condvar
+       wakeup, which are rare at best.) */
+       pthread_cond_wait(&m->is_free, &m->lock);
+  } while (m->busy);
+
+  m->busy = true;
+  atomic_fetch_add(&m->waiters, -1);
+
+  caml_acquire_domain_lock();
+
+  pthread_mutex_unlock(&m->lock);
+
+  return;
+}
+
+/* Triggered events */
+
+typedef struct st_event_struct {
+  pthread_mutex_t lock;         /* to protect contents */
+  bool status;                  /* false = not triggered, true = triggered */
+  pthread_cond_t triggered;     /* signaled when triggered */
+} * st_event;
+
+
+static int st_event_create(st_event * res)
+{
+  int rc;
+  st_event e = caml_stat_alloc_noexc(sizeof(struct st_event_struct));
+  if (e == NULL) return ENOMEM;
+  rc = pthread_mutex_init(&e->lock, NULL);
+  if (rc != 0) { caml_stat_free(e); return rc; }
+  rc = pthread_cond_init(&e->triggered, NULL);
+  if (rc != 0)
+  { pthread_mutex_destroy(&e->lock); caml_stat_free(e); return rc; }
+  e->status = false;
+  *res = e;
+  return 0;
+}
+
+static int st_event_destroy(st_event e)
+{
+  int rc1, rc2;
+  rc1 = pthread_mutex_destroy(&e->lock);
+  rc2 = pthread_cond_destroy(&e->triggered);
+  caml_stat_free(e);
+  return rc1 != 0 ? rc1 : rc2;
+}
+
+static int st_event_trigger(st_event e)
+{
+  int rc;
+  rc = pthread_mutex_lock(&e->lock);
+  if (rc != 0) return rc;
+  e->status = true;
+  rc = pthread_mutex_unlock(&e->lock);
+  if (rc != 0) return rc;
+  rc = pthread_cond_broadcast(&e->triggered);
+  return rc;
+}
+
+static int st_event_wait(st_event e)
+{
+  int rc;
+  rc = pthread_mutex_lock(&e->lock);
+  if (rc != 0) return rc;
+  while(!e->status) {
+    rc = pthread_cond_wait(&e->triggered, &e->lock);
+    if (rc != 0) return rc;
+  }
+  rc = pthread_mutex_unlock(&e->lock);
+  return rc;
+}
 
 /* Signal handling -- none under Win32 */
 

--- a/otherlibs/systhreads/st_win32.h
+++ b/otherlibs/systhreads/st_win32.h
@@ -30,59 +30,74 @@ Caml_inline void st_msleep(int msec)
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <pthread.h>
 #include <signal.h>
 #include <time.h>
-#ifdef HAS_UNISTD
-#include <unistd.h>
-#endif
+#include <caml/osdeps.h>
 
 
-typedef pthread_t st_thread_id;
-
+typedef HANDLE st_thread_id;
 
 /* Thread creation. Created in detached mode if [res] is NULL. */
 static int st_thread_create(st_thread_id * res,
-                            void * (*fn)(void *), void * arg)
+                            unsigned ( WINAPI *start_address )( void * ),
+                            void * arg)
 {
-  pthread_t thr;
-  pthread_attr_t attr;
-  int rc;
-
-  pthread_attr_init(&attr);
-  if (res == NULL) pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-  rc = pthread_create(&thr, &attr, fn, arg);
-  if (res != NULL) *res = thr;
-  return rc;
+  st_thread_id thr;
+  thr = (st_thread_id) _beginthreadex(
+    NULL, /* security: handle can't be inherited */
+    0,    /* stack size */
+    start_address,
+    arg,
+    0,    /* run immediately */
+    NULL  /* thread identifier */
+    );
+  if (thr == 0) {
+    return errno;
+  } else if (res == NULL) {
+    /* detach */
+    if (!CloseHandle(thr)) {
+      int err = caml_posixerr_of_win32err(GetLastError());
+      return err == 0 ? EINVAL : err;
+    }
+  } else {
+    *res = thr;
+  }
+  return 0;
 }
-
-#define ST_THREAD_FUNCTION void *
 
 /* Thread termination */
 
 static void st_thread_join(st_thread_id thr)
 {
-  pthread_join(thr, NULL);
+  WaitForSingleObject(thr, INFINITE);
   /* best effort: ignore errors */
 }
 
 /* Thread-specific state */
 
-typedef pthread_key_t st_tlskey;
+typedef DWORD st_tlskey;
 
 static int st_tls_newkey(st_tlskey * res)
 {
-  return pthread_key_create(res, NULL);
+  DWORD index = TlsAlloc();
+  if (index == TLS_OUT_OF_INDEXES) {
+    int err = caml_posixerr_of_win32err(GetLastError());
+    return err == 0 ? EINVAL : err;
+  }
+  *res = index;
+  return 0;
 }
 
 Caml_inline void * st_tls_get(st_tlskey k)
 {
-  return pthread_getspecific(k);
+  /* No errors are returned from pthread_getspecific(). Ignore
+   * TlsGetValue() errors.  */
+  return TlsGetValue(k);
 }
 
 Caml_inline void st_tls_set(st_tlskey k, void * v)
 {
-  pthread_setspecific(k, v);
+  (void)TlsSetValue(k, v);
 }
 
 /* The master lock.  This is a mutex that is held most of the time,
@@ -93,31 +108,23 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
 typedef struct {
   bool init;                      /* have the mutex and the cond been
                                      initialized already? */
-  pthread_mutex_t lock;           /* to protect contents */
+  SRWLOCK lock;                   /* to protect contents */
   bool busy;                      /* false = free, true = taken */
   atomic_uintnat waiters;         /* number of threads waiting on master lock */
-  pthread_cond_t is_free;         /* signaled when free */
+  CONDITION_VARIABLE is_free;     /* signaled when free */
 } st_masterlock;
 
 /* Returns non-zero on failure */
 static int st_masterlock_init(st_masterlock * m)
 {
-  int rc;
   if (!m->init) {
-    rc = pthread_mutex_init(&m->lock, NULL);
-    if (rc != 0) goto out_err;
-    rc = pthread_cond_init(&m->is_free, NULL);
-    if (rc != 0) goto out_err2;
+    InitializeSRWLock(&m->lock);
+    InitializeConditionVariable(&m->is_free);
     m->init = true;
   }
   m->busy = true;
   atomic_store_release(&m->waiters, 0);
   return 0;
-
- out_err2:
-  pthread_mutex_destroy(&m->lock);
- out_err:
-  return rc;
 }
 
 static uintnat st_masterlock_waiters(st_masterlock * m)
@@ -127,26 +134,27 @@ static uintnat st_masterlock_waiters(st_masterlock * m)
 
 static void st_masterlock_acquire(st_masterlock *m)
 {
-  pthread_mutex_lock(&m->lock);
+  AcquireSRWLockExclusive(&m->lock);
   while (m->busy) {
     atomic_fetch_add(&m->waiters, +1);
-    pthread_cond_wait(&m->is_free, &m->lock);
+    SleepConditionVariableSRW(&m->is_free, &m->lock,
+                              INFINITE, 0 /* exclusive */);
     atomic_fetch_add(&m->waiters, -1);
   }
   m->busy = true;
   st_bt_lock_acquire();
-  pthread_mutex_unlock(&m->lock);
+  ReleaseSRWLockExclusive(&m->lock);
 
   return;
 }
 
 static void st_masterlock_release(st_masterlock * m)
 {
-  pthread_mutex_lock(&m->lock);
+  AcquireSRWLockExclusive(&m->lock);
   m->busy = false;
   st_bt_lock_release(st_masterlock_waiters(m) == 0);
-  pthread_cond_signal(&m->is_free);
-  pthread_mutex_unlock(&m->lock);
+  WakeConditionVariable(&m->is_free);
+  ReleaseSRWLockExclusive(&m->lock);
 
   return;
 }
@@ -162,7 +170,7 @@ static void st_masterlock_release(st_masterlock * m)
 */
 Caml_inline void st_thread_yield(st_masterlock * m)
 {
-  pthread_mutex_lock(&m->lock);
+  AcquireSRWLockExclusive(&m->lock);
   /* We must hold the lock to call this. */
 
   /* We already checked this without the lock, but we might have raced--if
@@ -171,13 +179,13 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   uintnat waiters = st_masterlock_waiters(m);
 
   if (waiters == 0) {
-    pthread_mutex_unlock(&m->lock);
+    ReleaseSRWLockExclusive(&m->lock);
     return;
   }
 
   m->busy = false;
   atomic_fetch_add(&m->waiters, +1);
-  pthread_cond_signal(&m->is_free);
+  WakeConditionVariable(&m->is_free);
   /* releasing the domain lock but not triggering bt messaging
      messaging the bt should not be required because yield assumes
      that a thread will resume execution (be it the yielding thread
@@ -189,7 +197,8 @@ Caml_inline void st_thread_yield(st_masterlock * m)
        wait, which is good: we'll reliably continue waiting until the next
        yield() or enter_blocking_section() call (or we see a spurious condvar
        wakeup, which are rare at best.) */
-       pthread_cond_wait(&m->is_free, &m->lock);
+       SleepConditionVariableSRW(&m->is_free, &m->lock,
+                                 INFINITE, 0 /* exclusive */);
   } while (m->busy);
 
   m->busy = true;
@@ -197,7 +206,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 
   caml_acquire_domain_lock();
 
-  pthread_mutex_unlock(&m->lock);
+  ReleaseSRWLockExclusive(&m->lock);
 
   return;
 }
@@ -205,22 +214,18 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 /* Triggered events */
 
 typedef struct st_event_struct {
-  pthread_mutex_t lock;         /* to protect contents */
+  SRWLOCK lock;                 /* to protect contents */
   bool status;                  /* false = not triggered, true = triggered */
-  pthread_cond_t triggered;     /* signaled when triggered */
+  CONDITION_VARIABLE triggered; /* signaled when triggered */
 } * st_event;
 
 
 static int st_event_create(st_event * res)
 {
-  int rc;
   st_event e = caml_stat_alloc_noexc(sizeof(struct st_event_struct));
   if (e == NULL) return ENOMEM;
-  rc = pthread_mutex_init(&e->lock, NULL);
-  if (rc != 0) { caml_stat_free(e); return rc; }
-  rc = pthread_cond_init(&e->triggered, NULL);
-  if (rc != 0)
-  { pthread_mutex_destroy(&e->lock); caml_stat_free(e); return rc; }
+  InitializeSRWLock(&e->lock);
+  InitializeConditionVariable(&e->triggered);
   e->status = false;
   *res = e;
   return 0;
@@ -228,36 +233,32 @@ static int st_event_create(st_event * res)
 
 static int st_event_destroy(st_event e)
 {
-  int rc1, rc2;
-  rc1 = pthread_mutex_destroy(&e->lock);
-  rc2 = pthread_cond_destroy(&e->triggered);
   caml_stat_free(e);
-  return rc1 != 0 ? rc1 : rc2;
+  return 0;
 }
 
 static int st_event_trigger(st_event e)
 {
-  int rc;
-  rc = pthread_mutex_lock(&e->lock);
-  if (rc != 0) return rc;
+  AcquireSRWLockExclusive(&e->lock);
   e->status = true;
-  rc = pthread_mutex_unlock(&e->lock);
-  if (rc != 0) return rc;
-  rc = pthread_cond_broadcast(&e->triggered);
-  return rc;
+  ReleaseSRWLockExclusive(&e->lock);
+  WakeAllConditionVariable(&e->triggered);
+  return 0;
 }
 
 static int st_event_wait(st_event e)
 {
-  int rc;
-  rc = pthread_mutex_lock(&e->lock);
-  if (rc != 0) return rc;
+  AcquireSRWLockExclusive(&e->lock);
   while(!e->status) {
-    rc = pthread_cond_wait(&e->triggered, &e->lock);
-    if (rc != 0) return rc;
+    BOOL rc = SleepConditionVariableSRW(&e->triggered, &e->lock,
+                                        INFINITE, 0 /* exclusive */);
+    if (!rc) {
+      int err = caml_posixerr_of_win32err(GetLastError());
+      return err == 0 ? EINVAL : err;
+    }
   }
-  rc = pthread_mutex_unlock(&e->lock);
-  return rc;
+  ReleaseSRWLockExclusive(&e->lock);
+  return 0;
 }
 
 /* Signal handling -- none under Win32 */

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -73,6 +73,9 @@ struct caml_exception_context {
 
 int caml_is_special_exception(value exn);
 
+/* from runtime/sync.c */
+CAMLextern void caml_check_error(int err, char const * msg);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -23,18 +23,7 @@
 #include "camlatomic.h"
 #include "misc.h"
 #include "mlvalues.h"
-
-#ifndef _MSC_VER
 #include "platform.h"
-#else
-/* We avoid including platform.h (which is really only necessary here to declare
-   caml_plat_mutex) because that would end up pulling in pthread.h but we want
-   to hide it on the MSVC port as it is not the native way to handle threads.
-   So we inline here just the implementation of caml_plat_mutex on that port,
-   this should be kept in sync */
-#include <stdint.h>
-typedef intptr_t caml_plat_mutex;
-#endif
 
 #ifndef IO_BUFFER_SIZE
 #define IO_BUFFER_SIZE 65536

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -112,8 +112,11 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, intnat v) {
 
 #ifdef _WIN32
 
-typedef SRWLOCK caml_plat_mutex;
-#define CAML_PLAT_MUTEX_INITIALIZER SRWLOCK_INIT
+typedef struct {
+  SRWLOCK lock;
+  _Atomic DWORD owner_tid;      /* 0 if not owned */
+} caml_plat_mutex;
+#define CAML_PLAT_MUTEX_INITIALIZER { SRWLOCK_INIT, 0 }
 
 typedef CONDITION_VARIABLE caml_plat_cond;
 #define CAML_PLAT_COND_INITIALIZER CONDITION_VARIABLE_INIT
@@ -501,25 +504,37 @@ CAMLextern CAMLthread_local int caml_lockdepth;
 
 Caml_inline void caml_plat_lock_blocking(caml_plat_mutex* m)
 {
-  AcquireSRWLockExclusive(m);
-  DEBUG_LOCK(m);
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid != self_tid) {
+    AcquireSRWLockExclusive(&m->lock);
+    m->owner_tid = self_tid;
+    DEBUG_LOCK(m);
+  } else {
+    check_err("lock", EDEADLK);
+  }
 }
 
 Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
 {
-  BOOLEAN rc = TryAcquireSRWLockExclusive(m);
-  if (!rc) {
-    return 0;
-  } else {
+  if (TryAcquireSRWLockExclusive(&m->lock)) {
+    m->owner_tid = GetCurrentThreadId();
     DEBUG_LOCK(m);
     return 1;
+  } else {
+    return 0;
   }
 }
 
 Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
 {
+  DWORD self_tid = GetCurrentThreadId();
   DEBUG_UNLOCK(m);
-  ReleaseSRWLockExclusive(m);
+  if (m->owner_tid == self_tid) {
+    m->owner_tid = 0;
+    ReleaseSRWLockExclusive(&m->lock);
+  } else {
+    check_err("unlock", EPERM);
+  }
 }
 
 #else

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -20,7 +20,15 @@
 
 #ifdef CAML_INTERNALS
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define ATOM ATOM_WS
+#include <windows.h>
+#undef ATOM
+#else
 #include <pthread.h>
+#endif
+
 #include <errno.h>
 #include <string.h>
 #include "config.h"
@@ -102,8 +110,47 @@ Caml_inline uintnat atomic_fetch_add_verify_ge0(atomic_uintnat* p, intnat v) {
    functions from caml/sync.h should be used instead.
 */
 
+#ifdef _WIN32
+
+typedef SRWLOCK caml_plat_mutex;
+#define CAML_PLAT_MUTEX_INITIALIZER SRWLOCK_INIT
+
+typedef CONDITION_VARIABLE caml_plat_cond;
+#define CAML_PLAT_COND_INITIALIZER CONDITION_VARIABLE_INIT
+
+typedef HANDLE caml_plat_thread;
+typedef void * caml_plat_thread_attr;
+
+int caml_plat_thread_create(caml_plat_thread *restrict,
+                            const caml_plat_thread_attr *restrict,
+                            unsigned (WINAPI *)(void *),
+                            void *restrict);
+#define CAML_THREAD_FUNCTION unsigned WINAPI
+
+#else
+
 typedef pthread_mutex_t caml_plat_mutex;
 #define CAML_PLAT_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
+typedef pthread_cond_t caml_plat_cond;
+#define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
+
+typedef pthread_t caml_plat_thread;
+typedef pthread_attr_t caml_plat_thread_attr;
+
+int caml_plat_thread_create(caml_plat_thread *restrict,
+                            const caml_plat_thread_attr *restrict,
+                            void *(*)(void *),
+                            void *restrict);
+#define CAML_THREAD_FUNCTION void *
+
+#endif
+
+int caml_plat_thread_detach(caml_plat_thread);
+int caml_plat_thread_join(caml_plat_thread);
+int caml_plat_thread_equal(caml_plat_thread, caml_plat_thread);
+caml_plat_thread caml_plat_thread_self(void);
+
 CAMLextern void caml_plat_mutex_init(caml_plat_mutex*);
 Caml_inline void caml_plat_lock_blocking(caml_plat_mutex*);
 Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex*);
@@ -112,8 +159,6 @@ void caml_plat_assert_locked(caml_plat_mutex*);
 void caml_plat_assert_all_locks_unlocked(void);
 Caml_inline void caml_plat_unlock(caml_plat_mutex*);
 void caml_plat_mutex_free(caml_plat_mutex*);
-typedef pthread_cond_t caml_plat_cond;
-#define CAML_PLAT_COND_INITIALIZER PTHREAD_COND_INITIALIZER
 void caml_plat_cond_init(caml_plat_cond*);
 void caml_plat_wait(caml_plat_cond*, caml_plat_mutex*); /* blocking */
 void caml_plat_broadcast(caml_plat_cond*);
@@ -452,6 +497,33 @@ CAMLextern CAMLthread_local int caml_lockdepth;
 #define DEBUG_UNLOCK(m)
 #endif
 
+#ifdef _WIN32
+
+Caml_inline void caml_plat_lock_blocking(caml_plat_mutex* m)
+{
+  AcquireSRWLockExclusive(m);
+  DEBUG_LOCK(m);
+}
+
+Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
+{
+  BOOLEAN rc = TryAcquireSRWLockExclusive(m);
+  if (!rc) {
+    return 0;
+  } else {
+    DEBUG_LOCK(m);
+    return 1;
+  }
+}
+
+Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
+{
+  DEBUG_UNLOCK(m);
+  ReleaseSRWLockExclusive(m);
+}
+
+#else
+
 Caml_inline void caml_plat_lock_blocking(caml_plat_mutex* m)
 {
   check_err("lock", pthread_mutex_lock(m));
@@ -470,6 +542,14 @@ Caml_inline int caml_plat_try_lock(caml_plat_mutex* m)
   }
 }
 
+Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
+{
+  DEBUG_UNLOCK(m);
+  check_err("unlock", pthread_mutex_unlock(m));
+}
+
+#endif  /* _WIN32 */
+
 CAMLextern void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m);
 
 Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex* m)
@@ -477,12 +557,6 @@ Caml_inline void caml_plat_lock_non_blocking(caml_plat_mutex* m)
   if (!caml_plat_try_lock(m)) {
     caml_plat_lock_non_blocking_actual(m);
   }
-}
-
-Caml_inline void caml_plat_unlock(caml_plat_mutex* m)
-{
-  DEBUG_UNLOCK(m);
-  check_err("unlock", pthread_mutex_unlock(m));
 }
 
 extern intnat caml_plat_pagesize;

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -112,8 +112,8 @@ static_assert(
    When the main C-stack for a domain enters a blocking call,
    a 'backup thread' becomes responsible for servicing the STW
    sections on behalf of the domain. Care is needed to hand off duties
-   for servicing STW sections between the main pthread and the backup
-   pthread when caml_enter_blocking_section and
+   for servicing STW sections between the main thread and the backup
+   thread when caml_enter_blocking_section and
    caml_leave_blocking_section are called.
 
    When the state for the backup thread is BT_IN_BLOCKING_SECTION
@@ -125,26 +125,26 @@ static_assert(
            BT_INIT  <---------------------------------------+
               |                                             |
    (install_backup_thread)                                  |
-       [main pthread]                                       |
+       [main thread]                                        |
               |                                             |
               v                                             |
        BT_ENTERING_OCAML  <-----------------+               |
               |                             |               |
 (caml_enter_blocking_section)               |               |
-       [main pthread]                       |               |
+        [main thread]                       |               |
               |                             |               |
               |                             |               |
               |               (caml_leave_blocking_section) |
-              |                      [main pthread]         |
+              |                       [main thread]         |
               v                             |               |
     BT_IN_BLOCKING_SECTION  ----------------+               |
               |                                             |
      (domain_terminate)                                     |
-       [main pthread]                                       |
+        [main thread]                                       |
               |                                             |
               v                                             |
         BT_TERMINATE                               (backup_thread_func)
-              |                                      [backup pthread]
+              |                                      [backup thread]
               |                                             |
               +---------------------------------------------+
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1121,13 +1121,12 @@ static void install_backup_thread (dom_internal* di)
 
     atomic_store_release(&di->backup_thread_msg, BT_ENTERING_OCAML);
     err = pthread_create(&di->backup_thread, 0, backup_thread_func, (void*)di);
+    caml_check_error(err, "failed to create domain backup thread");
 
 #ifndef _WIN32
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-    if (err != 0)
-      caml_check_error(err, "failed to create domain backup thread");
     di->backup_thread_running = 1;
     pthread_detach(di->backup_thread);
   }
@@ -1292,10 +1291,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
-
-  if (err) {
-    caml_check_error(err, "failed to create domain thread: pthread_create");
-  }
+  caml_check_error(err, "failed to create domain thread: pthread_create");
 
   /* While waiting for the child thread to start up, we need to service any
      stop-the-world requests as they come in. */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1126,8 +1126,8 @@ static void install_backup_thread (dom_internal* di)
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-    if (err)
-      caml_failwith("failed to create domain backup thread");
+    if (err != 0)
+      caml_check_error(err, "failed to create domain backup thread");
     di->backup_thread_running = 1;
     pthread_detach(di->backup_thread);
   }
@@ -1294,7 +1294,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
 
   if (err) {
-    caml_failwith("failed to create domain thread");
+    caml_check_error(err, "failed to create domain thread: pthread_create");
   }
 
   /* While waiting for the child thread to start up, we need to service any

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -237,7 +237,7 @@ static void add_frame_descriptors(
 
 /* protected by STW sections */
 static caml_frame_descrs current_frame_descrs =
-  { 0, -1, NULL, NULL, NULL, PTHREAD_MUTEX_INITIALIZER };
+  { 0, -1, NULL, NULL, NULL, CAML_PLAT_MUTEX_INITIALIZER };
 
 static caml_frametable_list *cons(
   intnat *frametable, caml_frametable_list *tl)

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -79,7 +79,9 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 #endif
 }
 
+#ifdef DEBUG
 CAMLexport CAMLthread_local int caml_lockdepth = 0;
+#endif
 
 void caml_plat_assert_all_locks_unlocked(void)
 {

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -48,37 +48,6 @@ void caml_plat_fatal_error(const char * action, int err)
 
 /* Mutexes */
 
-CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
-{
-  int rc;
-  pthread_mutexattr_t attr;
-  rc = pthread_mutexattr_init(&attr);
-  if (rc != 0) goto error1;
-  rc = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
-  if (rc != 0) goto error2;
-  rc = pthread_mutex_init(m, &attr);
-  // fall through
-error2:
-  pthread_mutexattr_destroy(&attr);
-error1:
-  check_err("mutex_init", rc);
-}
-
-void caml_plat_assert_locked(caml_plat_mutex* m)
-{
-#ifdef DEBUG
-  int r = pthread_mutex_trylock(m);
-  if (r == EBUSY) {
-    /* ok, it was locked */
-    return;
-  } else if (r == 0) {
-    caml_fatal_error("Required mutex not locked");
-  } else {
-    check_err("assert_locked", r);
-  }
-#endif
-}
-
 #ifdef DEBUG
 CAMLexport CAMLthread_local int caml_lockdepth = 0;
 #endif
@@ -88,60 +57,6 @@ void caml_plat_assert_all_locks_unlocked(void)
 #ifdef DEBUG
   if (caml_lockdepth) caml_fatal_error("Locks still locked at termination");
 #endif
-}
-
-CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
-{
-  /* Avoid exceptions */
-  caml_enter_blocking_section_no_pending();
-  int rc = pthread_mutex_lock(m);
-  caml_leave_blocking_section();
-  check_err("lock_non_blocking", rc);
-  DEBUG_LOCK(m);
-}
-
-void caml_plat_mutex_free(caml_plat_mutex* m)
-{
-  check_err("mutex_free", pthread_mutex_destroy(m));
-}
-
-static void caml_plat_cond_init_aux(caml_plat_cond *cond)
-{
-  pthread_condattr_t attr;
-  pthread_condattr_init(&attr);
-#if defined(_POSIX_TIMERS) && \
-    defined(_POSIX_MONOTONIC_CLOCK) && \
-    _POSIX_MONOTONIC_CLOCK != (-1)
-  pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
-#endif
-  pthread_cond_init(cond, &attr);
-}
-
-/* Condition variables */
-void caml_plat_cond_init(caml_plat_cond* cond)
-{
-  caml_plat_cond_init_aux(cond);
-}
-
-void caml_plat_wait(caml_plat_cond* cond, caml_plat_mutex* mut)
-{
-  caml_plat_assert_locked(mut);
-  check_err("wait", pthread_cond_wait(cond, mut));
-}
-
-void caml_plat_broadcast(caml_plat_cond* cond)
-{
-  check_err("cond_broadcast", pthread_cond_broadcast(cond));
-}
-
-void caml_plat_signal(caml_plat_cond* cond)
-{
-  check_err("cond_signal", pthread_cond_signal(cond));
-}
-
-void caml_plat_cond_free(caml_plat_cond* cond)
-{
-  check_err("cond_free", pthread_cond_destroy(cond));
 }
 
 /* Futexes */

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -27,7 +27,11 @@
 #include "caml/runtime_events.h"
 
 /* System-dependent part */
+#ifdef _WIN32
+#include "sync_win32.h"
+#else
 #include "sync_posix.h"
+#endif
 
 /* Reporting errors */
 

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -29,9 +29,25 @@
 /* System-dependent part */
 #include "sync_posix.h"
 
+/* Reporting errors */
+
 CAMLexport void caml_check_error(int retcode, char const * msg)
 {
-  sync_check_error(retcode, msg);
+  char const * err;
+  char buf[1024];
+  int errlen, msglen;
+  value str;
+
+  if (retcode == 0) return;
+  if (retcode == ENOMEM) caml_raise_out_of_memory();
+  err = caml_strerror(retcode, buf, sizeof(buf));
+  msglen = strlen(msg);
+  errlen = strlen(err);
+  str = caml_alloc_string(msglen + 2 + errlen);
+  memcpy(&Byte(str, 0), msg, msglen);
+  memcpy(&Byte(str, msglen), ": ", 2);
+  memcpy(&Byte(str, msglen + 2), err, errlen);
+  caml_raise_sys_error(str);
 }
 
 /* Mutex operations */

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -29,6 +29,11 @@
 /* System-dependent part */
 #include "sync_posix.h"
 
+CAMLexport void caml_check_error(int retcode, char const * msg)
+{
+  sync_check_error(retcode, msg);
+}
+
 /* Mutex operations */
 
 static void caml_mutex_finalize(value wrapper)
@@ -74,7 +79,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
   sync_mutex mut = NULL;
   value wrapper;
 
-  sync_check_error(sync_mutex_create(&mut), "Mutex.create");
+  caml_check_error(sync_mutex_create(&mut), "Mutex.create");
   wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(pthread_mutex_t *),
                               0, 1);
   Mutex_val(wrapper) = mut;
@@ -93,7 +98,7 @@ CAMLprim value caml_ml_mutex_lock(value wrapper)
     caml_enter_blocking_section();
     retcode = sync_mutex_lock(mut);
     caml_leave_blocking_section();
-    sync_check_error(retcode, "Mutex.lock");
+    caml_check_error(retcode, "Mutex.lock");
   }
   CAMLreturn(Val_unit);
 }
@@ -104,7 +109,7 @@ CAMLprim value caml_ml_mutex_unlock(value wrapper)
   sync_mutex mut = Mutex_val(wrapper);
   /* PR#4351: no need to release and reacquire master lock */
   retcode = sync_mutex_unlock(mut);
-  sync_check_error(retcode, "Mutex.unlock");
+  caml_check_error(retcode, "Mutex.unlock");
   return Val_unit;
 }
 
@@ -114,7 +119,7 @@ CAMLprim value caml_ml_mutex_try_lock(value wrapper)
   sync_retcode retcode;
   retcode = sync_mutex_trylock(mut);
   if (retcode == MUTEX_ALREADY_LOCKED) return Val_false;
-  sync_check_error(retcode, "Mutex.try_lock");
+  caml_check_error(retcode, "Mutex.try_lock");
   return Val_true;
 }
 
@@ -153,7 +158,7 @@ CAMLprim value caml_ml_condition_new(value unit)
   value wrapper;
   sync_condvar cond = NULL;
 
-  sync_check_error(sync_condvar_create(&cond), "Condition.create");
+  caml_check_error(sync_condvar_create(&cond), "Condition.create");
   wrapper = caml_alloc_custom(&caml_condition_ops, sizeof(sync_condvar *),
                               0, 1);
   Condition_val(wrapper) = cond;
@@ -171,7 +176,7 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   caml_enter_blocking_section();
   retcode = sync_condvar_wait(cond, mut);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Condition.wait");
+  caml_check_error(retcode, "Condition.wait");
   CAML_EV_END(EV_DOMAIN_CONDITION_WAIT);
 
   CAMLreturn(Val_unit);
@@ -179,14 +184,14 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
 
 CAMLprim value caml_ml_condition_signal(value wrapper)
 {
-  sync_check_error(sync_condvar_signal(Condition_val(wrapper)),
+  caml_check_error(sync_condvar_signal(Condition_val(wrapper)),
                  "Condition.signal");
   return Val_unit;
 }
 
 CAMLprim value caml_ml_condition_broadcast(value wrapper)
 {
-  sync_check_error(sync_condvar_broadcast(Condition_val(wrapper)),
+  caml_check_error(sync_condvar_broadcast(Condition_val(wrapper)),
                  "Condition.broadcast");
   return Val_unit;
 }

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -96,7 +96,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
   value wrapper;
 
   caml_check_error(sync_mutex_create(&mut), "Mutex.create");
-  wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(pthread_mutex_t *),
+  wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(sync_mutex *),
                               0, 1);
   Mutex_val(wrapper) = mut;
   return wrapper;

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -116,25 +116,4 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
   return pthread_cond_wait(c, m);
 }
 
-/* Reporting errors */
-
-static void sync_check_error(int retcode, char * msg)
-{
-  char * err;
-  char buf[1024];
-  int errlen, msglen;
-  value str;
-
-  if (retcode == 0) return;
-  if (retcode == ENOMEM) caml_raise_out_of_memory();
-  err = caml_strerror(retcode, buf, sizeof(buf));
-  msglen = strlen(msg);
-  errlen = strlen(err);
-  str = caml_alloc_string(msglen + 2 + errlen);
-  memcpy (&Byte(str, 0), msg, msglen);
-  memcpy (&Byte(str, msglen), ": ", 2);
-  memcpy (&Byte(str, msglen + 2), err, errlen);
-  caml_raise_sys_error(str);
-}
-
 #endif /* CAML_SYNC_POSIX_H */

--- a/runtime/sync_win32.h
+++ b/runtime/sync_win32.h
@@ -30,9 +30,10 @@ typedef int sync_retcode;
 
 Caml_inline int sync_mutex_create(sync_mutex * res)
 {
-  sync_mutex m = caml_stat_alloc_noexc(sizeof(SRWLOCK));
+  sync_mutex m = caml_stat_alloc_noexc(sizeof(caml_plat_mutex));
   if (m == NULL) return ENOMEM;
-  InitializeSRWLock(m);
+  InitializeSRWLock(&m->lock);
+  m->owner_tid = 0;
   *res = m;
   return 0;
 }
@@ -45,8 +46,14 @@ Caml_inline int sync_mutex_destroy(sync_mutex m)
 
 Caml_inline int sync_mutex_lock(sync_mutex m)
 {
-  AcquireSRWLockExclusive(m);
-  return 0;
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid != self_tid) {
+    AcquireSRWLockExclusive(&m->lock);
+    m->owner_tid = self_tid;
+    return 0;
+  } else {
+    return EDEADLK;
+  }
 }
 
 #define MUTEX_PREVIOUSLY_UNLOCKED 0
@@ -54,14 +61,24 @@ Caml_inline int sync_mutex_lock(sync_mutex m)
 
 Caml_inline int sync_mutex_trylock(sync_mutex m)
 {
-  return TryAcquireSRWLockExclusive(m) ?
-    MUTEX_PREVIOUSLY_UNLOCKED : MUTEX_ALREADY_LOCKED;
+  if (TryAcquireSRWLockExclusive(&m->lock)) {
+    m->owner_tid = GetCurrentThreadId();
+    return MUTEX_PREVIOUSLY_UNLOCKED;
+  } else {
+    return MUTEX_ALREADY_LOCKED;
+  }
 }
 
 Caml_inline int sync_mutex_unlock(sync_mutex m)
 {
-  ReleaseSRWLockExclusive(m);
-  return 0;
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid == self_tid) {
+    m->owner_tid = 0;
+    ReleaseSRWLockExclusive(&m->lock);
+    return 0;
+  } else {
+    return EPERM;
+  }
 }
 
 /* Condition variables */
@@ -95,11 +112,22 @@ Caml_inline int sync_condvar_broadcast(sync_condvar c)
 
 Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 {
-  if (!SleepConditionVariableSRW(c, m, INFINITE, 0 /* exclusive */)) {
-    int rc = caml_posixerr_of_win32err(GetLastError());
-    return rc == 0 ? EINVAL : rc;
+  DWORD self_tid = GetCurrentThreadId();
+  int rc = 0;
+  if (m->owner_tid == self_tid) {
+    m->owner_tid = 0;
+    if (SleepConditionVariableSRW(c, &m->lock, INFINITE,
+                                  0 /* exclusive */)) {
+      m->owner_tid = GetCurrentThreadId();
+    } else {
+      rc = caml_posixerr_of_win32err(GetLastError());
+      /* Not clear if the thread owns the mutex or not, but there's a
+       * fatal error anyway.  */
+    }
+  } else {
+    rc = EPERM;
   }
-  return 0;
+  return rc;
 }
 
 #endif

--- a/runtime/sync_win32.h
+++ b/runtime/sync_win32.h
@@ -1,0 +1,105 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                         Antonin Decimo, Tarides                        */
+/*                                                                        */
+/*   Copyright 2024 Tarides                                               */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* Windows implementation of the user facing Mutex and Condition */
+/* To be included in runtime/sync.c */
+
+#ifndef CAML_SYNC_WIN32_H
+#define CAML_SYNC_WIN32_H
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include "caml/sync.h"
+#include "caml/osdeps.h"
+
+typedef int sync_retcode;
+
+/* Mutexes */
+
+Caml_inline int sync_mutex_create(sync_mutex * res)
+{
+  sync_mutex m = caml_stat_alloc_noexc(sizeof(SRWLOCK));
+  if (m == NULL) return ENOMEM;
+  InitializeSRWLock(m);
+  *res = m;
+  return 0;
+}
+
+Caml_inline int sync_mutex_destroy(sync_mutex m)
+{
+  caml_stat_free(m);
+  return 0;
+}
+
+Caml_inline int sync_mutex_lock(sync_mutex m)
+{
+  AcquireSRWLockExclusive(m);
+  return 0;
+}
+
+#define MUTEX_PREVIOUSLY_UNLOCKED 0
+#define MUTEX_ALREADY_LOCKED EBUSY
+
+Caml_inline int sync_mutex_trylock(sync_mutex m)
+{
+  return TryAcquireSRWLockExclusive(m) ?
+    MUTEX_PREVIOUSLY_UNLOCKED : MUTEX_ALREADY_LOCKED;
+}
+
+Caml_inline int sync_mutex_unlock(sync_mutex m)
+{
+  ReleaseSRWLockExclusive(m);
+  return 0;
+}
+
+/* Condition variables */
+
+Caml_inline int sync_condvar_create(sync_condvar * res)
+{
+  sync_condvar c = caml_stat_alloc_noexc(sizeof(CONDITION_VARIABLE));
+  if (c == NULL) return ENOMEM;
+  InitializeConditionVariable(c);
+  *res = c;
+  return 0;
+}
+
+Caml_inline int sync_condvar_destroy(sync_condvar c)
+{
+  caml_stat_free(c);
+  return 0;
+}
+
+Caml_inline int sync_condvar_signal(sync_condvar c)
+{
+  WakeConditionVariable(c);
+  return 0;
+}
+
+Caml_inline int sync_condvar_broadcast(sync_condvar c)
+{
+  WakeAllConditionVariable(c);
+  return 0;
+}
+
+Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
+{
+  if (!SleepConditionVariableSRW(c, m, INFINITE, 0 /* exclusive */)) {
+    int rc = caml_posixerr_of_win32err(GetLastError());
+    return rc == 0 ? EINVAL : rc;
+  }
+  return 0;
+}
+
+#endif

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -23,6 +23,7 @@
 #define _WIN32_WINNT 0x0600
 
 #define WIN32_LEAN_AND_MEAN
+#include <windows.h>
 #include <wtypes.h>
 #include <winbase.h>
 #include <winsock2.h>
@@ -30,6 +31,7 @@
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <direct.h>
+#include <process.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -1152,6 +1154,130 @@ void caml_plat_mem_unmap(void* mem, uintnat size)
 {
   if (!VirtualFree(mem, 0, MEM_RELEASE))
     CAMLassert(0);
+}
+
+/* Threads */
+
+int caml_plat_thread_create(caml_plat_thread *restrict thread,
+                            const caml_plat_thread_attr *restrict attr,
+                            unsigned ( WINAPI *start_address )( void * ),
+                            void *restrict arg)
+{
+  (void) attr; /* unused */
+  *thread = (caml_plat_thread) _beginthreadex(
+    NULL, /* security: handle can't be inherited */
+    0,    /* stack size */
+    start_address,
+    arg,
+    0,    /* run immediately */
+    NULL  /* thread identifier */
+    );
+  return (*thread != 0) ? 0 : errno;
+}
+
+int caml_plat_thread_detach(caml_plat_thread thread)
+{
+  /* This works as the thread handle is never duplicated. */
+  if (CloseHandle(thread)) {
+    return 0;
+  } else {
+    int err = caml_posixerr_of_win32err(GetLastError());
+    return err == 0 ? EINVAL : err;
+  }
+}
+
+int caml_plat_thread_join(caml_plat_thread thread)
+{
+  DWORD rc = WaitForSingleObject(thread, INFINITE);
+  switch (rc) {
+  case WAIT_OBJECT_0:
+    return 0;
+  case WAIT_FAILED: {
+    int err = caml_posixerr_of_win32err(GetLastError());
+    return err == 0 ? EINVAL : err;
+  }
+  default:
+    CAMLunreachable();
+  }
+}
+
+int caml_plat_thread_equal(caml_plat_thread t1, caml_plat_thread t2)
+{
+  DWORD id1 = GetThreadId(t1), id2 = GetThreadId(t2);
+  return id1 == 0 || id2 == 0 ? -1 : id1 == id2;
+}
+
+caml_plat_thread caml_plat_thread_self(void)
+{
+  /* A pseudo handle is a special constant that is interpreted as the
+   * current thread handle. The function cannot be used by one thread
+   * to create a handle that can be used by other threads to refer to
+   * the first thread. The handle is always interpreted as referring
+   * to the thread that is using it. */
+  return GetCurrentThread();
+}
+
+/* Mutexes */
+
+CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
+{
+  InitializeSRWLock(m);
+}
+
+void caml_plat_assert_locked(caml_plat_mutex *m)
+{
+#ifdef DEBUG
+  BOOLEAN r = TryAcquireSRWLockExclusive(m);
+  if (r == 0) {
+    /* ok, it was locked */
+    return;
+  } else {
+    caml_fatal_error("Required mutex not locked");
+  }
+#endif
+}
+
+CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
+{
+  /* Avoid exceptions */
+  caml_enter_blocking_section_no_pending();
+  AcquireSRWLockExclusive(m);
+  caml_leave_blocking_section();
+  DEBUG_LOCK(m);
+}
+
+void caml_plat_mutex_free(caml_plat_mutex* m)
+{
+  /* nothing to do */
+}
+
+/* Condition variables */
+
+void caml_plat_cond_init(caml_plat_cond *cond)
+{
+  InitializeConditionVariable(cond);
+}
+
+void caml_plat_wait(caml_plat_cond *cond, caml_plat_mutex* mut)
+{
+  caml_plat_assert_locked(mut);
+  BOOL rc = SleepConditionVariableSRW(cond, mut, INFINITE, 0 /* exclusive */);
+  check_err("wait", rc == 0);
+}
+
+void caml_plat_broadcast(caml_plat_cond* cond)
+{
+  WakeAllConditionVariable(cond);
+}
+
+void caml_plat_signal(caml_plat_cond* cond)
+{
+  WakeConditionVariable(cond);
+}
+
+void caml_plat_cond_free(caml_plat_cond* cond)
+{
+  /* nothing to do */
 }
 
 /* Mapping Win32 error codes to POSIX error codes */

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1221,13 +1221,14 @@ caml_plat_thread caml_plat_thread_self(void)
 
 CAMLexport void caml_plat_mutex_init(caml_plat_mutex * m)
 {
-  InitializeSRWLock(m);
+  InitializeSRWLock(&m->lock);
+  m->owner_tid = 0;
 }
 
 void caml_plat_assert_locked(caml_plat_mutex *m)
 {
 #ifdef DEBUG
-  BOOLEAN r = TryAcquireSRWLockExclusive(m);
+  BOOLEAN r = TryAcquireSRWLockExclusive(&m->lock);
   if (r == 0) {
     /* ok, it was locked */
     return;
@@ -1241,7 +1242,13 @@ CAMLexport void caml_plat_lock_non_blocking_actual(caml_plat_mutex* m)
 {
   /* Avoid exceptions */
   caml_enter_blocking_section_no_pending();
-  AcquireSRWLockExclusive(m);
+  DWORD self_tid = GetCurrentThreadId();
+  if (m->owner_tid != self_tid) {
+    AcquireSRWLockExclusive(&m->lock);
+    m->owner_tid = self_tid;
+  } else {
+    check_err("lock_non_blocking", EDEADLK);
+  }
   caml_leave_blocking_section();
   DEBUG_LOCK(m);
 }
@@ -1261,8 +1268,22 @@ void caml_plat_cond_init(caml_plat_cond *cond)
 void caml_plat_wait(caml_plat_cond *cond, caml_plat_mutex* mut)
 {
   caml_plat_assert_locked(mut);
-  BOOL rc = SleepConditionVariableSRW(cond, mut, INFINITE, 0 /* exclusive */);
-  check_err("wait", rc == 0);
+  DWORD self_tid = GetCurrentThreadId();
+  int rc = 0;
+  if (mut->owner_tid == self_tid) {
+    mut->owner_tid = 0;
+    if (SleepConditionVariableSRW(cond, &mut->lock, INFINITE,
+                                  0 /* exclusive */)) {
+      mut->owner_tid = GetCurrentThreadId();
+    } else {
+      rc = caml_posixerr_of_win32err(GetLastError());
+      /* Not clear if the thread owns the mutex or not, but there's a
+       * fatal error anyway.  */
+    }
+  } else {
+    rc = EPERM;
+  }
+  check_err("wait", rc);
 }
 
 void caml_plat_broadcast(caml_plat_cond* cond)

--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -38,15 +38,11 @@ val lock : t -> unit
    by another thread will suspend until the other thread unlocks
    the mutex.
 
-   @raise Sys_error if the mutex is already locked by the thread
-   calling {!Mutex.lock} on Unix platforms. On Windows, recursive
-   locking deadlocks.
+   @raise Sys_error if the mutex is already locked by the thread calling
+   {!Mutex.lock}.
 
    @before 4.12 {!Sys_error} was not raised for recursive locking
-   (platform-dependent behaviour).
-
-   @since 5.3 On Windows, {!Sys_error} is not raised for recursive
-   locking. *)
+   (platform-dependent behaviour) *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
@@ -58,15 +54,10 @@ val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
    by the thread that calls {!Mutex.unlock}.
-
-   @raise Sys_error if the mutex is unlocked or was locked by another
-   thread. This doesn't apply on Windows since OCaml 5.3.
+   @raise Sys_error if the mutex is unlocked or was locked by another thread.
 
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
-   or when unlocking a mutex from a different thread.
-
-   @since 5.3 5.3 On Windows, {!Sys_error} is not raised if the mutex
-   is unlocked or was locked by another thread. *)
+   or when unlocking a mutex from a different thread. *)
 
 val protect : t -> (unit -> 'a) -> 'a
 (** [protect mutex f] runs [f()] in a critical section where [mutex]

--- a/stdlib/mutex.mli
+++ b/stdlib/mutex.mli
@@ -38,11 +38,15 @@ val lock : t -> unit
    by another thread will suspend until the other thread unlocks
    the mutex.
 
-   @raise Sys_error if the mutex is already locked by the thread calling
-   {!Mutex.lock}.
+   @raise Sys_error if the mutex is already locked by the thread
+   calling {!Mutex.lock} on Unix platforms. On Windows, recursive
+   locking deadlocks.
 
    @before 4.12 {!Sys_error} was not raised for recursive locking
-   (platform-dependent behaviour) *)
+   (platform-dependent behaviour).
+
+   @since 5.3 On Windows, {!Sys_error} is not raised for recursive
+   locking. *)
 
 val try_lock : t -> bool
 (** Same as {!Mutex.lock}, but does not suspend the calling thread if
@@ -54,10 +58,15 @@ val unlock : t -> unit
 (** Unlock the given mutex. Other threads suspended trying to lock
    the mutex will restart.  The mutex must have been previously locked
    by the thread that calls {!Mutex.unlock}.
-   @raise Sys_error if the mutex is unlocked or was locked by another thread.
+
+   @raise Sys_error if the mutex is unlocked or was locked by another
+   thread. This doesn't apply on Windows since OCaml 5.3.
 
    @before 4.12 {!Sys_error} was not raised when unlocking an unlocked mutex
-   or when unlocking a mutex from a different thread. *)
+   or when unlocking a mutex from a different thread.
+
+   @since 5.3 5.3 On Windows, {!Sys_error} is not raised if the mutex
+   is unlocked or was locked by another thread. *)
 
 val protect : t -> (unit -> 'a) -> 'a
 (** [protect mutex f] runs [f()] in a critical section where [mutex]

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -2,6 +2,7 @@
  include systhreads;
  hassysthreads;
  no-tsan; (* tsan detects the mutex errors and fails *)
+ not-windows; (* Windows' SRWLock differ from pthreads ERRORCHECK mutexes. *)
  {
    bytecode;
  }{

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -2,7 +2,6 @@
  include systhreads;
  hassysthreads;
  no-tsan; (* tsan detects the mutex errors and fails *)
- not-windows; (* Windows' SRWLock differ from pthreads ERRORCHECK mutexes. *)
  {
    bytecode;
  }{

--- a/tools/ci/inria/main
+++ b/tools/ci/inria/main
@@ -162,7 +162,6 @@ check_make_alldepend=false
 jobs=''
 bootstrap=false
 init_submodule_flexdll=false
-init_submodule_winpthreads=false
 
 memory_model_tests="tests/memory-model/forbidden.ml \
 tests/memory-model/publish.ml"
@@ -209,7 +208,6 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlms'
     cleanup=true
     init_submodule_flexdll=true
-    init_submodule_winpthreads=true
   ;;
   msvc64)
     build='--build=x86_64-pc-cygwin'
@@ -217,7 +215,6 @@ case "${OCAML_ARCH}" in
     instdir='C:/ocamlms64'
     cleanup=true
     init_submodule_flexdll=true
-    init_submodule_winpthreads=true
   ;;
   *) arch_error;;
 esac
@@ -248,14 +245,6 @@ if $init_submodule_flexdll; then
 elif [ -f flexdll/Makefile ]; then
   if grep -Fq flexdll .gitmodules; then
     git submodule deinit --force flexdll
-  fi
-fi
-
-if $init_submodule_winpthreads; then
-  git submodule update --init winpthreads
-elif [ -f winpthreads/Makefile.in ]; then
-  if grep -Fq winpthreads .gitmodules; then
-    git submodule deinit --force winpthreads
   fi
 fi
 


### PR DESCRIPTION
The goal is to remove winpthreads (a library emulating pthreads on top of _old_ Windows APIs), and use _modern_ Windows APIs in both the MSVC and MinGW-w64 ports.

It would be great if this PR could be considered for inclusion in 5.3: although we were already using the system winpthreads for the MinGW-w64 port, we introduced it as a submodule during the 5.3 development cycle to support the MSVC port. If we could remove it now, end users won't ever (unknowingly) depend on it.

One commit removes winpthreads (breaks OCaml build on Windows) and another implements the `caml_plat_*` and `st_*` functions required to abstract over pthreads and Windows concurrency APIs.

Note that Windows [Mutex Objects](https://learn.microsoft.com/en-us/windows/win32/sync/mutex-objects) cannot be used with condition variables. The right pairing consists of [Slim Reader/Writer Locks](https://learn.microsoft.com/en-us/windows/win32/sync/slim-reader-writer--srw--locks) (SRW locks) and [condition variables](https://learn.microsoft.com/en-us/windows/win32/sync/condition-variables). SRW locks support shared locking (only readers) and exclusive locking (one writer). I've chosen to use exclusive locking in all cases. Windows condition variables have the problem that they cannot be statically initialized.

Both pthreads and WinAPI are quite similar, except for a few points that I've noted:
1. The type of a function that starts a thread. They return a `void *` pointer on pthreads, and an `unsigned int` on Windows, but it seems not to be a concern for us.
2. We use pthread `ERRORCHECK` mutexes. POSIX states:

   > The `pthread_mutex_lock()` function shall fail if:
   > [`EDEADLK`]
   >   The mutex type is `PTHREAD_MUTEX_ERRORCHECK` and the current thread already owns the mutex.

   The Windows documentation states:

   > Exclusive mode SRW locks cannot be acquired recursively. If a thread tries to acquire a lock that it already holds, that attempt will […] deadlock (for `AcquireSRWLockExclusive`).

   Deadlocks caused by recursive attempts to lock cannot be detected on Windows. We cannot either detect double unlocks, or attempts to unlock a lock owned by another thread. This would revert the `Stdlib.Mutex` module guarantees to those of before OCaml 4.12 _on Windows only_.
   
   I've thus chosen to implement so-called `ERRORCHECK` mutexes with a pair of a SRWLock, and the thread id of the owner, accessed atomically. The value 0 is used when the thread is not owned, and is a valid sentinel value.

3. A Windows thread is "detached" if all handles referring to the thread have been closed: it cannot be joined (waited on in Windows terminology) anymore but is not ended. pthread has a thread attribute to control the detached state.
