### PR TITLE
Concurrency code refactorings (runtime, systhreads)

### DIFF
--- a/Changes
+++ b/Changes
@@ -81,6 +81,12 @@ _______________
   (Antonin Décimo, review by Nicolás Ojeda Bär, Xavier Leroy, and
    Gabriel Scherer)
 
+- #12269, #12410, #13063: Fix unsafety, deadlocks, and/or leaks should
+  rare errors happen during domain creation and thread
+  creation/registration.
+  (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, B. Szilvasy,
+   Miod Vallat)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/Changes
+++ b/Changes
@@ -87,6 +87,11 @@ _______________
   (Guillaume Munch-Maccagnoni, review by Gabriel Scherer, B. Szilvasy,
    Miod Vallat)
 
+- #13227: Audit and fix usage of caml_plat_lock_blocking; there is a
+   possibility that this fixes some deadlocks in some situations
+   involving multiple domains.
+  (Guillaume Munch-Maccagnoni, review by)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -71,7 +71,7 @@ value caml_thread_sigmask(value cmd, value sigs)
   caml_enter_blocking_section();
   retcode = pthread_sigmask(how, &set, &oldset);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Thread.sigmask");
+  caml_check_error(retcode, "Thread.sigmask");
   /* Run any handlers for just-unmasked pending signals */
   caml_process_pending_actions();
   return st_encode_sigset(&oldset);
@@ -87,7 +87,7 @@ value caml_wait_signal(value sigs)
   caml_enter_blocking_section();
   retcode = sigwait(&set, &signo);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Thread.wait_signal");
+  caml_check_error(retcode, "Thread.wait_signal");
   return Val_int(caml_rev_convert_signal_number(signo));
 #else
   caml_invalid_argument("Thread.wait_signal not implemented");

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -26,20 +26,6 @@
 #include <unistd.h>
 #endif
 
-typedef int st_retcode;
-
-/* Variables used to stop "tick" threads */
-static atomic_uintnat tick_thread_stop[Max_domains];
-#define Tick_thread_stop tick_thread_stop[Caml_state->id]
-
-/* OS-specific initialization */
-
-static int st_initialize(void)
-{
-  atomic_store_release(&Tick_thread_stop, 0);
-  return 0;
-}
-
 /* Thread creation.  Created in detached mode if [res] is NULL. */
 
 typedef pthread_t st_thread_id;
@@ -93,14 +79,14 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
    all risks of busy-waiting.  Also, we count the number of waiting
    threads. */
 
-typedef struct {
+struct st_masterlock {
   int init;                       /* have the mutex and the cond been
                                      initialized already? */
   pthread_mutex_t lock;           /* to protect contents */
   uintnat busy;                   /* 0 = free, 1 = taken */
   atomic_uintnat waiters;         /* number of threads waiting on master lock */
   pthread_cond_t is_free;         /* signaled when free */
-} st_masterlock;
+};
 
 /* Returns non-zero on failure */
 static int st_masterlock_init(st_masterlock * m)
@@ -131,40 +117,6 @@ static void st_masterlock_destroy(st_masterlock * m)
   rc = pthread_mutex_destroy(&m->lock);
   CAMLassert(!rc);
   (void)rc;
-}
-
-static uintnat st_masterlock_waiters(st_masterlock * m)
-{
-  return atomic_load_acquire(&m->waiters);
-}
-
-static void st_bt_lock_acquire(st_masterlock *m) {
-
-  /* We do not want to signal the backup thread if it is not "working"
-     as it may very well not be, because we could have just resumed
-     execution from another thread right away. */
-  if (caml_bt_is_in_blocking_section()) {
-    caml_bt_enter_ocaml();
-  }
-
-  caml_acquire_domain_lock();
-
-  return;
-}
-
-static void st_bt_lock_release(st_masterlock *m) {
-
-  /* Here we do want to signal the backup thread iff there's
-     no thread waiting to be scheduled, and the backup thread is currently
-     idle. */
-  if (st_masterlock_waiters(m) == 0 &&
-      caml_bt_is_in_blocking_section() == 0) {
-    caml_bt_exit_ocaml();
-  }
-
-  caml_release_domain_lock();
-
-  return;
 }
 
 static void st_masterlock_acquire(st_masterlock *m)
@@ -300,22 +252,4 @@ static int st_event_wait(st_event e)
   }
   rc = pthread_mutex_unlock(&e->lock);
   return rc;
-}
-
-/* The tick thread: interrupt the domain periodically to force preemption  */
-
-static void * caml_thread_tick(void * arg)
-{
-  int *domain_id = (int *) arg;
-
-  caml_init_domain_self(*domain_id);
-  caml_domain_state *domain = Caml_state;
-
-  while(! atomic_load_acquire(&Tick_thread_stop)) {
-    st_msleep(Thread_timeout);
-
-    atomic_store_release(&domain->requested_external_interrupt, 1);
-    caml_interrupt_self();
-  }
-  return NULL;
 }

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -130,8 +130,6 @@ static void st_masterlock_acquire(st_masterlock *m)
   m->busy = true;
   st_bt_lock_acquire(m);
   pthread_mutex_unlock(&m->lock);
-
-  return;
 }
 
 static void st_masterlock_release(st_masterlock * m)
@@ -141,8 +139,6 @@ static void st_masterlock_release(st_masterlock * m)
   st_bt_lock_release(m);
   pthread_cond_signal(&m->is_free);
   pthread_mutex_unlock(&m->lock);
-
-  return;
 }
 
 /* Scheduling hints */
@@ -192,8 +188,6 @@ Caml_inline void st_thread_yield(st_masterlock * m)
   caml_acquire_domain_lock();
 
   pthread_mutex_unlock(&m->lock);
-
-  return;
 }
 
 /* Triggered events */

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -80,10 +80,10 @@ Caml_inline void st_tls_set(st_tlskey k, void * v)
    threads. */
 
 struct st_masterlock {
-  int init;                       /* have the mutex and the cond been
+  bool init;                      /* have the mutex and the cond been
                                      initialized already? */
   pthread_mutex_t lock;           /* to protect contents */
-  uintnat busy;                   /* 0 = free, 1 = taken */
+  bool busy;                      /* false = free, true = taken */
   atomic_uintnat waiters;         /* number of threads waiting on master lock */
   pthread_cond_t is_free;         /* signaled when free */
 };
@@ -97,9 +97,9 @@ static int st_masterlock_init(st_masterlock * m)
     if (rc != 0) goto out_err;
     rc = pthread_cond_init(&m->is_free, NULL);
     if (rc != 0) goto out_err2;
-    m->init = 1;
+    m->init = true;
   }
-  m->busy = 1;
+  m->busy = true;
   atomic_store_release(&m->waiters, 0);
   return 0;
 
@@ -127,7 +127,7 @@ static void st_masterlock_acquire(st_masterlock *m)
     pthread_cond_wait(&m->is_free, &m->lock);
     atomic_fetch_add(&m->waiters, -1);
   }
-  m->busy = 1;
+  m->busy = true;
   st_bt_lock_acquire(m);
   pthread_mutex_unlock(&m->lock);
 
@@ -137,7 +137,7 @@ static void st_masterlock_acquire(st_masterlock *m)
 static void st_masterlock_release(st_masterlock * m)
 {
   pthread_mutex_lock(&m->lock);
-  m->busy = 0;
+  m->busy = false;
   st_bt_lock_release(m);
   pthread_cond_signal(&m->is_free);
   pthread_mutex_unlock(&m->lock);
@@ -169,7 +169,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
     return;
   }
 
-  m->busy = 0;
+  m->busy = false;
   atomic_fetch_add(&m->waiters, +1);
   pthread_cond_signal(&m->is_free);
   /* releasing the domain lock but not triggering bt messaging
@@ -186,7 +186,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
        pthread_cond_wait(&m->is_free, &m->lock);
   } while (m->busy);
 
-  m->busy = 1;
+  m->busy = true;
   atomic_fetch_add(&m->waiters, -1);
 
   caml_acquire_domain_lock();
@@ -200,7 +200,7 @@ Caml_inline void st_thread_yield(st_masterlock * m)
 
 typedef struct st_event_struct {
   pthread_mutex_t lock;         /* to protect contents */
-  int status;                   /* 0 = not triggered, 1 = triggered */
+  bool status;                  /* false = not triggered, true = triggered */
   pthread_cond_t triggered;     /* signaled when triggered */
 } * st_event;
 
@@ -215,7 +215,7 @@ static int st_event_create(st_event * res)
   rc = pthread_cond_init(&e->triggered, NULL);
   if (rc != 0)
   { pthread_mutex_destroy(&e->lock); caml_stat_free(e); return rc; }
-  e->status = 0;
+  e->status = false;
   *res = e;
   return 0;
 }
@@ -234,7 +234,7 @@ static int st_event_trigger(st_event e)
   int rc;
   rc = pthread_mutex_lock(&e->lock);
   if (rc != 0) return rc;
-  e->status = 1;
+  e->status = true;
   rc = pthread_mutex_unlock(&e->lock);
   if (rc != 0) return rc;
   rc = pthread_cond_broadcast(&e->triggered);
@@ -246,7 +246,7 @@ static int st_event_wait(st_event e)
   int rc;
   rc = pthread_mutex_lock(&e->lock);
   if (rc != 0) return rc;
-  while(e->status == 0) {
+  while(!e->status) {
     rc = pthread_cond_wait(&e->triggered, &e->lock);
     if (rc != 0) return rc;
   }

--- a/otherlibs/systhreads/st_pthreads.h
+++ b/otherlibs/systhreads/st_pthreads.h
@@ -123,6 +123,16 @@ static int st_masterlock_init(st_masterlock * m)
   return rc;
 }
 
+static void st_masterlock_destroy(st_masterlock * m)
+{
+  int rc;
+  rc = pthread_cond_destroy(&m->is_free);
+  CAMLassert(!rc);
+  rc = pthread_mutex_destroy(&m->lock);
+  CAMLassert(!rc);
+  (void)rc;
+}
+
 static uintnat st_masterlock_waiters(st_masterlock * m)
 {
   return atomic_load_acquire(&m->waiters);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -58,12 +58,19 @@
 /* Max computation time before rescheduling, in milliseconds */
 #define Thread_timeout 50
 
+typedef struct st_masterlock st_masterlock;
+static void st_bt_lock_acquire(st_masterlock *m);
+static void st_bt_lock_release(st_masterlock *m);
+static uintnat st_masterlock_waiters(st_masterlock * m);
+
 /* OS-specific code */
 #ifdef _WIN32
 #include "st_win32.h"
 #else
 #include "st_posix.h"
 #endif
+
+#include "st_stubs.h"
 
 /* The ML value describing a thread (heap-allocated) */
 

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -442,7 +442,7 @@ static void caml_thread_reinitialize(void)
      the effective owner of the lock. So there is no need to run
      st_masterlock_acquire (busy = 1) */
   st_masterlock *m = Thread_lock(Caml_state->id);
-  m->init = 0; /* force reinitialization */
+  m->init = false; /* force reinitialization */
   /* Note: initializing an already-initialized mutex and cond variable
      is UB (especially mutexes that are locked). This is best
      effort. */

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -151,7 +151,7 @@ static void thread_lock_release(int dom_id)
 static atomic_uintnat thread_next_id = 0;
 
 /* Forward declarations */
-static value caml_threadstatus_new (void);
+static value caml_threadstatus_new_exn (void);
 static void caml_threadstatus_terminate (value);
 static st_retcode caml_threadstatus_wait (value);
 
@@ -351,13 +351,14 @@ void caml_thread_free_info(caml_thread_t th)
 
 /* Allocate a thread descriptor block. */
 
-static value caml_thread_new_descriptor(value clos)
+static value caml_thread_new_descriptor_exn(value clos)
 {
   CAMLparam1(clos);
   CAMLlocal1(mu);
   value descr;
   /* Create and initialize the termination semaphore */
-  mu = caml_threadstatus_new();
+  mu = caml_threadstatus_new_exn();
+  if (Is_exception_result(mu)) CAMLreturn(mu);
   /* Create a descriptor for the new thread */
   descr = caml_alloc_3(0, Val_long(atomic_fetch_add(&thread_next_id, +1)),
                        clos, mu);
@@ -383,7 +384,7 @@ static caml_thread_t thread_alloc_and_add(void)
 
 /* Remove a thread info block from the list of threads
    and free its resources. */
-static void caml_thread_remove_and_free(caml_thread_t th)
+static void thread_remove_and_free(caml_thread_t th)
 {
   if (th->next == th)
     reset_active(); /* last OCaml thread exiting */
@@ -480,25 +481,31 @@ static void caml_thread_domain_stop_hook(void) {
   };
 }
 
-/* FIXME: this should return an encoded exception for use in
-   domain_thread_func, but the latter is not ready to handle it
-   yet. */
-static void caml_thread_domain_initialize_hook(void)
+static value caml_thread_domain_initialize_hook_exn(void)
 {
-
+  value res = Val_unit;
   caml_thread_t new_thread;
 
   /* OS-specific initialization */
   st_initialize();
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
-  caml_check_error(ret, "caml_thread_domain_initialize_hook");
+  if (ret != 0)
+    return caml_check_error_exn(ret, "caml_thread_domain_initialize_hook");
 
   new_thread =
-    (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
+    (caml_thread_t) caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
+  if (new_thread == NULL) {
+    res = Make_exception_result(caml_exception_out_of_memory());
+    goto err1;
+  }
 
   new_thread->domain_id = Caml_state->id;
-  new_thread->descr = caml_thread_new_descriptor(Val_unit);
+
+  res = caml_thread_new_descriptor_exn(Val_unit);
+  if (Is_exception_result(res)) goto err2;
+  new_thread->descr = res;
+
   new_thread->next = new_thread;
   new_thread->prev = new_thread;
   new_thread->backtrace_last_exn = Val_unit;
@@ -508,6 +515,13 @@ static void caml_thread_domain_initialize_hook(void)
 
   Active_thread = new_thread;
   caml_memprof_enter_thread(new_thread->memprof);
+  return Val_unit;
+
+ err2:
+  caml_stat_free(new_thread);
+ err1:
+  st_masterlock_destroy(Thread_lock(Caml_state->id));
+  return res;
 }
 
 static void thread_yield(void);
@@ -547,14 +561,15 @@ CAMLprim value caml_thread_initialize(value unit)
   st_tls_newkey(&caml_thread_key);
 
   /* First initialise the systhread chain on this domain */
-  caml_thread_domain_initialize_hook();
+  value res = caml_thread_domain_initialize_hook_exn();
+  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
 
   prev_scan_roots_hook = atomic_exchange(&caml_scan_roots_hook,
                                          caml_thread_scan_roots);
   caml_enter_blocking_section_hook = caml_thread_enter_blocking_section;
   caml_leave_blocking_section_hook = caml_thread_leave_blocking_section;
   caml_domain_external_interrupt_hook = caml_thread_interrupt_hook;
-  caml_domain_initialize_hook = caml_thread_domain_initialize_hook;
+  caml_domain_initialize_hook_exn = caml_thread_domain_initialize_hook_exn;
   caml_domain_stop_hook = caml_thread_domain_stop_hook;
   caml_atfork_hook = caml_thread_reinitialize;
 
@@ -579,30 +594,24 @@ CAMLprim value caml_thread_cleanup(value unit)
   return Val_unit;
 }
 
+static void thread_destroy_current(caml_thread_t th);
+
 static void thread_detach_from_runtime(void)
 {
   caml_thread_t th = This_thread;
   CAMLassert(th == Active_thread);
-  /* PR#5188, PR#7220: some of the global runtime state may have
-     changed as the thread was running, so we save it in the
-     This_thread data to make sure that the cleanup logic
-     below uses accurate information. */
-  save_runtime_state();
   /* The main domain thread does not go through
      [thread_detach_from_runtime]. There is always one more thread in
      the chain at this point in time. */
   CAMLassert(th->next != th);
   /* Signal that the thread has terminated */
   caml_threadstatus_terminate(Terminated(th->descr));
-  /* Remove signal stack */
-  CAMLassert(th->signal_stack != NULL);
-  caml_free_signal_stack(th->signal_stack);
+  /* Undo thread_init_current */
+  thread_destroy_current(th);
   /* The following also sets Active_thread to a sane value in case the
      backup thread does a GC before the domain lock is acquired
      again. */
-  caml_thread_remove_and_free(th);
-  /* Forget the now-freed thread info */
-  st_tls_set(caml_thread_key, NULL);
+  thread_remove_and_free(th);
   /* Release domain lock */
   thread_lock_release(Caml_state->id);
 }
@@ -612,7 +621,21 @@ static void thread_init_current(caml_thread_t th)
 {
   st_tls_set(caml_thread_key, th);
   restore_runtime_state(th);
+  /* FIXME: deal with errors */
   th->signal_stack = caml_init_signal_stack();
+}
+
+/* Undo thread_init_current */
+static void thread_destroy_current(caml_thread_t th)
+{
+  CAMLassert(th->signal_stack != NULL);
+  caml_free_signal_stack(th->signal_stack);
+  /* PR#5188, PR#7220: some of the global runtime state may have
+     changed as the thread was running, so we save it in the
+     This_thread data to make sure that the cleanup logic
+     uses accurate information. */
+  save_runtime_state();
+  st_tls_set(caml_thread_key, NULL);
 }
 
 /* Create a thread */
@@ -666,6 +689,7 @@ static st_retcode create_tick_thread(void)
 CAMLprim value caml_thread_new(value clos)
 {
   CAMLparam1(clos);
+  CAMLlocal1(res);
 
 #ifndef NATIVE_CODE
   if (caml_debugger_in_use)
@@ -681,17 +705,20 @@ CAMLprim value caml_thread_new(value clos)
   /* Create a thread info block */
   caml_thread_t th = thread_alloc_and_add();
   if (th == NULL) caml_raise_out_of_memory();
-  th->descr = caml_thread_new_descriptor(clos);
+
+  res = caml_thread_new_descriptor_exn(clos);
+  if (Is_exception_result(res)) goto err;
+  th->descr = res;
 
   err = st_thread_create(NULL, caml_thread_start, (void *) th);
-
-  if (err != 0) {
-    /* Creation failed, remove thread info block from list of threads */
-    caml_thread_remove_and_free(th);
-    caml_check_error(err, "Thread.create");
-  }
+  if (err != 0) { res = caml_check_error_exn(err, "Thread.create"); goto err; }
 
   CAMLreturn(th->descr);
+
+ err:
+  res = Extract_exception(res);
+  thread_remove_and_free(th);
+  caml_raise(res);
 }
 
 /* Register a thread already created from C */
@@ -719,20 +746,26 @@ CAMLexport int caml_c_thread_register(void)
 
   /* Set a thread info block */
   caml_thread_t th = thread_alloc_and_add();
-  /* If it fails, we release the lock and return an error. */
   if (th == NULL) goto out_err;
+
   thread_init_current(th);
+
   /* We can now allocate the thread descriptor on the major heap */
-  th->descr = caml_thread_new_descriptor(Val_unit);  /* no closure */
+  value res = caml_thread_new_descriptor_exn(Val_unit);  /* no closure */
+  if (Is_exception_result(res)) goto out_err2;
+  th->descr = res;
 
   /* Release the domain lock the regular way. Note: we cannot receive
      an exception here. */
   caml_enter_blocking_section_no_pending();
   return 1;
 
-out_err:
-  /* Note: we cannot raise an exception here. */
+ out_err2:
+  thread_destroy_current(th);
+  thread_remove_and_free(th);
+ out_err:
   thread_lock_release(Dom_c_threads);
+  /* Note: we cannot raise an exception here. */
   return 0;
 }
 
@@ -847,11 +880,14 @@ static struct custom_operations caml_threadstatus_ops = {
   custom_fixed_length_default
 };
 
-static value caml_threadstatus_new (void)
+static value caml_threadstatus_new_exn(void)
 {
   st_event ts = NULL;           /* suppress warning */
   value wrapper;
-  caml_check_error(st_event_create(&ts), "Thread.create");
+  value ret = st_event_create(&ts);
+  if (ret != 0) return caml_check_error_exn(ret, "Thread.create");
+
+  /* this is a small allocation: no noexc version possible */
   wrapper = caml_alloc_custom(&caml_threadstatus_ops,
                               sizeof(st_event *),
                               0, 1);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -51,8 +51,6 @@
 #include "caml/sys.h"
 #include "caml/memprof.h"
 
-#include "../../runtime/sync_posix.h"
-
 /* "caml/threads.h" is *not* included since it contains the _external_
    declarations for the caml_c_thread_register and caml_c_thread_unregister
    functions. */
@@ -494,7 +492,7 @@ static void caml_thread_domain_initialize_hook(void)
   st_initialize();
 
   int ret = st_masterlock_init(Thread_lock(Caml_state->id));
-  sync_check_error(ret, "caml_thread_domain_initialize_hook");
+  caml_check_error(ret, "caml_thread_domain_initialize_hook");
 
   new_thread =
     (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
@@ -678,7 +676,7 @@ CAMLprim value caml_thread_new(value clos)
      Because of PR#4666, we start the tick thread late, only when we create
      the first additional thread in the current process */
   st_retcode err = create_tick_thread();
-  sync_check_error(err, "Thread.create");
+  caml_check_error(err, "Thread.create");
 
   /* Create a thread info block */
   caml_thread_t th = thread_alloc_and_add();
@@ -690,7 +688,7 @@ CAMLprim value caml_thread_new(value clos)
   if (err != 0) {
     /* Creation failed, remove thread info block from list of threads */
     caml_thread_remove_and_free(th);
-    sync_check_error(err, "Thread.create");
+    caml_check_error(err, "Thread.create");
   }
 
   CAMLreturn(th->descr);
@@ -818,7 +816,7 @@ CAMLprim value caml_thread_yield(value unit)
 CAMLprim value caml_thread_join(value th)
 {
   st_retcode rc = caml_threadstatus_wait(Terminated(th));
-  sync_check_error(rc, "Thread.join");
+  caml_check_error(rc, "Thread.join");
   return Val_unit;
 }
 
@@ -853,7 +851,7 @@ static value caml_threadstatus_new (void)
 {
   st_event ts = NULL;           /* suppress warning */
   value wrapper;
-  sync_check_error(st_event_create(&ts), "Thread.create");
+  caml_check_error(st_event_create(&ts), "Thread.create");
   wrapper = caml_alloc_custom(&caml_threadstatus_ops,
                               sizeof(st_event *),
                               0, 1);

--- a/otherlibs/systhreads/st_stubs.h
+++ b/otherlibs/systhreads/st_stubs.h
@@ -1,0 +1,80 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*          Xavier Leroy and Damien Doligez, INRIA Rocquencourt           */
+/*                                                                        */
+/*   Copyright 2009 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+typedef int st_retcode;
+
+/* Variables used to stop "tick" threads */
+static atomic_uintnat tick_thread_stop[Max_domains];
+#define Tick_thread_stop tick_thread_stop[Caml_state->id]
+
+/* OS-specific initialization */
+
+static int st_initialize(void)
+{
+  atomic_store_release(&Tick_thread_stop, 0);
+  return 0;
+}
+
+static uintnat st_masterlock_waiters(st_masterlock * m)
+{
+  return atomic_load_acquire(&m->waiters);
+}
+
+static void st_bt_lock_acquire(st_masterlock *m) {
+
+  /* We do not want to signal the backup thread if it is not "working"
+     as it may very well not be, because we could have just resumed
+     execution from another thread right away. */
+  if (caml_bt_is_in_blocking_section()) {
+    caml_bt_enter_ocaml();
+  }
+
+  caml_acquire_domain_lock();
+
+  return;
+}
+
+static void st_bt_lock_release(st_masterlock *m) {
+
+  /* Here we do want to signal the backup thread iff there's
+     no thread waiting to be scheduled, and the backup thread is currently
+     idle. */
+  if (st_masterlock_waiters(m) == 0 &&
+      caml_bt_is_in_blocking_section() == 0) {
+    caml_bt_exit_ocaml();
+  }
+
+  caml_release_domain_lock();
+
+  return;
+}
+
+/* The tick thread: interrupt the domain periodically to force preemption  */
+
+static void * caml_thread_tick(void * arg)
+{
+  int *domain_id = (int *) arg;
+
+  caml_init_domain_self(*domain_id);
+  caml_domain_state *domain = Caml_state;
+
+  while(! atomic_load_acquire(&Tick_thread_stop)) {
+    st_msleep(Thread_timeout);
+
+    atomic_store_release(&domain->requested_external_interrupt, 1);
+    caml_interrupt_self();
+  }
+  return NULL;
+}

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -397,7 +397,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_plat_lock_blocking(&named_value_lock); // FIXME
+  caml_plat_lock_non_blocking(&named_value_lock);
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
       caml_modify_generational_global_root(&nv->val, val);
@@ -421,7 +421,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
 CAMLexport const value* caml_named_value(char const *name)
 {
   struct named_value * nv;
-  caml_plat_lock_blocking(&named_value_lock); // FIXME
+  caml_plat_lock_non_blocking(&named_value_lock);
   for (nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
@@ -437,7 +437,7 @@ CAMLexport const value* caml_named_value(char const *name)
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
   int i;
-  caml_plat_lock_blocking(&named_value_lock); // FIXME
+  caml_plat_lock_non_blocking(&named_value_lock);
   for(i = 0; i < Named_value_size; i++){
     struct named_value * nv;
     for (nv = named_value_table[i]; nv != NULL; nv = nv->next) {

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -397,7 +397,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
   unsigned int h = hash_value_name(name);
   int found = 0;
 
-  caml_plat_lock_blocking(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock); // FIXME
   for (nv = named_value_table[h]; nv != NULL; nv = nv->next) {
     if (strcmp(name, nv->name) == 0) {
       caml_modify_generational_global_root(&nv->val, val);
@@ -421,7 +421,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
 CAMLexport const value* caml_named_value(char const *name)
 {
   struct named_value * nv;
-  caml_plat_lock_blocking(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock); // FIXME
   for (nv = named_value_table[hash_value_name(name)];
        nv != NULL;
        nv = nv->next) {
@@ -437,7 +437,7 @@ CAMLexport const value* caml_named_value(char const *name)
 CAMLexport void caml_iterate_named_values(caml_named_action f)
 {
   int i;
-  caml_plat_lock_blocking(&named_value_lock);
+  caml_plat_lock_blocking(&named_value_lock); // FIXME
   for(i = 0; i < Named_value_size; i++){
     struct named_value * nv;
     for (nv = named_value_table[i]; nv != NULL; nv = nv->next) {

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -81,7 +81,7 @@ CAMLextern void caml_release_domain_lock(void);
 
 /* These hooks are not modified after other domains are spawned. */
 CAMLextern void (*caml_atfork_hook)(void);
-CAMLextern void (*caml_domain_initialize_hook)(void);
+CAMLextern value (*caml_domain_initialize_hook_exn)(void);
 CAMLextern void (*caml_domain_stop_hook)(void);
 CAMLextern void (*caml_domain_external_interrupt_hook)(void);
 

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -73,6 +73,9 @@ struct caml_exception_context {
 
 int caml_is_special_exception(value exn);
 
+/* from runtime/sync.c */
+CAMLextern void caml_check_error(int err, char * msg);
+
 #endif /* CAML_INTERNALS */
 
 #ifdef __cplusplus

--- a/runtime/caml/fail.h
+++ b/runtime/caml/fail.h
@@ -75,6 +75,7 @@ int caml_is_special_exception(value exn);
 
 /* from runtime/sync.c */
 CAMLextern void caml_check_error(int err, char * msg);
+CAMLextern value caml_check_error_exn(int err, char * msg);
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -63,8 +63,12 @@ struct channel {
 
 enum {
   CHANNEL_FLAG_FROM_SOCKET = 1,  /* For Windows */
-  CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization */
-  CHANNEL_TEXT_MODE = 8,           /* "Text mode" for Windows and Cygwin */
+  CHANNEL_FLAG_MANAGED_BY_GC = 4,  /* Free and close using GC finalization. */
+  /* Note: For backwards-compatibility, channels without the flag
+     CHANNEL_FLAG_MANAGED_BY_GC can be used inside single-threaded
+     programs without locking, but using such a channel from an
+     asynchronous callback can result in deadlocks. */
+  CHANNEL_TEXT_MODE = 8, /* "Text mode" for Windows and Cygwin */
   CHANNEL_FLAG_UNBUFFERED = 16     /* Unbuffered (for output channels only) */
 };
 

--- a/runtime/caml/sync.h
+++ b/runtime/caml/sync.h
@@ -34,9 +34,6 @@ typedef caml_plat_cond * sync_condvar;
 #define Mutex_val(v) (* ((sync_mutex *) Data_custom_val(v)))
 #define Condition_val(v) (* (sync_condvar *) Data_custom_val(v))
 
-CAMLextern int caml_mutex_lock(sync_mutex mut);
-CAMLextern int caml_mutex_unlock(sync_mutex mut);
-
 value caml_ml_mutex_lock(value wrapper);
 value caml_ml_mutex_unlock(value wrapper);
 value caml_ml_condition_broadcast(value wrapper);

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -130,7 +130,13 @@ unsigned char *caml_digest_of_code_fragment(struct code_fragment *cf) {
   /* Note: this approach is a bit heavy-handed as we take a lock in
      all cases. It would be possible to take a lock only in the
      DIGEST_LATER case, which occurs at most once per fragment, by
-     using double-checked locking -- see #11791. */
+     using double-checked locking -- see #11791.
+
+     Note: we do not use [caml_plat_lock_non_blocking] because this is
+     called by intern.c and extern.c, both of which share state
+     between threads of the same domain. We expect the critical
+     sections to be short anyway.
+  */
   caml_plat_lock_blocking(&cf->mutex);
   {
     if (cf->digest_status == DIGEST_IGNORE) {

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -111,8 +111,8 @@ static_assert(
    When the main C-stack for a domain enters a blocking call,
    a 'backup thread' becomes responsible for servicing the STW
    sections on behalf of the domain. Care is needed to hand off duties
-   for servicing STW sections between the main pthread and the backup
-   pthread when caml_enter_blocking_section and
+   for servicing STW sections between the main thread and the backup
+   thread when caml_enter_blocking_section and
    caml_leave_blocking_section are called.
 
    When the state for the backup thread is BT_IN_BLOCKING_SECTION
@@ -124,26 +124,26 @@ static_assert(
            BT_INIT  <---------------------------------------+
               |                                             |
    (install_backup_thread_exn)                              |
-       [main pthread]                                       |
+        [main thread]                                       |
               |                                             |
               v                                             |
        BT_ENTERING_OCAML  <-----------------+               |
               |                             |               |
 (caml_enter_blocking_section)               |               |
-       [main pthread]                       |               |
+        [main thread]                       |               |
               |                             |               |
               |                             |               |
               |               (caml_leave_blocking_section) |
-              |                      [main pthread]         |
+              |                       [main thread]         |
               v                             |               |
     BT_IN_BLOCKING_SECTION  ----------------+               |
               |                                             |
      (domain_terminate)                                     |
-       [main pthread]                                       |
+        [main thread]                                       |
               |                                             |
               v                                             |
         BT_TERMINATE                               (backup_thread_func)
-              |                                      [backup pthread]
+              |                                      [backup thread]
               |                                             |
               +---------------------------------------------+
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -984,8 +984,8 @@ struct domain_ml_values {
 
 /* stdlib/domain.ml */
 #define Term_state(sync) (&Field(sync, 0))
-#define Term_mutex(sync) (&Field(sync, 1))
-#define Term_condition(sync) (&Field(sync, 2))
+#define Term_mutex(sync) (Mutex_val(Field(sync, 1)))
+#define Term_condition(sync) (Condition_val(Field(sync, 2)))
 
 static void init_domain_ml_values(struct domain_ml_values* ml_values,
                                   value callback, value term_sync)
@@ -1013,7 +1013,6 @@ struct domain_startup_params {
   enum domain_status status; /* in+out:
                                 parent and child synchronize on this value. */
   struct domain_ml_values* ml_values; /* in */
-  dom_internal* newdom; /* out */
   uintnat unique_id; /* out */
 };
 
@@ -1147,28 +1146,49 @@ CAMLexport _Atomic caml_timing_hook caml_domain_terminated_hook =
 
 static void domain_terminate(void);
 
-static value make_finished(caml_result result)
+static value make_finished(value res_or_exn)
 {
   CAMLparam0();
   CAMLlocal1(res);
-  res = caml_alloc_1(
-    (caml_result_is_exception(result) ?
-     1 /* Error */ :
-     0 /* Ok */),
-    result.data);
+  if (Is_exception_result(res_or_exn)) {
+    res = Extract_exception(res_or_exn);
+    /* [Error res] */
+    res = caml_alloc_1(1, res);
+  } else {
+    /* [Ok res_of_exn] */
+    res = caml_alloc_1(0, res_or_exn);
+  }
   /* [Finished res] */
   res = caml_alloc_1(0, res);
   CAMLreturn(res);
 }
 
+static void handshake_success(struct domain_startup_params *p)
+{
+  caml_plat_lock_blocking(&p->parent->interruptor.lock);
+  p->status = Dom_started;
+  p->unique_id = domain_self->interruptor.unique_id;
+  caml_plat_broadcast(&p->parent->interruptor.cond);
+  caml_plat_unlock(&p->parent->interruptor.lock);
+}
+
+static void handshake_failure(struct domain_startup_params *p)
+{
+  caml_plat_lock_blocking(&p->parent->interruptor.lock);
+  p->status = Dom_failed;
+  caml_plat_broadcast(&p->parent->interruptor.cond);
+  caml_plat_unlock(&p->parent->interruptor.lock);
+  caml_gc_log("Failed to create domain");
+}
+
+/* Synchronize with joining domains. */
 static void sync_result(value term_sync, value res)
 {
   CAMLparam2(term_sync, res);
-  /* Synchronize with joining domains. We call [caml_ml_mutex_lock]
-     because the systhreads are still running on this domain. We
-     assume this does not fail the exception it would raise at this
-     point would be bad for us. */
-  caml_ml_mutex_lock(*Term_mutex(term_sync));
+  /* We only call functions that do not raise exceptions, as this
+     would be bad for us at this point. */
+  /* To avoid deadlocks, we must not block. */
+  caml_plat_lock_non_blocking(Term_mutex(term_sync));
 
   /* Store result */
   volatile value *state = Term_state(term_sync);
@@ -1176,85 +1196,97 @@ static void sync_result(value term_sync, value res)
   caml_modify(state, res);
 
   /* Signal all the waiting domains to be woken up */
-  caml_ml_condition_broadcast(*Term_condition(term_sync));
+  caml_plat_broadcast(Term_condition(term_sync));
 
-  /* The mutex is unlocked in the runtime after the cleanup
-     functions are finished. */
+  /* The mutex is unlocked after the domain is destroyed; we must
+     release the local roots before this. */
   CAMLreturn0;
 }
 
 static void* domain_thread_func(void* v)
 {
-  struct domain_startup_params* p = v;
-  struct domain_ml_values *ml_values = p->ml_values;
+#ifndef _WIN32
+  void *signal_stack;
+#endif
+  struct domain_ml_values *ml_values;
+  value res;
+
+  /* Create domain and do handshake with parent */
+
+  {
+    struct domain_startup_params *p = v;
+    ml_values = p->ml_values;
+    /* This thread now owns ml_values */
 
 #ifndef _WIN32
-  void * signal_stack = caml_init_signal_stack();
-  if (signal_stack == NULL) {
-    caml_fatal_error("Failed to create domain: signal stack");
-  }
+    signal_stack = caml_init_signal_stack();
+    if (signal_stack == NULL) {
+      handshake_failure(p);
+      goto out1;
+    }
 #endif
 
-  domain_create(caml_params->init_minor_heap_wsz, p->parent->state);
+    domain_create(caml_params->init_minor_heap_wsz, p->parent->state);
+    if (domain_self == NULL) {
+      handshake_failure(p);
+      goto out2;
+    }
 
-  /* this domain is now part of the STW participant set */
-  p->newdom = domain_self;
+    /* This domain is now part of the STW participant set */
 
-  /* handshake with the parent domain */
-  caml_plat_lock_blocking(&p->parent->interruptor.lock);
-  if (domain_self) {
-    p->status = Dom_started;
-    p->unique_id = domain_self->interruptor.unique_id;
-  } else {
-    p->status = Dom_failed;
+    handshake_success(p);
+
+    /* p can no longer be accessed. */
   }
-  caml_plat_broadcast(&p->parent->interruptor.cond);
-  caml_plat_unlock(&p->parent->interruptor.lock);
-  /* Cannot access p below here. */
 
-  if (domain_self) {
-    install_backup_thread_exn(domain_self);
+  res = install_backup_thread_exn(domain_self);
+  if (Is_exception_result(res)) goto terminate_domain;
 
-    caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
-                domain_self->interruptor.unique_id);
-    CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
-    /* FIXME: ignoring errors during domain initialization is unsafe
-       and/or can deadlock. */
-    caml_domain_initialize_hook_exn();
+  caml_gc_log("Domain starting (unique_id = %"ARCH_INTNAT_PRINTF_FORMAT"u)",
+              domain_self->interruptor.unique_id);
+  CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
 
-    /* release callback early;
-       see the [note about callbacks and GC] in callback.c */
-    value unrooted_callback = ml_values->callback;
-    caml_modify_generational_global_root(&ml_values->callback, Val_unit);
-    value res =
-      make_finished(caml_callback_res(unrooted_callback, Val_unit));
-    sync_result(ml_values->term_sync, res);
+  res = caml_domain_initialize_hook_exn();
+  if (Is_exception_result(res)) goto terminate_domain;
 
-    sync_mutex mut = Mutex_val(*Term_mutex(ml_values->term_sync));
-    domain_terminate();
+  /* release callback early;
+     see the [note about callbacks and GC] in callback.c */
+  value unrooted_callback = ml_values->callback;
+  caml_modify_generational_global_root(&ml_values->callback, Val_unit);
+  res = caml_callback_exn(unrooted_callback, Val_unit);
+  /* fall through */
 
-    /* This domain currently holds [mut], and has signaled all the
-       waiting domains to be woken up. We unlock [mut] to release the
-       joining domains. The unlock is done after [domain_terminate] to
-       ensure that this domain has released all of its runtime state.
-       We call [caml_mutex_unlock] directly instead of
-       [caml_ml_mutex_unlock] because the domain no longer exists at
-       this point. */
-    caml_mutex_unlock(mut);
+ terminate_domain:
+  /* Allocate the result value. */
+  res = make_finished(res);
+  sync_result(ml_values->term_sync, res);
+  /* This domain currently holds [mut]; and it is kept alive by a
+     global root inside ml_values. */
+  caml_plat_mutex *mut = Term_mutex(ml_values->term_sync);
+  /* Join all systhreads on this domain and release runtime state. */
+  domain_terminate();
+  /* This domain has signaled all the waiting domains to be woken up.
+     We unlock [mut] to release the joining domains. The unlock is
+     done after [domain_terminate] to ensure that this domain has
+     released all of its runtime state. We call [caml_plat_unlock]
+     because the domain no longer exists at this point. */
+  caml_plat_unlock(mut);
+  caml_plat_assert_all_locks_unlocked();
 
-    /* [ml_values] must be freed after unlocking [mut]. This ensures
-       that [term_sync] is only removed from the root set after [mut]
-       is unlocked. Otherwise, there is a risk of [mut] being
-       destroyed by [caml_mutex_finalize] finaliser while it remains
-       locked, leading to undefined behaviour. */
-    free_domain_ml_values(ml_values);
-  } else {
-    caml_gc_log("Failed to create domain");
-  }
+  /* fall through */
+
+ out2:
 #ifndef _WIN32
   caml_free_signal_stack(signal_stack);
 #endif
-  return 0;
+ out1:
+  /* [ml_values] must be freed after unlocking [mut]. This ensures
+     that [term_sync] is only removed from the root set after [mut] is
+     unlocked. Otherwise, there is a risk of [mut] being destroyed by
+     [caml_mutex_finalize] finaliser while it remains locked, leading
+     to undefined behaviour. */
+  free_domain_ml_values(ml_values);
+  return NULL;
 }
 
 CAMLprim value caml_domain_spawn(value callback, value term_sync)
@@ -1284,13 +1316,16 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
-
   if (err) {
+    free_domain_ml_values(p.ml_values);
     caml_check_error(err, "failed to create domain thread : pthread_create");
   }
 
-  /* While waiting for the child thread to start up, we need to service any
-     stop-the-world requests as they come in. */
+  /* p.ml_values is now owned by the new domain */
+
+  /* Handshake with the new domain. While waiting for the child thread
+     to start up, we need to service any stop-the-world requests as
+     they come in. */
   struct interruptor *interruptor = &domain_self->interruptor;
   caml_plat_lock_blocking(&interruptor->lock);
   while (p.status == Dom_starting) {
@@ -1305,14 +1340,12 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   caml_plat_unlock(&interruptor->lock);
 
   if (p.status == Dom_started) {
-    /* successfully created a domain.
-       p.ml_values is now owned by that domain */
+    /* successfully created a domain */
     pthread_detach(th);
   } else {
     CAMLassert (p.status == Dom_failed);
     /* failed */
     pthread_join(th, 0);
-    free_domain_ml_values(p.ml_values);
     caml_failwith("failed to allocate domain");
   }
 
@@ -2094,7 +2127,6 @@ static void domain_terminate (void)
   caml_plat_signal(&domain_self->domain_cond);
   caml_plat_unlock(&domain_self->domain_lock);
 
-  caml_plat_assert_all_locks_unlocked();
   /* This is the last thing we do because we need to be able to rely
      on caml_domain_alone (which uses caml_num_domains_running) in at least
      the shared_heap lockfree fast paths */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1117,9 +1117,9 @@ static void install_backup_thread (dom_internal* di)
   }
 }
 
-static void caml_domain_initialize_default(void)
+static value caml_domain_initialize_default_exn(void)
 {
-  return;
+  return Val_unit;
 }
 
 static void caml_domain_stop_default(void)
@@ -1132,8 +1132,8 @@ static void caml_domain_external_interrupt_hook_default(void)
   return;
 }
 
-CAMLexport void (*caml_domain_initialize_hook)(void) =
-   caml_domain_initialize_default;
+CAMLexport value (*caml_domain_initialize_hook_exn)(void) =
+   caml_domain_initialize_default_exn;
 
 CAMLexport void (*caml_domain_stop_hook)(void) =
    caml_domain_stop_default;
@@ -1219,7 +1219,7 @@ static void* domain_thread_func(void* v)
     CAML_EV_LIFECYCLE(EV_DOMAIN_SPAWN, getpid());
     /* FIXME: ignoring errors during domain initialization is unsafe
        and/or can deadlock. */
-    caml_domain_initialize_hook();
+    caml_domain_initialize_hook_exn();
 
     /* release callback early;
        see the [note about callbacks and GC] in callback.c */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1328,6 +1328,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   /* Handshake with the new domain. While waiting for the child thread
      to start up, we need to service any stop-the-world requests as
      they come in. */
+// TODO blocking section
   struct interruptor *interruptor = &domain_self->interruptor;
   caml_plat_lock_blocking(&interruptor->lock);
   while (p.status == Dom_starting) {
@@ -1336,10 +1337,10 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
       handle_incoming(interruptor);
       caml_plat_lock_blocking(&interruptor->lock);
     } else {
-      caml_plat_wait(&interruptor->cond, &interruptor->lock);
+      caml_plat_wait(&domain_self->interruptor.cond, &interruptor->lock);
     }
   }
-  caml_plat_unlock(&interruptor->lock);
+  caml_plat_unlock(&domain_self->interruptor.lock);
 
   if (p.status == Dom_started) {
     /* successfully created a domain */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -1110,8 +1110,8 @@ static void install_backup_thread (dom_internal* di)
     pthread_sigmask(SIG_SETMASK, &old_mask, NULL);
 #endif
 
-    if (err)
-      caml_failwith("failed to create domain backup thread");
+    if (err != 0)
+      caml_check_error(err, "failed to create domain backup thread");
     di->backup_thread_running = 1;
     pthread_detach(di->backup_thread);
   }
@@ -1278,7 +1278,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);
 
   if (err) {
-    caml_failwith("failed to create domain thread");
+    caml_check_error(err, "failed to create domain thread : pthread_create");
   }
 
   /* While waiting for the child thread to start up, we need to service any

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -237,7 +237,7 @@ static void add_frame_descriptors(
 
 /* protected by STW sections */
 static caml_frame_descrs current_frame_descrs =
-  { 0, -1, NULL, NULL, NULL, PTHREAD_MUTEX_INITIALIZER };
+  { 0, -1, NULL, NULL, NULL, CAML_PLAT_MUTEX_INITIALIZER };
 
 static caml_frametable_list *cons(
   intnat *frametable, caml_frametable_list *tl)

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -82,8 +82,11 @@ void caml_reset_domain_alloc_stats(caml_domain_state *local)
 static caml_plat_mutex orphan_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static struct alloc_stats orphaned_alloc_stats = {0,};
 
-void caml_accum_orphan_alloc_stats(struct alloc_stats *acc) {
-  caml_plat_lock_blocking(&orphan_lock); // FIX threads?
+void caml_accum_orphan_alloc_stats(struct alloc_stats *acc)
+{
+  /* This is called from both the mutator and the collector, so we
+     cannot call caml_plat_lock_non_blocking. */
+  caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(acc, &orphaned_alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }
@@ -96,7 +99,9 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
   caml_reset_domain_alloc_stats(domain);
 
   /* push them into the orphan stats */
-  caml_plat_lock_blocking(&orphan_lock); // FIX threads?
+  /* This is called from both the mutator and the collector, so we
+     cannot call caml_plat_lock_non_blocking. */
+  caml_plat_lock_blocking(&orphan_lock);
   caml_accum_alloc_stats(&orphaned_alloc_stats, &alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -83,7 +83,7 @@ static caml_plat_mutex orphan_lock = CAML_PLAT_MUTEX_INITIALIZER;
 static struct alloc_stats orphaned_alloc_stats = {0,};
 
 void caml_accum_orphan_alloc_stats(struct alloc_stats *acc) {
-  caml_plat_lock_blocking(&orphan_lock);
+  caml_plat_lock_blocking(&orphan_lock); // FIX threads?
   caml_accum_alloc_stats(acc, &orphaned_alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }
@@ -96,7 +96,7 @@ void caml_orphan_alloc_stats(caml_domain_state *domain) {
   caml_reset_domain_alloc_stats(domain);
 
   /* push them into the orphan stats */
-  caml_plat_lock_blocking(&orphan_lock);
+  caml_plat_lock_blocking(&orphan_lock); // FIX threads?
   caml_accum_alloc_stats(&orphaned_alloc_stats, &alloc_stats);
   caml_plat_unlock(&orphan_lock);
 }

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -58,6 +58,7 @@ Caml_inline void caml_insert_global_root(struct skiplist * list, value * r)
 
 Caml_inline void caml_delete_global_root(struct skiplist * list, value * r)
 {
+  /* This can be called without holding the domain lock */
   caml_plat_lock_blocking(&roots_mutex);
   caml_skiplist_remove(list, (uintnat) r);
   caml_plat_unlock(&roots_mutex);

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -122,10 +122,7 @@ static void check_pending(struct channel *channel)
        while any signal handlers (or finalisers, etc) are running.
        Don't do this for channels allocated and used from C,
        as their locks may or may not be taken depending on the
-       usage pattern in the C code.
-
-       FIXME?
-    */
+       usage pattern in the C code. */
     if (channel->flags & CHANNEL_FLAG_MANAGED_BY_GC)
       caml_channel_unlock(channel);
     caml_process_pending_actions();

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -560,7 +560,7 @@ void caml_finalize_channel(value vchan)
   }
   /* Don't run concurrently with caml_ml_out_channels_list that may resurrect
      a dead channel . */
-  caml_plat_lock_blocking(&caml_all_opened_channels_mutex); //FIXME threads?
+  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
   chan->refcount --;
   if (chan->refcount > 0 || notflushed) {
     /* We need to keep the channel around, either because it is being
@@ -613,7 +613,7 @@ CAMLprim value caml_ml_open_descriptor_in_with_flags(int fd, int flags)
   struct channel * chan = caml_open_descriptor_in(fd);
   chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
-  caml_plat_lock_blocking(&caml_all_opened_channels_mutex); //FIXME threads?
+  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
@@ -628,7 +628,7 @@ CAMLprim value caml_ml_open_descriptor_out_with_flags(int fd, int flags)
   struct channel * chan = caml_open_descriptor_out(fd);
   chan->flags |= flags | CHANNEL_FLAG_MANAGED_BY_GC;
   chan->refcount = 1;
-  caml_plat_lock_blocking(&caml_all_opened_channels_mutex); //FIXME threads?
+  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
   link_channel (chan);
   caml_plat_unlock (&caml_all_opened_channels_mutex);
   return caml_alloc_channel(chan);
@@ -665,7 +665,7 @@ CAMLprim value caml_ml_out_channels_list (value unit)
   struct channel_list *channel_list = NULL, *cl_tmp;
   mlsize_t i, num_channels = 0;
 
-  caml_plat_lock_blocking(&caml_all_opened_channels_mutex); //FIXME threads?
+  caml_plat_lock_non_blocking(&caml_all_opened_channels_mutex);
   for (channel = caml_all_opened_channels;
        channel != NULL;
        channel = channel->next) {

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -79,7 +79,9 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 #endif
 }
 
+#ifdef DEBUG
 CAMLexport CAMLthread_local int caml_lockdepth = 0;
+#endif
 
 void caml_plat_assert_all_locks_unlocked(void)
 {

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -87,7 +87,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
   value wrapper;
 
   caml_check_error(sync_mutex_create(&mut), "Mutex.create");
-  wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(pthread_mutex_t *),
+  wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(sync_mutex *),
                               0, 1);
   Mutex_val(wrapper) = mut;
   return wrapper;

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -96,7 +96,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
 CAMLprim value caml_ml_mutex_lock(value wrapper)
 {
   CAMLparam1(wrapper);
-  sync_retcode retcode;
+  int retcode;
   sync_mutex mut = Mutex_val(wrapper);
 
   /* PR#4351: first try to acquire mutex without releasing the master lock */
@@ -112,7 +112,7 @@ CAMLprim value caml_ml_mutex_lock(value wrapper)
 
 CAMLprim value caml_ml_mutex_unlock(value wrapper)
 {
-  sync_retcode retcode;
+  int retcode;
   sync_mutex mut = Mutex_val(wrapper);
   /* PR#4351: no need to release and reacquire master lock */
   retcode = sync_mutex_unlock(mut);
@@ -123,7 +123,7 @@ CAMLprim value caml_ml_mutex_unlock(value wrapper)
 CAMLprim value caml_ml_mutex_try_lock(value wrapper)
 {
   sync_mutex mut = Mutex_val(wrapper);
-  sync_retcode retcode;
+  int retcode;
   retcode = sync_mutex_trylock(mut);
   if (retcode == MUTEX_ALREADY_LOCKED) return Val_false;
   caml_check_error(retcode, "Mutex.try_lock");
@@ -177,7 +177,7 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   CAMLparam2(wcond, wmut);
   sync_condvar cond = Condition_val(wcond);
   sync_mutex mut = Mutex_val(wmut);
-  sync_retcode retcode;
+  int retcode;
 
   CAML_EV_BEGIN(EV_DOMAIN_CONDITION_WAIT);
   caml_enter_blocking_section();

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -31,8 +31,15 @@
 
 CAMLexport void caml_check_error(int retcode, char * msg)
 {
-  return sync_check_error(retcode, msg);
+  value res = sync_check_error_exn(retcode, msg);
+  if (Is_exception_result(res)) caml_raise(Extract_exception(res));
 }
+
+CAMLexport value caml_check_error_exn(int retcode, char * msg)
+{
+  return sync_check_error_exn(retcode, msg);
+}
+
 
 /* Mutex operations */
 

--- a/runtime/sync.c
+++ b/runtime/sync.c
@@ -29,6 +29,11 @@
 /* System-dependent part */
 #include "sync_posix.h"
 
+CAMLexport void caml_check_error(int retcode, char * msg)
+{
+  return sync_check_error(retcode, msg);
+}
+
 /* Mutex operations */
 
 static void caml_mutex_finalize(value wrapper)
@@ -74,7 +79,7 @@ CAMLprim value caml_ml_mutex_new(value unit)
   sync_mutex mut = NULL;
   value wrapper;
 
-  sync_check_error(sync_mutex_create(&mut), "Mutex.create");
+  caml_check_error(sync_mutex_create(&mut), "Mutex.create");
   wrapper = caml_alloc_custom(&caml_mutex_ops, sizeof(pthread_mutex_t *),
                               0, 1);
   Mutex_val(wrapper) = mut;
@@ -93,7 +98,7 @@ CAMLprim value caml_ml_mutex_lock(value wrapper)
     caml_enter_blocking_section();
     retcode = sync_mutex_lock(mut);
     caml_leave_blocking_section();
-    sync_check_error(retcode, "Mutex.lock");
+    caml_check_error(retcode, "Mutex.lock");
   }
   CAMLreturn(Val_unit);
 }
@@ -104,7 +109,7 @@ CAMLprim value caml_ml_mutex_unlock(value wrapper)
   sync_mutex mut = Mutex_val(wrapper);
   /* PR#4351: no need to release and reacquire master lock */
   retcode = sync_mutex_unlock(mut);
-  sync_check_error(retcode, "Mutex.unlock");
+  caml_check_error(retcode, "Mutex.unlock");
   return Val_unit;
 }
 
@@ -114,7 +119,7 @@ CAMLprim value caml_ml_mutex_try_lock(value wrapper)
   sync_retcode retcode;
   retcode = sync_mutex_trylock(mut);
   if (retcode == MUTEX_ALREADY_LOCKED) return Val_false;
-  sync_check_error(retcode, "Mutex.try_lock");
+  caml_check_error(retcode, "Mutex.try_lock");
   return Val_true;
 }
 
@@ -153,7 +158,7 @@ CAMLprim value caml_ml_condition_new(value unit)
   value wrapper;
   sync_condvar cond = NULL;
 
-  sync_check_error(sync_condvar_create(&cond), "Condition.create");
+  caml_check_error(sync_condvar_create(&cond), "Condition.create");
   wrapper = caml_alloc_custom(&caml_condition_ops, sizeof(sync_condvar *),
                               0, 1);
   Condition_val(wrapper) = cond;
@@ -171,7 +176,7 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
   caml_enter_blocking_section();
   retcode = sync_condvar_wait(cond, mut);
   caml_leave_blocking_section();
-  sync_check_error(retcode, "Condition.wait");
+  caml_check_error(retcode, "Condition.wait");
   CAML_EV_END(EV_DOMAIN_CONDITION_WAIT);
 
   CAMLreturn(Val_unit);
@@ -179,14 +184,14 @@ CAMLprim value caml_ml_condition_wait(value wcond, value wmut)
 
 CAMLprim value caml_ml_condition_signal(value wrapper)
 {
-  sync_check_error(sync_condvar_signal(Condition_val(wrapper)),
+  caml_check_error(sync_condvar_signal(Condition_val(wrapper)),
                  "Condition.signal");
   return Val_unit;
 }
 
 CAMLprim value caml_ml_condition_broadcast(value wrapper)
 {
-  sync_check_error(sync_condvar_broadcast(Condition_val(wrapper)),
+  caml_check_error(sync_condvar_broadcast(Condition_val(wrapper)),
                  "Condition.broadcast");
   return Val_unit;
 }

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -25,8 +25,6 @@
 
 #include "caml/sync.h"
 
-typedef int sync_retcode;
-
 /* Mutexes */
 
 Caml_inline int sync_mutex_create(sync_mutex * res)

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -118,23 +118,21 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 
 /* Reporting errors */
 
-static void sync_check_error(int retcode, char * msg)
+static value sync_check_error_exn(int retcode, char * msg)
 {
-  char * err;
-  char buf[1024];
-  int errlen, msglen;
-  value str;
+  if (retcode == 0) return Val_unit;
+  if (retcode == ENOMEM)
+    return Make_exception_result(caml_exception_out_of_memory());
 
-  if (retcode == 0) return;
-  if (retcode == ENOMEM) caml_raise_out_of_memory();
-  err = caml_strerror(retcode, buf, sizeof(buf));
-  msglen = strlen(msg);
-  errlen = strlen(err);
-  str = caml_alloc_string(msglen + 2 + errlen);
+  char buf[1024];
+  char * err = caml_strerror(retcode, buf, sizeof(buf));
+  int msglen = strlen(msg);
+  int errlen = strlen(err);
+  value str = caml_alloc_string(msglen + 2 + errlen);
   memcpy (&Byte(str, 0), msg, msglen);
   memcpy (&Byte(str, msglen), ": ", 2);
   memcpy (&Byte(str, msglen + 2), err, errlen);
-  caml_raise_sys_error(str);
+  return Make_exception_result(caml_exception_sys_error(str));
 }
 
 #endif /* CAML_SYNC_POSIX_H */

--- a/stdlib/domain.ml
+++ b/stdlib/domain.ml
@@ -252,7 +252,8 @@ let spawn f =
   do_before_first_spawn ();
   let pk = DLS.get_initial_keys () in
 
-  (* [term_sync] is used to synchronize with the joining domains *)
+  (* [term_sync] is used to synchronize with the joining domains.
+     Accessed from C code: runtime/domain.c. *)
   let term_sync =
     Raw.{ state = Running ;
           mut = Mutex.create () ;


### PR DESCRIPTION
The goal is to remove winpthreads (a library emulating pthreads on top of _old_ Windows APIs), and use _modern_ Windows APIs in both the MSVC and MinGW-w64 ports.
To do so, I've prepared a preliminary PR consisting of refactors and cleanups. It's mainly about extracting code using pthreads to system-specific files, and sharing code that doesn't use pthreads directly.
This preliminary PR should also show that my changes are sound, before abandoning winpthreads.