### PR TITLE
Silence cl output when building executables without flexlink

### DIFF
--- a/configure
+++ b/configure
@@ -14571,7 +14571,7 @@ esac
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_ldflags_prefix='-link '
-    mkexe_via_cc_ldflags_prefix='/link '
+    mkexe_via_cc_ldflags_prefix='/nologo /link '
     oc_exe_ldflags='/ENTRY:wmainCRTStartup'
     mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
     mkexedebugflag='' ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -1057,7 +1057,7 @@ AS_CASE([$ocaml_cc_vendor,$host],
     mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_cmd="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
     mkexe_ldflags_prefix='-link '
-    mkexe_via_cc_ldflags_prefix='/link '
+    mkexe_via_cc_ldflags_prefix='/nologo /link '
     oc_exe_ldflags='/ENTRY:wmainCRTStartup'
     mkexe_extra_flags="$mkexe_ldflags_prefix$oc_exe_ldflags"
     mkexedebugflag=''],


### PR DESCRIPTION
PR#13200 stopped passing `CLFAGS` to the linker. The `CFLAGS` contained
`/nologo`, which silences the compiler. Add it back for a quieter build.

Piggy-backing a small cosmetic fix, use - (dash) style parameters for MSVC.

No change entry needed.