### PR TITLE
Clarify barriers and spin macros with delayed expansion

### DIFF
--- a/otherlibs/unix/channels_win32.c
+++ b/otherlibs/unix/channels_win32.c
@@ -21,6 +21,7 @@
 #include <caml/memory.h>
 #include <caml/platform.h>
 #include "caml/unixsupport.h"
+#include <stdbool.h>
 #include <fcntl.h>
 #include <io.h>
 #include <errno.h>

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -221,15 +221,15 @@ void caml_global_barrier_release_as_final(barrier_status status);
  */
 #define Caml_global_barrier_if_final_(alone, b, go, num_participating)  \
   /* fast path when alone */                                            \
-  int alone = (num_participating) == 1;                                 \
+  bool alone = (num_participating) == 1;                                \
   barrier_status b = 0;                                                 \
   if (alone ||                                                          \
       (b = caml_global_barrier_and_check_final(num_participating)))     \
-    for (int go = 1; go;                                                \
+    for (bool go = true; go;                                            \
          /* release the barrier after the body has executed once */     \
          (alone ? (void)0 :                                             \
           caml_global_barrier_release_as_final(b)),                     \
-         go = 0)
+         go = false)
 
 #define Caml_global_barrier_if_final(num_participating)                \
   Caml_global_barrier_if_final_(CAML_GENSYM(alone), CAML_GENSYM(b),    \

--- a/runtime/caml/domain.h
+++ b/runtime/caml/domain.h
@@ -219,18 +219,21 @@ void caml_global_barrier_release_as_final(barrier_status status);
    Note: this expands to an [if] and [for] header, do not exit the body using
    jumps or returns, and do not put an [else] immediately after.
  */
-#define Caml_global_barrier_if_final(num_participating)                 \
+#define Caml_global_barrier_if_final_(alone, b, go, num_participating)  \
   /* fast path when alone */                                            \
-  int CAML_GENSYM(alone) = (num_participating) == 1;                    \
-  barrier_status CAML_GENSYM(b) = 0;                                    \
-  if (CAML_GENSYM(alone) ||                                             \
-      (CAML_GENSYM(b)                                                   \
-       = caml_global_barrier_and_check_final(num_participating)))       \
-    for (int CAML_GENSYM(continue) = 1; CAML_GENSYM(continue);          \
+  int alone = (num_participating) == 1;                                 \
+  barrier_status b = 0;                                                 \
+  if (alone ||                                                          \
+      (b = caml_global_barrier_and_check_final(num_participating)))     \
+    for (int go = 1; go;                                                \
          /* release the barrier after the body has executed once */     \
-         ((CAML_GENSYM(alone) ? (void)0 :                               \
-           caml_global_barrier_release_as_final(CAML_GENSYM(b))),       \
-          CAML_GENSYM(continue) = 0))
+         (alone ? (void)0 :                                             \
+          caml_global_barrier_release_as_final(b)),                     \
+         go = 0)
+
+#define Caml_global_barrier_if_final(num_participating)                \
+  Caml_global_barrier_if_final_(CAML_GENSYM(alone), CAML_GENSYM(b),    \
+                                CAML_GENSYM(go), num_participating)
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -608,10 +608,10 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #  endif
 #endif
 
-/* Generate a named symbol that is unique within the current macro expansion */
-#define CAML_GENSYM_3(name, l) caml__##name##_##l
-#define CAML_GENSYM_2(name, l) CAML_GENSYM_3(name, l)
-#define CAML_GENSYM(name) CAML_GENSYM_2(name, __LINE__)
+/* Generate a named symbol that is unique */
+#define CAML_GENSYM__(name, id) caml__##name##_##id
+#define CAML_GENSYM_(name, id) CAML_GENSYM__(name, id)
+#define CAML_GENSYM(name) CAML_GENSYM_(name, __COUNTER__)
 
 #endif /* CAML_INTERNALS */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -421,7 +421,7 @@ Caml_inline unsigned caml_plat_spin_step(unsigned spins,
   static const struct caml_plat_srcloc loc =                    \
     { __FILE__, __LINE__, __func__ };                           \
   for (unsigned int spins = 0, max_spins = (N);                 \
-       1;                                                       \
+       true;                                                    \
        spins = caml_plat_spin_step(spins, max_spins, &loc))
 
 #define SPIN_WAIT_BACK_OFF(N)                                           \

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -17,6 +17,7 @@
 
 /* Operations on objects */
 
+#include <stdbool.h>
 #include <string.h>
 #include "caml/camlatomic.h"
 #include "caml/alloc.h"

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <stdbool.h>
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
Using delayed macro expansion to generate the identifiers, it's possible to simplify the code content of the macros.

Use `__COUNTER__`, which expands to sequential integral values starting from 0, to avoid conflicts. `__COUNTER__` is documented by GCC, clang, MSVC, and xlc, but what of Sun C?

Also reduce the scope of for loop iterators, and use C99 booleans.