### PR TITLE
Enable software prefetching on MSVC and clang-cl

### DIFF
--- a/Changes
+++ b/Changes
@@ -87,6 +87,10 @@ _______________
   (Antonin Décimo, review by Nick Barnes, Xavier Leroy, Gabriel Scherer,
    and Miod Vallat)
 
+- #?????: Enable software prefetching on x86 and x86_64 when building
+  with MSVC or clang-cl.
+  (Antonin Décimo, review by ????)
+
 ### Code generation and optimizations:
 
 - #13014: Enable compile-time option -function-sections on all previously

--- a/release-info/News
+++ b/release-info/News
@@ -1,3 +1,63 @@
+OCaml 5.2.0 (13 May 2024)
+------------------------
+
+OCaml 5.2.0 is still a somewhat experimental release compared to the OCaml 4.14
+branch. Some of the highlights in OCaml 5.2.0 are:
+
+- Re-introduced GC compaction
+- Restored native backend for POWER 64 bits
+- Thread sanitizer support
+- New Dynarray module
+- New -H flag for hidden include directories
+- Project-wide occurence metadata support for developer tools
+- Raw identifiers
+- Local open in type expressions
+
+And a lot of incremental changes:
+
+- Around 20 new functions in the standard library
+- Many fixes and improvements in the runtime
+- Many bug fixes
+
+OCaml 5.1.0 (14 September 2023)
+-------------------------------
+
+OCaml 5.1.0 is still a relatively experimental release compared to the OCaml
+4.14 branch. Some of the highlights in OCaml 5.1.0 are:
+
+-  Many runtime performance regression and memory-leaks fixes
+    (dynlinking, weak arrays, weak hash sets, GC with idle domains,
+     and GC prefetching).
+- Restored support for native code generation on RISC-V and s390x architectures.
+- Restored Cygwin port.
+- Reduced installation size (50% reduction)
+- Compressed compilation artefacts (.cmi, .cmt, .cmti, .cmo, .cma files)
+- 19 error message improvements
+- 14 standard library functions made tail-recursive
+  with Tail-Recursion-Modulo-Cons (TRMC), such as List.append and List.map.
+- 57 new standard library functions
+- More examples in the standard library documentation
+- 42 bug fixes
+
+
+OCaml 5.0.0 (15 December 2022)
+------------------------------
+
+OCaml 5.0.0 introduces a completely new runtime environment with support for
+shared memory parallelism and effect handlers.
+
+As a language, OCaml 5 is fully compatible with OCaml 4 down to the performance
+characteristics of your programs. In other words, any code that works with OCaml
+4 should work the same with OCaml 5.
+
+The currently known exceptions to this rule are:
+
+- the removal of many long-deprecated functions and modules
+- changes to the internal runtime API
+- the performance of ephemerons is currently (and temporarily) strongly
+  degraded.
+
+
 OCaml 4.14.0 (28 March 2022)
 ----------------------------
 

--- a/release-info/calendar.md
+++ b/release-info/calendar.md
@@ -1,0 +1,32 @@
+# Prospective release calendar
+
+This is a prospective calendar for the next releases of OCaml.
+
+This document is intended to give a very rough idea of the timeline for the next
+versions of OCaml to anyone interested. However, it would be an unforeseen
+accident if this prospective calendar ever matches the real release calendar.
+
+
+# Main versions
+
+## OCaml 5.3.0
+(Last updated on 29th May 2024)
+
+|    Phase              | Expected (early) | Expected (late) | Actual        |
+|-----------------------|------------------|-----------------|---------------|
+| Feature freeze        | 15 August 2024   | (same)          |               |
+| 1st beta release      | 10th September   | 15th October    |               |
+| 1st release candidate | 1st October      | 7th November    |               |
+| Release               | 7th October      | 21st November   |               |
+
+## OCaml 5.4.0
+
+|    Release            | Expected (early) | Expected (late)  | Actual      |
+|-----------------------|------------------|------------------|-------------|
+| Release               | April 2025       |  May 2025        |             |
+
+# LTS version
+
+## OCaml 4.14.3
+
+- release: after July 2024

--- a/release-info/howto.md
+++ b/release-info/howto.md
@@ -24,8 +24,8 @@ OCamlLabs folks (for OPAM testing).
 rm -f /tmp/env-$USER.sh
 cat >/tmp/env-$USER.sh <<EOF
 # Update the data below
-export MAJOR=4
-export MINOR=12
+export MAJOR=5
+export MINOR=2
 export BUGFIX=0
 export PLUSEXT=
 
@@ -35,7 +35,7 @@ export HUMAN=
 # do we need to use tar or gtar?
 export TAR=tar
 
-export WORKTREE=~/o/\$MAJOR.\$MINOR
+export WORKTREE=~/ocaml/\$MAJOR.\$MINOR
   # must be the git worktree for the branch you are releasing
 
 export BRANCH=\$MAJOR.\$MINOR
@@ -121,7 +121,7 @@ make tests
 ## 5: build, tag and push the new release
 
 ```
-# at this point, the VERSION file contains N+devD
+# at this point, the build-aux/ocaml_version.m4 file contains N+devD
 # increment it into N+dev(D+1); for example,
 #   4.07.0+dev8-2018-06-19 => 4.07.0+dev9-2018-06-26
 # for production releases: check and change the Changes header
@@ -129,10 +129,9 @@ make tests
 make -B configure
 git commit -a -m "last commit before tagging $VERSION"
 
-# update VERSION with the new release; for example,
+# update build-aux/ocaml_version.m4 with the new release; for example,
 #   4.07.0+dev9-2018-06-26 => 4.07.0+rc2
 # Update ocaml-variants.opam with new version.
-# Update \year in manual/src/macros.hva
 make -B configure
 # For a production release
 make coreboot -j5
@@ -140,13 +139,13 @@ make coreboot -j5 # must say "Fixpoint reached, bootstrap succeeded."
 git commit -m "release $VERSION" -a
 git tag -m "release $VERSION" $TAGVERSION
 
-# for production releases, change the VERSION file into (N+1)+dev0; for example,
+# for production releases, change the build-aux/ocaml_version.m4 file into (N+1)+dev0; for example,
 #   4.08.0 => 4.08.1+dev0
 # for testing candidates, use N+dev(D+2) instead; for example,
 #   4.07.0+rc2 => 4.07.0+dev10-2018-06-26
 # Revert ocaml-variants.opam to its "trunk" version.
 make -B configure
-git commit -m "increment version number after tagging $VERSION" VERSION configure ocaml-variants.opam
+git commit -m "increment version number after tagging $VERSION" build-aux/ocaml_version.m4 VERSION configure ocaml-variants.opam
 git push
 git push --tags
 ```
@@ -155,7 +154,7 @@ git push --tags
 
 This needs to be more tested, tread with care.
 ```
-# at this point, the VERSION file contains N+devD
+# at this point, the build-aux/ocaml_version.m4 file contains N+devD
 # increment it into N+dev(D+1); for example,
 #   4.07.0+dev0-2018-06-19 => 4.07.0+dev1-2018-06-26
 # Rename the "Working version" header in Changes
@@ -164,7 +163,7 @@ make -B configure
 git commit -a -m "last commit before branching $BRANCH"
 git branch $BRANCH
 
-# update VERSION with the new future branch,
+# update build-aux/ocaml_version.m4 with the new future branch,
 #   4.07.0+dev1-2018-06-26 => 4.08.0+dev0-2018-06-30
 # Update ocaml-variants.opam with new version.
 make -B configure
@@ -273,6 +272,7 @@ cd $WORKTREE
 TMPDIR=/tmp/ocaml-release
 git checkout $TAGVERSION
 git checkout-index -a -f --prefix=$TMPDIR/ocaml-$VERSION/
+git switch $BRANCH
 cd $TMPDIR
 $TAR -c --owner 0 --group 0 -f ocaml-$VERSION.tar ocaml-$VERSION
 gzip -9 <ocaml-$VERSION.tar >ocaml-$VERSION.tar.gz
@@ -345,8 +345,6 @@ it was a release candidate.
 ```
 cd $WORKTREE
 make
-make install
-export PATH="$INSTDIR/bin:$PATH"
 cd manual
 make clean
 make

--- a/release-info/introduction.md
+++ b/release-info/introduction.md
@@ -3,32 +3,32 @@
 OCaml releases follow a linux-like scheme for their version string. The
 OCaml version string consists in three numbers, optionally followed by
 either a prerelease or development tag
-(`%i.%i.%i[~alpha%i|~beta%i|~rc%i|+%s]`). For example, 4.14.1,
+(`%i.%i.%i[~alpha%i|~beta%i|~rc%i|+%s]`). For example, `4.14.1`,
 5.1.0~alpha2 and 5.3.0+dev0-2023-12-22 are valid OCaml versions.
 
-- The first version number (4 in 4.14.1) is the major version of OCaml.
+- The first version number (`4` in `4.14.1`) is the major version of OCaml.
   This version number is updated when major new features are added to the OCaml
   language. For instance, OCaml 5 added shared memory parallelism and effect
   handlers and OCaml 4 introduced GADTs (Generalised Abstract Data Types).
 
-- The second version number (14 in 4.14.1) is the minor version of OCaml.
+- The second version number (`14` in` 4.14.1`) is the minor version of OCaml.
   This number is increased for every new release of OCaml. In particular, a new
   minor version of OCaml can contain breaking changes. However, we strive to
   maintain backward compatibility as much as possible.
 
-- The last number (1 in 4.14.1) is the bugfix number.
+- The last number (`1` in `4.14.1`) is the bugfix number.
   Updating to the latest bugfix release is always safe, those bugfix versions
   are meant to be completely backward compatible and only contain important or
   very safe bug fixes.
 
-- The prerelease tag `~alpha%i`, `~beta%i`, `~rc%i` (~alpha2 in
-  5.1.0~alpha2) describes a prerelease version of the compiler that is
-  currently being tested. See [below](## Prerelease versions) for
+- The prerelease tag `~alpha%i`, `~beta%i`, `~rc%i` (`~alpha2` in
+  `5.1.0~alpha2`) describes a prerelease version of the compiler that is
+  currently being tested. See [below](#prerelease-versions) for
   a more thorough explanation.
 
 - The development tag `+tag` indicates a development or experimental version of
-  the compiler. +dev0-2023-12-22 in 5.3.0+dev0-2023-12-22 is an example of the
-  tags of the form +dev%i-%date used by the compiler for its development
+  the compiler. `+dev0-2023-12-22` in `5.3.0+dev0-2023-12-22` is an example of the
+  tags of the form `+dev%i-%date` used by the compiler for its development
   versions.
 
 
@@ -39,8 +39,8 @@ a new minor version of OCaml is released every six months.
 
 For instance, at the date of writing, the next planned releases of OCaml are:
 
-- OCaml 5.2: around April 2024
 - OCaml 5.3: around October 2024
+- OCaml 5.4: around April 2025
 
 The timing is approximate, as we often delay a release to ensure quality when
 unforeseen issues come up. In consequence, releases are often late, typically by
@@ -68,7 +68,7 @@ regressions coming from last-minute changes. Only bugfixes and documentation
 improvements go to the release branch -- by cherry-picking them from 'trunk'.
 
 We do not have the resources to maintain more than one dev branch, one prelease
-branch, and [one exceptional LTS branch](# Exceptional LTS versions).
+branch, and [one exceptional LTS branch](#Exceptional-LTS-versions).
 
 ### Example
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -178,9 +178,15 @@ CAMLdeprecated_typedef(addr, char *);
 /* Prefetching */
 
 #ifdef CAML_INTERNALS
-#if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+#if (__has_builtin(__builtin_prefetch) || defined(__GNUC__)) && \
+    (defined(__i386__) || defined(__x86_64__) || \
+     defined(_M_IX86) || defined(_M_AMD64))
 #define caml_prefetch(p) __builtin_prefetch((p), 1, 3)
 /* 1 = intent to write; 3 = all cache levels */
+#elif defined(_M_IX86) || defined(_M_AMD64)
+#include <intrin.h>
+#define caml_prefetch(p) _mm_prefetch((char const *) p, _MM_HINT_T0)
+/* PreFetchCacheLine(PF_TEMPORAL_LEVEL_1, p) */
 #else
 #define caml_prefetch(p)
 #endif

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -29,7 +29,7 @@
 
 #include "camlatomic.h"
 
-/* Detection of available C attributes */
+/* Detection of available C compiler extensions */
 
 #ifndef __has_c_attribute
 #define __has_c_attribute(x) 0
@@ -37,6 +37,10 @@
 
 #ifndef __has_attribute
 #define __has_attribute(x) 0
+#endif
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
 #endif
 
 /* Deprecation warnings */
@@ -328,14 +332,6 @@ CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
 #endif
 ;
 
-/* Detection of available C built-in functions, the Clang way. */
-
-#ifdef __has_builtin
-#define Caml_has_builtin(x) __has_builtin(x)
-#else
-#define Caml_has_builtin(x) 0
-#endif
-
 /* Integer arithmetic with overflow detection.
    The functions return 0 if no overflow, 1 if overflow.
    The result of the operation is always stored at [*res].
@@ -345,7 +341,7 @@ CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
 
 Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_add_overflow)
+#if __has_builtin(__builtin_add_overflow) || defined(__GNUC__) && __GNUC__ >= 5
   return __builtin_add_overflow(a, b, res);
 #else
   uintnat c = a + b;
@@ -356,7 +352,7 @@ Caml_inline int caml_uadd_overflow(uintnat a, uintnat b, uintnat * res)
 
 Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 {
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_sub_overflow)
+#if __has_builtin(__builtin_sub_overflow) || defined(__GNUC__) && __GNUC__ >= 5
   return __builtin_sub_overflow(a, b, res);
 #else
   uintnat c = a - b;
@@ -365,7 +361,7 @@ Caml_inline int caml_usub_overflow(uintnat a, uintnat b, uintnat * res)
 #endif
 }
 
-#if __GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow)
+#if __has_builtin(__builtin_mul_overflow) || defined(__GNUC__) && __GNUC__ >= 5
 Caml_inline int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
   return __builtin_mul_overflow(a, b, res);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -210,7 +210,8 @@ void caml_ext_table_free(struct ext_table * tbl, int free_entries)
 
 /* Integer arithmetic with overflow detection */
 
-#if ! (__GNUC__ >= 5 || Caml_has_builtin(__builtin_mul_overflow))
+#if ! (__has_builtin(__builtin_mul_overflow) || \
+       defined(__GNUC__) && __GNUC__ >= 5)
 CAMLexport int caml_umul_overflow(uintnat a, uintnat b, uintnat * res)
 {
 #define HALF_SIZE (sizeof(uintnat) * 4)


### PR DESCRIPTION
Both GCC and MSVC emit the `prefetcht0` instruction.
Prefer clang's builtin instead of the intrinsic.
With MSVC, call the intrinsic directly in order not to have to pull `winnt.h` via `windows.h` (for [`PreFetchCacheLine`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/nf-winnt-prefetchcacheline)).

https://godbolt.org/z/eKeaEzr5Y