### PR TITLE
Use C99 for loop to reduce the scope of the loop iterator

### DIFF
--- a/ocamltest/run_stubs.c
+++ b/ocamltest/run_stubs.c
@@ -36,11 +36,11 @@
 static array cstringvect(value arg)
 {
   array res;
-  mlsize_t size, i;
+  mlsize_t size;
 
   size = Wosize_val(arg);
   res = (array) caml_stat_alloc((size + 1) * sizeof(char_os *));
-  for (i = 0; i < size; i++)
+  for (mlsize_t i = 0; i < size; i++)
     res[i] = caml_stat_strdup_to_os(String_val(Field(arg, i)));
   res[size] = NULL;
   return res;
@@ -48,8 +48,7 @@ static array cstringvect(value arg)
 
 static void free_cstringvect(array v)
 {
-  char_os **p;
-  for (p = v; *p != NULL; p++)
+  for (char_os **p = v; *p != NULL; p++)
     caml_stat_free(*p);
   caml_stat_free(v);
 }

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -135,8 +135,7 @@ static int paths_same_file(
 
 static void update_environment(array local_env)
 {
-  array envp;
-  for (envp = local_env; *envp != NULL; envp++) {
+  for (array envp = local_env; *envp != NULL; envp++) {
     char *pos_eq = strchr(*envp, '=');
     if (pos_eq != NULL) {
       char *name, *value;

--- a/ocamltest/run_win32.c
+++ b/ocamltest/run_win32.c
@@ -111,7 +111,7 @@ static WCHAR *find_program(const WCHAR *program_name)
 
 static WCHAR *commandline_of_arguments(WCHAR **arguments)
 {
-  WCHAR *commandline = NULL, **arguments_p, *commandline_p;
+  WCHAR *commandline = NULL, *commandline_p;
   int args = 0; /* Number of arguments */
   int commandline_length = 0;
 
@@ -119,7 +119,7 @@ static WCHAR *commandline_of_arguments(WCHAR **arguments)
   /* From here we know there is at least one argument */
 
   /* First compute number of arguments and commandline length */
-  for (arguments_p = arguments; *arguments_p != NULL; arguments_p++)
+  for (WCHAR **arguments_p = arguments; *arguments_p != NULL; arguments_p++)
   {
     args++;
     commandline_length += wcslen(*arguments_p);
@@ -130,7 +130,7 @@ static WCHAR *commandline_of_arguments(WCHAR **arguments)
   commandline = malloc(commandline_length*sizeof(WCHAR));
   if (commandline == NULL) return NULL;
   commandline_p = commandline;
-  for (arguments_p = arguments; *arguments_p!=NULL; arguments_p++)
+  for (WCHAR **arguments_p = arguments; *arguments_p != NULL; arguments_p++)
   {
     int l = wcslen(*arguments_p);
     memcpy(commandline_p, *arguments_p, l*sizeof(WCHAR));
@@ -145,7 +145,6 @@ static WCHAR *commandline_of_arguments(WCHAR **arguments)
 static LPVOID prepare_environment(WCHAR **localenv)
 {
   LPTCH p, r, env, process_env = NULL;
-  WCHAR **q;
   int l, process_env_length, localenv_length, env_length;
 
   if (localenv == NULL) return NULL;
@@ -164,7 +163,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
 
   /* Compute length of local environment */
   localenv_length = 0;
-  for (q = localenv; *q != NULL; q++) {
+  for (WCHAR **q = localenv; *q != NULL; q++) {
     localenv_length += wcslen(*q) + 1;
   }
 
@@ -184,7 +183,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
     l = wcslen(p) + 1; /* also count terminating '\0' */
     /* Temporarily change the = to \0 for wcscmp */
     *pos_eq = L'\0';
-    for (q = localenv; *q != NULL; q++) {
+    for (WCHAR **q = localenv; *q != NULL; q++) {
       wchar_t *pos_eq2 = wcschr(*q, L'=');
       /* Compare this name in localenv with the current one in processenv */
       if (pos_eq2) *pos_eq2 = L'\0';
@@ -200,7 +199,7 @@ static LPVOID prepare_environment(WCHAR **localenv)
     p += l;
   }
   FreeEnvironmentStrings(process_env);
-  for (q = localenv; *q != NULL; q++) {
+  for (WCHAR **q = localenv; *q != NULL; q++) {
     /* A string in localenv without '=' signals deletion, which has been done */
     wchar_t *pos_eq = wcschr(*q, L'=');
     if (pos_eq) {

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -698,12 +698,10 @@ static int ml_alloc(int domain_id, void *callback_data, uint64_t timestamp,
 
   tmp_callback = Field(callbacks_root, 3); /* ev_alloc */
   if (Is_some(tmp_callback)) {
-    int i;
-
     ts_val = caml_copy_int64(timestamp);
     misc_val = caml_alloc(RUNTIME_EVENTS_NUM_ALLOC_BUCKETS, 0);
 
-    for (i = 0; i < RUNTIME_EVENTS_NUM_ALLOC_BUCKETS; i++) {
+    for (int i = 0; i < RUNTIME_EVENTS_NUM_ALLOC_BUCKETS; i++) {
       Store_field(misc_val, i, Val_long(sz[i]));
     }
 

--- a/otherlibs/str/strstubs.c
+++ b/otherlibs/str/strstubs.c
@@ -129,11 +129,10 @@ static value re_alloc_groups(value re, unsigned char * starttxt,
 {
   value res;
   int n = Numgroups(re);
-  int i;
   struct re_group * group;
 
   res = caml_alloc(n * 2, 0);
-  for (i = 0; i < n; i++) {
+  for (int i = 0; i < n; i++) {
     group = &(groups[i]);
     if (group->start == NULL || group->end == NULL) {
       Field(res, i * 2) = Val_int(-1);
@@ -281,9 +280,8 @@ static value re_match(value re,
     case REFGROUP: {
       int group_no = Arg(instr);
       struct re_group * group = &(groups[group_no]);
-      unsigned char * s;
       if (group->start == NULL || group->end == NULL) goto backtrack;
-      for (s = group->start; s < group->end; s++) {
+      for (unsigned char *s = group->start; s < group->end; s++) {
         if (txt == endtxt) goto prefix_match;
         if (*s != *txt) goto backtrack;
         txt++;

--- a/otherlibs/systhreads/st_posix.h
+++ b/otherlibs/systhreads/st_posix.h
@@ -46,11 +46,10 @@ static value st_encode_sigset(sigset_t * set)
 {
   CAMLparam0();
   CAMLlocal1(res);
-  int i;
 
   res = Val_emptylist;
 
-  for (i = 1; i < NSIG; i++)
+  for (int i = 1; i < NSIG; i++)
     if (sigismember(set, i) > 0) {
       res = caml_alloc_2(Tag_cons,
                          Val_int(caml_rev_convert_signal_number(i)), res);

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -422,7 +422,6 @@ static void caml_thread_reinitialize(void)
      are hopeless.)
   */
 
-  struct channel * chan;
   caml_thread_t th, next;
 
   th = Active_thread->next;
@@ -451,7 +450,7 @@ static void caml_thread_reinitialize(void)
   /* Reinitialize IO mutexes, in case the fork happened while another thread
      had locked the channel. If so, we're likely in an inconsistent state,
      but we may be able to proceed anyway. */
-  for (chan = caml_all_opened_channels;
+  for (struct channel *chan = caml_all_opened_channels;
        chan != NULL;
        chan = chan->next) {
     caml_plat_mutex_init(&chan->mutex);

--- a/otherlibs/unix/cst2constr.c
+++ b/otherlibs/unix/cst2constr.c
@@ -19,8 +19,7 @@
 
 value caml_unix_cst_to_constr(int n, const int *tbl, int size, int deflt)
 {
-  int i;
-  for (i = 0; i < size; i++)
+  for (int i = 0; i < size; i++)
     if (n == tbl[i]) return Val_int(i);
   return Val_int(deflt);
 }

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -24,14 +24,14 @@
 char_os ** caml_unix_cstringvect(value arg, char * cmdname)
 {
   char_os ** res;
-  mlsize_t size, i;
+  mlsize_t size;
 
   size = Wosize_val(arg);
-  for (i = 0; i < size; i++)
+  for (mlsize_t i = 0; i < size; i++)
     if (! caml_string_is_c_safe(Field(arg, i)))
       caml_unix_error(EINVAL, cmdname, Field(arg, i));
   res = (char_os **) caml_stat_alloc((size + 1) * sizeof(char_os *));
-  for (i = 0; i < size; i++)
+  for (mlsize_t i = 0; i < size; i++)
     res[i] = caml_stat_strdup_to_os(String_val(Field(arg, i)));
   res[size] = NULL;
   return res;

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -73,7 +73,7 @@ static int caml_unix_execve_script(const char * path,
                               char * const argv[],
                               char * const envp[])
 {
-  size_t argc, i;
+  size_t argc;
   char ** new_argv;
 
   /* Try executing directly.  Will not return if it succeeds. */
@@ -87,7 +87,7 @@ static int caml_unix_execve_script(const char * path,
   if (new_argv == NULL) return ENOMEM;
   new_argv[0] = "/bin/sh";
   new_argv[1] = (char *) path;
-  for (i = 1; i < argc; i++) new_argv[i + 1] = argv[i];
+  for (size_t i = 1; i < argc; i++) new_argv[i + 1] = argv[i];
   new_argv[argc + 1] = NULL;
   /* Execute the shell with the new argument vector.
      Will not return if it succeeds. */

--- a/otherlibs/unix/getaddrinfo.c
+++ b/otherlibs/unix/getaddrinfo.c
@@ -63,7 +63,7 @@ CAMLprim value caml_unix_getaddrinfo(value vnode, value vserv, value vopts)
   CAMLlocal3(vres, v, e);
   char * node, * serv;
   struct addrinfo hints;
-  struct addrinfo * res, * r;
+  struct addrinfo * res;
   int retcode;
 
   if (! (caml_string_is_c_safe(vnode) && caml_string_is_c_safe(vserv)))
@@ -117,7 +117,7 @@ CAMLprim value caml_unix_getaddrinfo(value vnode, value vserv, value vopts)
   /* Convert result */
   vres = Val_emptylist;
   if (retcode == 0) {
-    for (r = res; r != NULL; r = r->ai_next) {
+    for (struct addrinfo *r = res; r != NULL; r = r->ai_next) {
       e = convert_addrinfo(r);
       v = caml_alloc_small(2, Tag_cons);
       Field(v, 0) = e;

--- a/otherlibs/unix/getgroups.c
+++ b/otherlibs/unix/getgroups.c
@@ -31,12 +31,11 @@ CAMLprim value caml_unix_getgroups(value unit)
   gid_t gidset[NGROUPS_MAX];
   int n;
   value res;
-  int i;
 
   n = getgroups(NGROUPS_MAX, gidset);
   if (n == -1) caml_uerror("getgroups", Nothing);
   res = caml_alloc_tuple(n);
-  for (i = 0; i < n; i++)
+  for (int i = 0; i < n; i++)
     Field(res, i) = Val_int(gidset[i]);
   return res;
 }

--- a/otherlibs/unix/mmap_ba.c
+++ b/otherlibs/unix/mmap_ba.c
@@ -61,14 +61,13 @@ CAMLexport value
 caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
 {
   uintnat asize;
-  int i;
   value res;
   struct caml_ba_array * b;
   intnat dimcopy[CAML_BA_MAX_NUM_DIMS];
 
   CAMLassert(num_dims >= 0 && num_dims <= CAML_BA_MAX_NUM_DIMS);
   CAMLassert((flags & CAML_BA_KIND_MASK) < CAML_BA_FIRST_UNIMPLEMENTED_KIND);
-  for (i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
+  for (int i = 0; i < num_dims; i++) dimcopy[i] = dim[i];
   asize = SIZEOF_BA_ARRAY + num_dims * sizeof(intnat);
   res = caml_alloc_custom(&caml_ba_mapped_ops, asize, 0, 1);
   b = Caml_ba_array_val(res);
@@ -76,6 +75,6 @@ caml_unix_mapped_alloc(int flags, int num_dims, void * data, intnat * dim)
   b->num_dims = num_dims;
   b->flags = flags | CAML_BA_MAPPED_FILE;
   b->proxy = NULL;
-  for (i = 0; i < num_dims; i++) b->dim[i] = dimcopy[i];
+  for (int i = 0; i < num_dims; i++) b->dim[i] = dimcopy[i];
   return res;
 }

--- a/otherlibs/unix/mmap_unix.c
+++ b/otherlibs/unix/mmap_unix.c
@@ -97,7 +97,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
                                   value vshared, value vdim, value vstart)
 {
   int fd, flags, major_dim, shared;
-  intnat num_dims, i;
+  intnat num_dims;
   intnat dim[CAML_BA_MAX_NUM_DIMS];
   file_offset startpos, file_size, data_size;
   struct stat st;
@@ -113,7 +113,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   num_dims = Wosize_val(vdim);
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Unix.map_file: bad number of dimensions");
-  for (i = 0; i < num_dims; i++) {
+  for (intnat i = 0; i < num_dims; i++) {
     dim[i] = Long_val(Field(vdim, i));
     if (dim[i] == -1 && i == major_dim) continue;
     if (dim[i] < 0)
@@ -131,7 +131,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   /* Determine array size in bytes (or size of array without the major
      dimension if that dimension wasn't specified) */
   array_size = caml_ba_element_size[flags & CAML_BA_KIND_MASK];
-  for (i = 0; i < num_dims; i++)
+  for (intnat i = 0; i < num_dims; i++)
     if (dim[i] != -1) array_size *= dim[i];
   /* Check if the major dimension is unknown */
   if (dim[major_dim] == -1) {

--- a/otherlibs/unix/mmap_win32.c
+++ b/otherlibs/unix/mmap_win32.c
@@ -40,7 +40,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
 {
   HANDLE fd, fmap;
   int flags, major_dim, mode, perm;
-  intnat num_dims, i;
+  intnat num_dims;
   intnat dim[CAML_BA_MAX_NUM_DIMS];
   __int64 startpos, data_size;
   LARGE_INTEGER file_size;
@@ -59,7 +59,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   num_dims = Wosize_val(vdim);
   if (num_dims < 1 || num_dims > CAML_BA_MAX_NUM_DIMS)
     caml_invalid_argument("Unix.map_file: bad number of dimensions");
-  for (i = 0; i < num_dims; i++) {
+  for (intnat i = 0; i < num_dims; i++) {
     dim[i] = Long_val(Field(vdim, i));
     if (dim[i] == -1 && i == major_dim) continue;
     if (dim[i] < 0)
@@ -71,7 +71,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   /* Determine array size in bytes (or size of array without the major
      dimension if that dimension wasn't specified) */
   array_size = caml_ba_element_size[flags & CAML_BA_KIND_MASK];
-  for (i = 0; i < num_dims; i++)
+  for (intnat i = 0; i < num_dims; i++)
     if (dim[i] != -1) array_size *= dim[i];
   /* Check if the first/last dimension is unknown */
   if (dim[major_dim] == -1) {

--- a/otherlibs/unix/select_unix.c
+++ b/otherlibs/unix/select_unix.c
@@ -33,9 +33,8 @@
 
 static int fdlist_to_fdset(value fdlist, fd_set *fdset, int *maxfd)
 {
-  value l;
   FD_ZERO(fdset);
-  for (l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
+  for (value l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
     long fd = Long_val(Field(l, 0));
     /* PR#5563: harden against bad fds */
     if (fd < 0 || fd >= FD_SETSIZE) return -1;

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -46,14 +46,12 @@ typedef SELECTHANDLESET *LPSELECTHANDLESET;
 
 static void handle_set_init (LPSELECTHANDLESET hds, LPHANDLE lpHdl, DWORD max)
 {
-  DWORD i;
-
   hds->lpHdl = lpHdl;
   hds->nMax  = max;
   hds->nLast = 0;
 
   /* Set to invalid value every entry of the handle */
-  for (i = 0; i < hds->nMax; i++)
+  for (DWORD i = 0; i < hds->nMax; i++)
   {
     hds->lpHdl[i] = INVALID_HANDLE_VALUE;
   };
@@ -75,10 +73,9 @@ static void handle_set_add (LPSELECTHANDLESET hds, HANDLE hdl)
 static BOOL handle_set_mem (LPSELECTHANDLESET hds, HANDLE hdl)
 {
   BOOL  res;
-  DWORD i;
 
   res = FALSE;
-  for (i = 0; !res && i < hds->nLast; i++)
+  for (DWORD i = 0; !res && i < hds->nLast; i++)
   {
     res = (hds->lpHdl[i] == hdl);
   }
@@ -88,9 +85,7 @@ static BOOL handle_set_mem (LPSELECTHANDLESET hds, HANDLE hdl)
 
 static void handle_set_reset (LPSELECTHANDLESET hds)
 {
-  DWORD i;
-
-  for (i = 0; i < hds->nMax; i++)
+  for (DWORD i = 0; i < hds->nMax; i++)
   {
     hds->lpHdl[i] = INVALID_HANDLE_VALUE;
   }
@@ -403,7 +398,6 @@ static void read_pipe_poll (HANDLE hStop, void *_data)
   DWORD         n;
   LPSELECTQUERY iterQuery;
   LPSELECTDATA  lpSelectData;
-  DWORD         i;
   DWORD         wait;
 
   /* Poll pipe */
@@ -415,7 +409,7 @@ static void read_pipe_poll (HANDLE hStop, void *_data)
   DEBUG_PRINT("Checking data pipe");
   while (lpSelectData->EState == SELECT_STATE_NONE)
   {
-    for (i = 0; i < lpSelectData->nQueriesCount; i++)
+    for (DWORD i = 0; i < lpSelectData->nQueriesCount; i++)
     {
       iterQuery = &(lpSelectData->aQueries[i]);
       res = PeekNamedPipe(
@@ -503,7 +497,6 @@ static void socket_poll (HANDLE hStop, void *_data)
   HANDLE           aEvents[MAXIMUM_SELECT_OBJECTS];
   DWORD            nEvents;
   long             maskEvents;
-  DWORD            i;
   u_long           iMode;
   SELECTMODE       mode;
   WSANETWORKEVENTS events;
@@ -556,7 +549,7 @@ static void socket_poll (HANDLE hStop, void *_data)
 
   if (lpSelectData->nError == 0)
   {
-    for (i = 0; i < lpSelectData->nQueriesCount; i++)
+    for (DWORD i = 0; i < lpSelectData->nQueriesCount; i++)
     {
       iterQuery = &(lpSelectData->aQueries[i]);
       if (WaitForSingleObject(aEvents[i], 0) == WAIT_OBJECT_0)
@@ -902,7 +895,6 @@ static value find_handle(LPSELECTRESULT iterResult, value readfds,
 {
   CAMLparam3(readfds, writefds, exceptfds);
   CAMLlocal2(result, list);
-  int i;
 
   switch( iterResult->EMode )
   {
@@ -919,7 +911,7 @@ static value find_handle(LPSELECTRESULT iterResult, value readfds,
       CAMLassert(0);
   };
 
-  for(i=0; list != Val_unit && i < iterResult->lpOrigIdx; ++i )
+  for(int i=0; list != Val_unit && i < iterResult->lpOrigIdx; ++i )
   {
     list = Field(list, 1);
   }
@@ -940,10 +932,10 @@ static value find_handle(LPSELECTRESULT iterResult, value readfds,
  */
 static int fdlist_to_fdset(value fdlist, fd_set *fdset)
 {
-  value l, c;
+  value c;
   int n = 0;
   FD_ZERO(fdset);
-  for (l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
+  for (value l = fdlist; l != Val_emptylist; l = Field(l, 1)) {
     if (++n > FD_SETSIZE) {
       DEBUG_PRINT("More than FD_SETSIZE sockets");
       return 0;

--- a/otherlibs/unix/setgroups.c
+++ b/otherlibs/unix/setgroups.c
@@ -31,12 +31,12 @@
 CAMLprim value caml_unix_setgroups(value groups)
 {
   gid_t * gidset;
-  mlsize_t size, i;
+  mlsize_t size;
   int n;
 
   size = Wosize_val(groups);
   gidset = (gid_t *) caml_stat_alloc(size * sizeof(gid_t));
-  for (i = 0; i < size; i++) gidset[i] = Int_val(Field(groups, i));
+  for (mlsize_t i = 0; i < size; i++) gidset[i] = Int_val(Field(groups, i));
 
   n = setgroups(size, gidset);
 

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -40,9 +40,7 @@ static value encode_sigset(sigset_t * set)
 {
   CAMLparam0();
   CAMLlocal1(res);
-  int i;
-
-  for (i = 1; i < NSIG; i++)
+  for (int i = 1; i < NSIG; i++)
     if (sigismember(set, i) > 0) {
       value newcons = caml_alloc_2(Tag_cons,
         Val_int(caml_rev_convert_signal_number(i)),
@@ -74,13 +72,12 @@ CAMLprim value caml_unix_sigprocmask(value vaction, value vset)
 CAMLprim value caml_unix_sigpending(value unit)
 {
   sigset_t pending;
-  int i, j;
   uintnat curr;
   if (sigpending(&pending) == -1) caml_uerror("sigpending", Nothing);
-  for (i = 0; i < NSIG_WORDS; i++) {
+  for (int i = 0; i < NSIG_WORDS; i++) {
     curr = atomic_load(&caml_pending_signals[i]);
     if (curr == 0) continue;
-    for (j = 0; j < BITS_PER_WORD; j++) {
+    for (int j = 0; j < BITS_PER_WORD; j++) {
       if (curr & ((uintnat)1 << j))
       sigaddset(&pending, i * BITS_PER_WORD + j + 1);
     }

--- a/otherlibs/unix/spawn.c
+++ b/otherlibs/unix/spawn.c
@@ -38,7 +38,7 @@ CAMLprim value caml_unix_spawn(value executable, /* string */
   char ** envp;
   const char * path;
   pid_t pid;
-  int src, dst, r, i;
+  int src, r;
   posix_spawn_file_actions_t act;
 
   caml_unix_check_path(executable, "create_process");
@@ -51,14 +51,14 @@ CAMLprim value caml_unix_spawn(value executable, /* string */
   }
   /* Prepare the redirections for stdin, stdout, stderr */
   posix_spawn_file_actions_init(&act);
-  for (dst = 0; dst <= 2; dst++) {
+  for (int dst = 0; dst <= 2; dst++) {
     /* File descriptor [redirect.(dst)] becomes file descriptor [dst] */
     src = Int_val(Field(redirect, dst));
     if (src != dst) {
       r = posix_spawn_file_actions_adddup2(&act, src, dst);
       if (r != 0) goto error;
       /* Close [src] if this is its last use */
-      for (i = dst + 1; i <= 2; i++) {
+      for (int i = dst + 1; i <= 2; i++) {
         if (src == Int_val(Field(redirect, i))) goto dontclose;
       }
       r = posix_spawn_file_actions_addclose(&act, src);
@@ -100,7 +100,7 @@ CAMLprim value caml_unix_spawn(value executable, /* string */
   char ** envp;
   const char * path;
   pid_t pid;
-  int src, dst, i;
+  int src;
 
   caml_unix_check_path(executable, "create_process");
   path = String_val(executable);
@@ -120,13 +120,13 @@ CAMLprim value caml_unix_spawn(value executable, /* string */
   }
   /* This is the child process */
   /* Perform the redirections for stdin, stdout, stderr */
-  for (dst = 0; dst <= 2; dst++) {
+  for (int dst = 0; dst <= 2; dst++) {
     /* File descriptor [redirect.(dst)] becomes file descriptor [dst] */
     src = Int_val(Field(redirect, dst));
     if (src != dst) {
       if (dup2(src, dst) == -1) _exit(ERROR_EXIT_STATUS);
       /* Close [src] if this is its last use */
-      for (i = dst + 1; i <= 2; i++) {
+      for (int i = dst + 1; i <= 2; i++) {
         if (src == Int_val(Field(redirect, i))) goto dontclose;
       }
       if (close(src) == -1) _exit(ERROR_EXIT_STATUS);

--- a/otherlibs/unix/termios.c
+++ b/otherlibs/unix/termios.c
@@ -239,7 +239,7 @@ static void encode_terminal_status(volatile value *dst, struct termios *src)
 
 static void decode_terminal_status(struct termios *dst, volatile value *src)
 {
-  for (const long * pc = terminal_io_descr; *pc != End; src++) {
+  for (const long *pc = terminal_io_descr; *pc != End; src++) {
     switch(*pc++) {
     case Bool:
       { tcflag_t * dst_p = (tcflag_t *) ((char *)dst + *pc++);

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -37,12 +37,10 @@ Caml_inline uintnat pos_next(struct addrmap* t, uintnat pos)
 
 int caml_addrmap_contains(struct addrmap* t, value key)
 {
-  uintnat pos, i;
-
   CAMLassert(Is_block(key));
   if (!t->entries) return 0;
 
-  for (i = 0, pos = pos_initial(t, key);
+  for (uintnat i = 0, pos = pos_initial(t, key);
        i < MAX_CHAIN;
        i++, pos = pos_next(t, pos)) {
     if (t->entries[pos].key == ADDRMAP_INVALID_KEY) break;
@@ -53,12 +51,10 @@ int caml_addrmap_contains(struct addrmap* t, value key)
 
 value caml_addrmap_lookup(struct addrmap* t, value key)
 {
-  uintnat pos;
-
   CAMLassert(Is_block(key));
   CAMLassert(t->entries);
 
-  for (pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
+  for (uintnat pos = pos_initial(t, key); ; pos = pos_next(t, pos)) {
     CAMLassert(t->entries[pos].key != ADDRMAP_INVALID_KEY);
     if (t->entries[pos].key == key)
       return t->entries[pos].value;
@@ -67,11 +63,10 @@ value caml_addrmap_lookup(struct addrmap* t, value key)
 
 static void addrmap_alloc(struct addrmap* t, uintnat sz)
 {
-  uintnat i;
   CAMLassert(Is_power_of_2(sz));
   t->entries = caml_stat_alloc(sizeof(struct addrmap_entry) * sz);
   t->size = sz;
-  for (i = 0; i < sz; i++) {
+  for (uintnat i = 0; i < sz; i++) {
     t->entries[i].key = ADDRMAP_INVALID_KEY;
     t->entries[i].value = ADDRMAP_NOT_PRESENT;
   }
@@ -91,13 +86,12 @@ void caml_addrmap_clear(struct addrmap* t) {
 
 
 value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
-  uintnat i, pos;
   CAMLassert(Is_block(key));
   if (!t->entries) {
     /* first call, initialise table with a small initial size */
     addrmap_alloc(t, 256);
   }
-  for (i = 0, pos = pos_initial(t, key);
+  for (uintnat i = 0, pos = pos_initial(t, key);
        i < MAX_CHAIN;
        i++,   pos = pos_next(t, pos)) {
     if (t->entries[pos].key == ADDRMAP_INVALID_KEY) {
@@ -112,7 +106,7 @@ value* caml_addrmap_insert_pos(struct addrmap* t, value key) {
     struct addrmap_entry* old_table = t->entries;
     uintnat old_size = t->size;
     addrmap_alloc(t, old_size * 2);
-    for (i = 0; i < old_size; i++) {
+    for (uintnat i = 0; i < old_size; i++) {
       if (old_table[i].key != ADDRMAP_INVALID_KEY) {
         value* p = caml_addrmap_insert_pos(t, old_table[i].key);
         CAMLassert(*p == ADDRMAP_NOT_PRESENT);
@@ -131,8 +125,7 @@ void caml_addrmap_insert(struct addrmap* t, value k, value v) {
 }
 
 void caml_addrmap_iter(struct addrmap* t, void (*f)(value, value)) {
-  addrmap_iterator i;
-  for (i = caml_addrmap_iterator(t);
+  for (addrmap_iterator i = caml_addrmap_iterator(t);
        caml_addrmap_iter_ok(t, i);
        i = caml_addrmap_next(t, i)) {
     f(caml_addrmap_iter_key(t, i),

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -78,13 +78,13 @@ CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
 /* Copy the values to be preserved to a different array.
    The original vals array never escapes, generating better code in
    the fast path. */
-#define Enter_gc_preserve_vals(dom_st, wosize) do {         \
-    CAMLparam0();                                           \
-    CAMLlocalN(vals_copy, (wosize));                        \
-    for (i = 0; i < (wosize); i++) vals_copy[i] = vals[i];  \
-    Alloc_small_enter_GC(dom_st, wosize);                   \
-    for (i = 0; i < (wosize); i++) vals[i] = vals_copy[i];  \
-    CAMLdrop;                                               \
+#define Enter_gc_preserve_vals(dom_st, wosize) do {                     \
+    CAMLparam0();                                                       \
+    CAMLlocalN(vals_copy, (wosize));                                    \
+    for (mlsize_t j = 0; j < (wosize); j++) vals_copy[j] = vals[j];     \
+    Alloc_small_enter_GC(dom_st, wosize);                               \
+    for (mlsize_t j = 0; j < (wosize); j++) vals[j] = vals_copy[j];     \
+    CAMLdrop;                                                           \
   } while (0)
 
 /* This has to be done with a macro, rather than an inline function, since
@@ -95,12 +95,11 @@ CAMLexport value caml_alloc_shr_check_gc (mlsize_t wosize, tag_t tag)
   Caml_check_caml_state();                              \
   value v;                                              \
   value vals[wosize] = {__VA_ARGS__};                   \
-  mlsize_t i;                                           \
   CAMLassert ((tag) < 256);                             \
                                                         \
   Alloc_small(v, wosize, tag, Enter_gc_preserve_vals);  \
-  for (i = 0; i < (wosize); i++) {                      \
-    Field(v, i) = vals[i];                              \
+  for (mlsize_t j = 0; j < (wosize); j++) {             \
+    Field(v, j) = vals[j];                              \
   }                                                     \
   return v;                                             \
 }

--- a/runtime/alloc.c
+++ b/runtime/alloc.c
@@ -33,7 +33,6 @@
 CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
 {
   value result;
-  mlsize_t i;
 
   CAMLassert (tag < 256);
   CAMLassert (tag != Infix_tag);
@@ -44,13 +43,13 @@ CAMLexport value caml_alloc (mlsize_t wosize, tag_t tag)
       Caml_check_caml_state();
       Alloc_small (result, wosize, tag, Alloc_small_enter_GC);
       if (tag < No_scan_tag){
-        for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
+        for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;
       }
     }
   } else {
     result = caml_alloc_shr (wosize, tag);
     if (tag < No_scan_tag) {
-      for (i = 0; i < wosize; i++) Field (result, i) = Val_unit;
+      for (mlsize_t i = 0; i < wosize; i++) Field (result, i) = Val_unit;
     }
     result = caml_check_urgent_gc (result);
   }
@@ -224,13 +223,13 @@ CAMLexport value caml_alloc_array(value (*funct)(char const *),
                                   char const * const* arr)
 {
   CAMLparam0 ();
-  mlsize_t nbr, n;
+  mlsize_t nbr;
   CAMLlocal2 (v, result);
 
   nbr = 0;
   while (arr[nbr] != 0) nbr++;
   result = caml_alloc (nbr, 0);
-  for (n = 0; n < nbr; n++) {
+  for (mlsize_t n = 0; n < nbr; n++) {
     /* The two statements below must be separate because of evaluation
        order (don't take the address &Field(result, n) before
        calling funct, which may cause a GC and move result). */
@@ -321,7 +320,7 @@ CAMLprim value caml_alloc_dummy_infix(value vsize, value voffset)
 
 CAMLprim value caml_update_dummy(value dummy, value newval)
 {
-  mlsize_t size, i;
+  mlsize_t size;
   tag_t tag;
 
   tag = Tag_val (newval);
@@ -341,7 +340,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
     CAMLassert (Tag_val(dummy) != Infix_tag);
     Unsafe_store_tag_val(dummy, Double_array_tag);
     size = Wosize_val (newval) / Double_wosize;
-    for (i = 0; i < size; i++) {
+    for (mlsize_t i = 0; i < size; i++) {
       Store_double_flat_field (dummy, i, Double_flat_field (newval, i));
     }
   } else if (tag == Infix_tag) {
@@ -356,7 +355,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
        from [clos] to [dummy], because the value being overwritten is
        an integer, and the new "value" is a pointer outside the minor
        heap. */
-    for (i = 0; i < size; i++) {
+    for (mlsize_t i = 0; i < size; i++) {
       caml_modify (&Field(dummy, i), Field(clos, i));
     }
   } else {
@@ -367,7 +366,7 @@ CAMLprim value caml_update_dummy(value dummy, value newval)
     CAMLassert (size == Wosize_val(dummy));
     /* See comment above why this is safe even if [tag == Closure_tag]
        and some of the "values" being copied are actually code pointers. */
-    for (i = 0; i < size; i++){
+    for (mlsize_t i = 0; i < size; i++){
       caml_modify (&Field(dummy, i), Field(newval, i));
     }
   }

--- a/runtime/array.c
+++ b/runtime/array.c
@@ -202,7 +202,7 @@ CAMLprim value caml_array_make(value len, value init)
 {
   CAMLparam2 (len, init);
   CAMLlocal1 (res);
-  mlsize_t size, i;
+  mlsize_t size;
 
   size = Long_val(len);
   if (size == 0) {
@@ -216,14 +216,14 @@ CAMLprim value caml_array_make(value len, value init)
     wsize = size * Double_wosize;
     if (wsize > Max_wosize) caml_invalid_argument("Array.make");
     res = caml_alloc(wsize, Double_array_tag);
-    for (i = 0; i < size; i++) {
+    for (mlsize_t i = 0; i < size; i++) {
       Store_double_flat_field(res, i, d);
     }
 #endif
   } else {
     if (size <= Max_young_wosize) {
       res = caml_alloc_small(size, 0);
-      for (i = 0; i < size; i++) Field(res, i) = init;
+      for (mlsize_t i = 0; i < size; i++) Field(res, i) = init;
     }
     else if (size > Max_wosize) caml_invalid_argument("Array.make");
     else {
@@ -237,7 +237,7 @@ CAMLprim value caml_array_make(value len, value init)
       res = caml_alloc_shr(size, 0);
       /* We now know that [init] is not in the minor heap, so there is
          no need to call [caml_initialize]. */
-      for (i = 0; i < size; i++) Field(res, i) = init;
+      for (mlsize_t i = 0; i < size; i++) Field(res, i) = init;
     }
   }
   /* Give the GC a chance to run, and run memprof callbacks */
@@ -278,7 +278,7 @@ CAMLprim value caml_array_of_uniform_array(value init)
 {
 #ifdef FLAT_FLOAT_ARRAY
   CAMLparam1 (init);
-  mlsize_t wsize, size, i;
+  mlsize_t wsize, size;
   CAMLlocal2 (v, res);
 
   size = Wosize_val(init);
@@ -296,7 +296,7 @@ CAMLprim value caml_array_of_uniform_array(value init)
       } else {
         res = caml_alloc_shr(wsize, Double_array_tag);
       }
-      for (i = 0; i < size; i++) {
+      for (mlsize_t i = 0; i < size; i++) {
         double d = Double_val(Field(init, i));
         Store_double_flat_field(res, i, d);
       }
@@ -346,8 +346,6 @@ static void wo_memmove (volatile value* const dst,
                         volatile const value* const src,
                         mlsize_t nvals)
 {
-  mlsize_t i;
-
   if (caml_domain_alone ()) {
     memmove ((value*)dst, (value*)src, nvals * sizeof (value));
   } else {
@@ -355,12 +353,12 @@ static void wo_memmove (volatile value* const dst,
     atomic_thread_fence(memory_order_acquire);
     if (dst < src) {
       /* copy ascending */
-      for (i = 0; i < nvals; i++)
+      for (mlsize_t i = 0; i < nvals; i++)
         atomic_store_release(&((atomic_value*)dst)[i], src[i]);
 
     } else {
       /* copy descending */
-      for (i = nvals; i > 0; i--)
+      for (mlsize_t i = nvals; i > 0; i--)
         atomic_store_release(&((atomic_value*)dst)[i-1], src[i-1]);
     }
   }

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -103,9 +103,7 @@ static void print_location(struct caml_loc_info * li, int index)
 /* Print a backtrace */
 CAMLexport void caml_print_exception_backtrace(void)
 {
-  int i;
   struct caml_loc_info li;
-  debuginfo dbg;
 
   if (!caml_debug_info_available()) {
     fprintf(stderr, "(Cannot print stack backtrace: "
@@ -113,7 +111,8 @@ CAMLexport void caml_print_exception_backtrace(void)
     return;
   }
 
-  for (i = 0; i < Caml_state->backtrace_pos; i++) {
+  for (int i = 0; i < Caml_state->backtrace_pos; i++) {
+    debuginfo dbg;
     for (dbg = caml_debuginfo_extract(Caml_state->backtrace_buffer[i]);
          dbg != NULL;
          dbg = caml_debuginfo_next(dbg))
@@ -175,7 +174,6 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
   else {
     backtrace_slot saved_caml_backtrace_buffer[BACKTRACE_BUFFER_SIZE];
     int saved_caml_backtrace_pos;
-    intnat i;
 
     saved_caml_backtrace_pos = Caml_state->backtrace_pos;
 
@@ -187,7 +185,7 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
            saved_caml_backtrace_pos * sizeof(backtrace_slot));
 
     res = caml_alloc(saved_caml_backtrace_pos, 0);
-    for (i = 0; i < saved_caml_backtrace_pos; i++) {
+    for (intnat i = 0; i < saved_caml_backtrace_pos; i++) {
       caml_initialize(&Field(res, i),
                       Val_backtrace_slot(saved_caml_backtrace_buffer[i]));
     }
@@ -201,7 +199,6 @@ CAMLprim value caml_get_exception_raw_backtrace(value unit)
 /* noalloc (caml value): so no CAMLparam* CAMLreturn* */
 CAMLprim value caml_restore_raw_backtrace(value exn, value backtrace)
 {
-  intnat i;
   mlsize_t bt_size;
 
   caml_domain_state* domain_state = Caml_state;
@@ -227,7 +224,7 @@ CAMLprim value caml_restore_raw_backtrace(value exn, value backtrace)
   }
 
   domain_state->backtrace_pos = bt_size;
-  for(i=0; i < domain_state->backtrace_pos; i++){
+  for (intnat i = 0; i < domain_state->backtrace_pos; i++){
     domain_state->backtrace_buffer[i] = Backtrace_slot_val(Field(backtrace, i));
   }
 
@@ -359,7 +356,6 @@ CAMLprim value caml_get_exception_backtrace(value unit)
 {
   CAMLparam0();
   CAMLlocal3(arr, res, backtrace);
-  intnat i;
 
   if (!caml_debug_info_available()) {
     res = Val_none;
@@ -367,7 +363,7 @@ CAMLprim value caml_get_exception_backtrace(value unit)
     backtrace = caml_get_exception_raw_backtrace(Val_unit);
 
     arr = caml_alloc(Wosize_val(backtrace), 0);
-    for (i = 0; i < Wosize_val(backtrace); i++) {
+    for (intnat i = 0; i < Wosize_val(backtrace); i++) {
       backtrace_slot slot = Backtrace_slot_val(Field(backtrace, i));
       debuginfo dbg = caml_debuginfo_extract(slot);
       Store_field(arr, i, caml_convert_debuginfo(dbg));

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -86,8 +86,7 @@ struct debug_info {
 
 static struct debug_info *find_debug_info(code_t pc)
 {
-  int i;
-  for (i = 0; i < caml_debug_info.size; i++) {
+  for (int i = 0; i < caml_debug_info.size; i++) {
     struct debug_info *di = caml_debug_info.contents[i];
     if (pc >= di->start && pc < di->end)
       return di;
@@ -139,12 +138,12 @@ static struct ev_info *process_debug_events(code_t code_start,
 {
   CAMLparam1(events_heap);
   CAMLlocal4(l, ev, ev_start, ev_end);
-  mlsize_t i, j;
+  mlsize_t j;
   struct ev_info *events;
 
   /* Compute the size of the required event buffer. */
   *num_events = 0;
-  for (i = 0; i < caml_array_length(events_heap); i++)
+  for (mlsize_t i = 0; i < caml_array_length(events_heap); i++)
     for (l = Field(events_heap, i); l != Val_int(0); l = Field(l, 1))
       (*num_events)++;
 
@@ -156,7 +155,7 @@ static struct ev_info *process_debug_events(code_t code_start,
     caml_fatal_error ("caml_add_debug_info: out of memory");
 
   j = 0;
-  for (i = 0; i < caml_array_length(events_heap); i++) {
+  for (mlsize_t i = 0; i < caml_array_length(events_heap); i++) {
     for (l = Field(events_heap, i); l != Val_int(0); l = Field(l, 1)) {
       ev = Field(l, 0);
 
@@ -238,8 +237,7 @@ value caml_remove_debug_info(code_t start)
   CAMLparam0();
   CAMLlocal2(dis, prev);
 
-  int i;
-  for (i = 0; i < caml_debug_info.size; i++) {
+  for (int i = 0; i < caml_debug_info.size; i++) {
     struct debug_info *di = caml_debug_info.contents[i];
     if (di->start == start) {
       /* note that caml_ext_table_remove calls caml_stat_free on the
@@ -375,9 +373,8 @@ static value alloc_callstack(backtrace_slot *trace, size_t slots)
 {
   CAMLparam0();
   CAMLlocal1(callstack);
-  int i;
   callstack = caml_alloc(slots, 0);
-  for (i = 0; i < slots; i++)
+  for (int i = 0; i < slots; i++)
     Store_field(callstack, i, Val_backtrace_slot(trace[i]));
   caml_stat_free(trace);
   CAMLreturn(callstack);
@@ -447,7 +444,7 @@ static void read_main_debug_info(struct debug_info *di)
   CAMLparam0();
   CAMLlocal3(events, evl, l);
   char_os *exec_name;
-  int fd, num_events, orig, i;
+  int fd, num_events, orig;
   struct channel *chan;
   struct exec_trailer trail;
 
@@ -482,7 +479,7 @@ static void read_main_debug_info(struct debug_info *di)
     num_events = caml_getword(chan);
     events = caml_alloc(num_events, 0);
 
-    for (i = 0; i < num_events; i++) {
+    for (int i = 0; i < num_events; i++) {
       orig = caml_getword(chan);
       evl = caml_input_val(chan);
       caml_input_val(chan); /* Skip the list of absolute directory names */

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -217,9 +217,8 @@ static value alloc_callstack(backtrace_slot* trace, size_t slots)
 {
   CAMLparam0();
   CAMLlocal1(callstack);
-  int i;
   callstack = caml_alloc(slots, 0);
-  for (i = 0; i < slots; i++)
+  for (int i = 0; i < slots; i++)
     Store_field(callstack, i, Val_backtrace_slot(trace[i]));
   caml_stat_free(trace);
   CAMLreturn(callstack);

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -1275,13 +1275,13 @@ CAMLprim value caml_ba_blit(value vsrc, value vdst)
   if (leave_runtime) caml_leave_blocking_section();                          \
 }while(0)
 
-#define FILL_SCALAR_LOOP                                        \
+#define FILL_SCALAR_LOOP(T)                                     \
   FILL_GEN_LOOP(num_elts,                                       \
-    for (p = data; num_elts > 0; p++, num_elts--) *p = init)
+    for (T p = data; num_elts > 0; p++, num_elts--) *p = init)
 
-#define FILL_COMPLEX_LOOP                                                    \
+#define FILL_COMPLEX_LOOP(T)                                                 \
   FILL_GEN_LOOP(num_elts + num_elts,                                         \
-    for (p = data; num_elts > 0; num_elts--) { *p++ = init0; *p++ = init1; })
+    for (T p = data; num_elts > 0; num_elts--) { *p++ = init0; *p++ = init1; })
 
 CAMLprim value caml_ba_fill(value vb, value vinit)
 {
@@ -1293,73 +1293,62 @@ CAMLprim value caml_ba_fill(value vb, value vinit)
   switch (b->flags & CAML_BA_KIND_MASK) {
   case CAML_BA_FLOAT16: {
     uint16 init = caml_float_to_float16(Double_val(vinit));
-    uint16 * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(uint16 *);
     break;
   }
   case CAML_BA_FLOAT32: {
     float init = Double_val(vinit);
-    float * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(float *);
     break;
   }
   case CAML_BA_FLOAT64: {
     double init = Double_val(vinit);
-    double * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(double *);
     break;
   }
   case CAML_BA_CHAR:
   case CAML_BA_SINT8:
   case CAML_BA_UINT8: {
     int init = Int_val(vinit);
-    unsigned char * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(unsigned char *);
     break;
   }
   case CAML_BA_SINT16:
   case CAML_BA_UINT16: {
     int init = Int_val(vinit);
-    int16 * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(int16 *);
     break;
   }
   case CAML_BA_INT32: {
     int32_t init = Int32_val(vinit);
-    int32_t * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(int32_t *);
     break;
   }
   case CAML_BA_INT64: {
     int64_t init = Int64_val(vinit);
-    int64_t * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(int64_t *);
     break;
   }
   case CAML_BA_NATIVE_INT: {
     intnat init = Nativeint_val(vinit);
-    intnat * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(intnat *);
     break;
   }
   case CAML_BA_CAML_INT: {
     intnat init = Long_val(vinit);
-    intnat * p;
-    FILL_SCALAR_LOOP;
+    FILL_SCALAR_LOOP(intnat *);
     break;
   }
   case CAML_BA_COMPLEX32: {
     float init0 = Double_flat_field(vinit, 0);
     float init1 = Double_flat_field(vinit, 1);
-    float * p;
-    FILL_COMPLEX_LOOP;
+    FILL_COMPLEX_LOOP(float *);
     break;
   }
   case CAML_BA_COMPLEX64: {
     double init0 = Double_flat_field(vinit, 0);
     double init1 = Double_flat_field(vinit, 1);
-    double * p;
-    FILL_COMPLEX_LOOP;
+    FILL_COMPLEX_LOOP(double *);
     break;
   }
   default:

--- a/runtime/caml/skiplist.h
+++ b/runtime/caml/skiplist.h
@@ -87,10 +87,13 @@ extern void caml_skiplist_empty(struct skiplist * sk);
    Other operations performed over the skiplist during its traversal have
    unspecified effects on the traversal. */
 
-#define FOREACH_SKIPLIST_ELEMENT(var,sk,action) \
-  { struct skipcell * var, * caml__next; \
-    for (var = (sk)->forward[0]; var != NULL; var = caml__next) \
-    { caml__next = (var)->forward[0]; action; } \
+#define FOREACH_SKIPLIST_ELEMENT(var,sk,action) {               \
+    for (struct skipcell *var = (sk)->forward[0], *caml__next;  \
+         var != NULL;                                           \
+         var = caml__next) {                                    \
+      caml__next = (var)->forward[0];                           \
+      action;                                                   \
+    }                                                           \
   }
 
 #endif

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -239,9 +239,8 @@ static intnat do_compare_val(struct compare_stack* stk,
       case Double_array_tag: {
         mlsize_t sz1 = Wosize_val(v1) / Double_wosize;
         mlsize_t sz2 = Wosize_val(v2) / Double_wosize;
-        mlsize_t i;
         if (sz1 != sz2) return sz1 - sz2;
-        for (i = 0; i < sz1; i++) {
+        for (mlsize_t i = 0; i < sz1; i++) {
           double d1 = Double_flat_field(v1, i);
           double d2 = Double_flat_field(v2, i);
           if (d1 < d2) return LESS;

--- a/runtime/custom.c
+++ b/runtime/custom.c
@@ -151,8 +151,9 @@ caml_register_custom_operations(const struct custom_operations * ops)
 
 struct custom_operations * caml_find_custom_operations(const char * ident)
 {
-  struct custom_operations_list * l;
-  for (l = atomic_load(&custom_ops_table); l != NULL; l = l->next)
+  for (struct custom_operations_list *l = atomic_load(&custom_ops_table);
+       l != NULL;
+       l = l->next)
     if (strcmp(l->ops->identifier, ident) == 0)
       return (struct custom_operations*)l->ops;
   return NULL;
@@ -162,9 +163,10 @@ static custom_operations_table custom_ops_final_table = NULL;
 
 struct custom_operations * caml_final_custom_operations(final_fun fn)
 {
-  struct custom_operations_list * l;
   struct custom_operations * ops;
-  for (l = atomic_load(&custom_ops_final_table); l != NULL; l = l->next)
+  for (struct custom_operations_list *l = atomic_load(&custom_ops_final_table);
+       l != NULL;
+       l = l->next)
     if (l->ops->finalize == fn) return (struct custom_operations*)l->ops;
   ops = caml_stat_alloc(sizeof(struct custom_operations));
   ops->identifier = "_final";

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -938,8 +938,6 @@ void caml_update_minor_heap_max(uintnat requested_wsz) {
 
 void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
 {
-  int i;
-
   /* Use [caml_stat_calloc_noexc] to zero initialize [all_domains]. */
   all_domains = caml_stat_calloc_noexc(max_domains, sizeof(dom_internal));
   if (all_domains == NULL)
@@ -958,7 +956,7 @@ void caml_init_domains(uintnat max_domains, uintnat minor_heap_wsz)
   reserve_minor_heaps_from_stw_single();
   /* stw_single: mutators and domains have not started yet. */
 
-  for (i = 0; i < max_domains; i++) {
+  for (int i = 0; i < max_domains; i++) {
     struct dom_internal* dom = &all_domains[i];
 
     stw_domains.domains[i] = dom;

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -65,14 +65,13 @@ struct ext_table caml_shared_libs_path;
    then in the opened shared libraries (shared_libs) */
 static c_primitive lookup_primitive(char * name)
 {
-  int i;
   void * res;
 
-  for (i = 0; caml_names_of_builtin_cprim[i] != NULL; i++) {
+  for (int i = 0; caml_names_of_builtin_cprim[i] != NULL; i++) {
     if (strcmp(name, caml_names_of_builtin_cprim[i]) == 0)
       return caml_builtin_cprim[i];
   }
-  for (i = 0; i < shared_libs.size; i++) {
+  for (int i = 0; i < shared_libs.size; i++) {
     res = caml_dlsym(shared_libs.contents[i], name);
     if (res != NULL) return (c_primitive) res;
   }
@@ -171,9 +170,6 @@ void caml_build_primitive_table(char_os * lib_path,
                                 char_os * libs,
                                 char * req_prims)
 {
-  char_os * p;
-  char * q;
-
   /* Initialize the search path for dynamic libraries:
      - directories specified on the command line with the -I option
      - directories specified in the CAML_LD_LIBRARY_PATH
@@ -185,19 +181,19 @@ void caml_build_primitive_table(char_os * lib_path,
   caml_decompose_path(&caml_shared_libs_path,
                       caml_secure_getenv(T("CAML_LD_LIBRARY_PATH")));
   if (lib_path != NULL)
-    for (p = lib_path; *p != 0; p += strlen_os(p) + 1)
+    for (char_os *p = lib_path; *p != 0; p += strlen_os(p) + 1)
       caml_ext_table_add(&caml_shared_libs_path, p);
   caml_parse_ld_conf();
   /* Open the shared libraries */
   caml_ext_table_init(&shared_libs, 8);
   if (libs != NULL)
-    for (p = libs; *p != 0; p += strlen_os(p) + 1)
+    for (char_os *p = libs; *p != 0; p += strlen_os(p) + 1)
       open_shared_lib(p);
   /* Build the primitive table */
   caml_ext_table_init(&caml_prim_table, 0x180);
   caml_ext_table_init(&caml_prim_name_table, 0x180);
   if (req_prims != NULL)
-    for (q = req_prims; *q != 0; q += strlen(q) + 1) {
+    for (char *q = req_prims; *q != 0; q += strlen(q) + 1) {
       c_primitive prim = lookup_primitive(q);
       if (prim == NULL)
             caml_fatal_error("unknown C primitive `%s'", q);
@@ -211,9 +207,8 @@ void caml_build_primitive_table(char_os * lib_path,
 
 void caml_build_primitive_table_builtin(void)
 {
-  int i;
   caml_build_primitive_table(NULL, NULL, NULL);
-  for (i = 0; caml_builtin_cprim[i] != 0; i++) {
+  for (int i = 0; caml_builtin_cprim[i] != 0; i++) {
     caml_ext_table_add(&caml_prim_table, (void *) caml_builtin_cprim[i]);
     caml_ext_table_add(&caml_prim_name_table,
                        caml_stat_strdup(caml_names_of_builtin_cprim[i]));
@@ -230,7 +225,6 @@ CAMLprim value caml_dynlink_get_bytecode_sections(value unit)
 {
   CAMLparam1(unit);
   CAMLlocal4(ret, tbl, list, str);
-  int i, j;
   ret = caml_alloc(4, 0);
 
   if (caml_params->section_table != NULL) {
@@ -238,8 +232,8 @@ CAMLprim value caml_dynlink_get_bytecode_sections(value unit)
     const char* sec_names[] = {"SYMB", "CRCS"};
     tbl = caml_input_value_from_block(caml_params->section_table,
                                       caml_params->section_table_size);
-    for (i = 0; i < sizeof(sec_names)/sizeof(sec_names[0]); i++) {
-      for (j = 0; j < Wosize_val(tbl); j++) {
+    for (int i = 0; i < sizeof(sec_names)/sizeof(sec_names[0]); i++) {
+      for (int j = 0; j < Wosize_val(tbl); j++) {
         value kv = Field(tbl, j);
         if (!strcmp(sec_names[i], String_val(Field(kv, 0))))
           Store_field(ret, i, Field(kv, 1));
@@ -284,14 +278,14 @@ CAMLprim value caml_dynlink_get_bytecode_sections(value unit)
   }
 
   list = Val_emptylist;
-  for (i = caml_prim_name_table.size - 1; i >= 0; i--) {
+  for (int i = caml_prim_name_table.size - 1; i >= 0; i--) {
     str = caml_copy_string(caml_prim_name_table.contents[i]);
     list = caml_alloc_2(Tag_cons, str, list);
   }
   Store_field(ret, 2, list);
 
   list = Val_emptylist;
-  for (i = caml_shared_libs_path.size - 1; i >= 0; i--) {
+  for (int i = caml_shared_libs_path.size - 1; i >= 0; i--) {
     str = caml_copy_string_of_os(caml_shared_libs_path.contents[i]);
     list = caml_alloc_2(Tag_cons, str, list);
   }
@@ -356,10 +350,9 @@ CAMLprim value caml_dynlink_get_current_libs(value unit)
 {
   CAMLparam0();
   CAMLlocal1(res);
-  int i;
 
   res = caml_alloc_tuple(shared_libs.size);
-  for (i = 0; i < shared_libs.size; i++) {
+  for (int i = 0; i < shared_libs.size; i++) {
     value v = caml_alloc_small(1, Abstract_tag);
     Handle_val(v) = shared_libs.contents[i];
     Store_field(res, i, v);

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -111,14 +111,13 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
 
 CAMLprim value caml_natdynlink_register(value handle_v, value symbols) {
   CAMLparam2 (handle_v, symbols);
-  int i;
   int nsymbols = Wosize_val(symbols);
   void* handle = Handle_val(handle_v);
   void** table;
 
   table = caml_stat_alloc(sizeof(void*) * nsymbols);
 
-  for (i = 0; i < nsymbols; i++) {
+  for (int i = 0; i < nsymbols; i++) {
     const char* unit = String_val(Field(symbols, i));
     table[i] = getsym(handle, unit, "frametable");
     if (table[i] == NULL) {
@@ -129,7 +128,7 @@ CAMLprim value caml_natdynlink_register(value handle_v, value symbols) {
   }
   caml_register_frametables(table, nsymbols);
 
-  for (i = 0; i < nsymbols; i++) {
+  for (int i = 0; i < nsymbols; i++) {
     const char* unit = String_val(Field(symbols, i));
     table[i] = getsym(handle, unit, "gc_roots");
     if (table[i] == NULL) {
@@ -140,7 +139,7 @@ CAMLprim value caml_natdynlink_register(value handle_v, value symbols) {
   }
   caml_register_dyn_globals(table, nsymbols);
 
-  for (i = 0; i < nsymbols; i++) {
+  for (int i = 0; i < nsymbols; i++) {
     const char* unit = String_val(Field(symbols, i));
     void* sym = getsym(handle, unit, "code_begin");
     void* sym2 = getsym(handle, unit, "code_end");

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -271,7 +271,7 @@ static void extern_resize_position_table(struct caml_extern_state *s)
   int new_shift;
   uintnat * new_present;
   struct object_position * new_entries;
-  uintnat i, h;
+  uintnat h;
   struct position_table old = s->pos_table;
 
   /* Grow the table quickly (x 8) up to 10^6 entries,
@@ -303,7 +303,7 @@ static void extern_resize_position_table(struct caml_extern_state *s)
   s->pos_table.entries = new_entries;
 
   /* Insert every entry of the old table in the new table */
-  for (i = 0; i < old.size; i++) {
+  for (uintnat i = 0; i < old.size; i++) {
     if (! bitvect_test(old.present, i)) continue;
     h = Hash(old.entries[i].obj, s->pos_table.shift);
     while (bitvect_test(new_present, h)) {
@@ -381,10 +381,10 @@ static void close_extern_output(struct caml_extern_state* s)
 
 static void free_extern_output(struct caml_extern_state* s)
 {
-  struct caml_output_block * blk, * nextblk;
-
   if (s->extern_userprovided_output == NULL) {
-    for (blk = s->extern_output_first; blk != NULL; blk = nextblk) {
+    for (struct caml_output_block *blk = s->extern_output_first, *nextblk;
+         blk != NULL;
+         blk = nextblk) {
       nextblk = blk->next;
       caml_stat_free(blk);
     }
@@ -1108,7 +1108,6 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
   int header_len;
   intnat data_len;
   char * res;
-  struct caml_output_block * blk, * nextblk;
   struct caml_extern_state* s = init_extern_state ();
 
   init_extern_output(s);
@@ -1119,7 +1118,9 @@ CAMLexport void caml_output_value_to_malloc(value v, value flags,
   *len = header_len + data_len;
   memcpy(res, header, header_len);
   res += header_len;
-  for (blk = s->extern_output_first; blk != NULL; blk = nextblk) {
+  for (struct caml_output_block *blk = s->extern_output_first, *nextblk;
+       blk != NULL;
+       blk = nextblk) {
     intnat n = blk->end - blk->data;
     memcpy(res, blk->data, n);
     res += n;

--- a/runtime/fail.c
+++ b/runtime/fail.c
@@ -51,12 +51,11 @@ CAMLexport value caml_exception_with_args(value exn_constr,
   Assert_is_exn_constructor(exn_constr);
 
   value bucket;
-  int i;
 
   CAMLassert(1 + nargs <= Max_young_wosize);
   bucket = caml_alloc_small (1 + nargs, 0);
   Field(bucket, 0) = exn_constr;
-  for (i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
+  for (int i = 0; i < nargs; i++) Field(bucket, 1 + i) = args[i];
   CAMLreturn(bucket);
 }
 

--- a/runtime/finalise.c
+++ b/runtime/finalise.c
@@ -52,12 +52,11 @@ static void alloc_todo (caml_domain_state* d, int size)
 static void generic_final_update
   (caml_domain_state* d, struct finalisable *final, int darken_value)
 {
-  uintnat i, j, k;
   uintnat todo_count = 0;
   struct caml_final_info *f = d->final_info;
 
   CAMLassert (final->old <= final->young);
-  for (i = 0; i < final->old; i++) {
+  for (uintnat i = 0; i < final->old; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (is_unmarked (final->table[i].val)) {
       ++ todo_count;
@@ -74,6 +73,7 @@ static void generic_final_update
       - k : index in to_do_tl, next available slot.
   */
   if (todo_count > 0) {
+    uintnat i, j, k;
     caml_set_action_pending(d);
     alloc_todo (d, todo_count);
     j = k = 0;
@@ -182,26 +182,26 @@ void caml_final_do_roots
   (scanning_action act, scanning_action_flags fflags, void* fdata,
    caml_domain_state* d, int do_val)
 {
-  uintnat i;
-  struct final_todo *todo;
   struct caml_final_info *f = d->final_info;
 
   CAMLassert (f->first.old <= f->first.young);
-  for (i = 0; i < f->first.young; i++) {
+  for (uintnat i = 0; i < f->first.young; i++) {
     Call_action (act, fdata, f->first.table[i].fun);
     if (do_val)
       Call_action (act, fdata, f->first.table[i].val);
   }
 
   CAMLassert (f->last.old <= f->last.young);
-  for (i = 0; i < f->last.young; i++) {
+  for (uintnat i = 0; i < f->last.young; i++) {
     Call_action (act, fdata, f->last.table[i].fun);
     if (do_val)
       Call_action (act, fdata, f->last.table[i].val);
   }
 
-  for (todo = f->todo_head; todo != NULL; todo = todo->next) {
-    for (i = 0; i < todo->size; i++) {
+  for (struct final_todo *todo = f->todo_head;
+       todo != NULL;
+       todo = todo->next) {
+    for (uintnat i = 0; i < todo->size; i++) {
       Call_action (act, fdata, todo->item[i].fun);
       Call_action (act, fdata, todo->item[i].val);
     }
@@ -213,17 +213,16 @@ void caml_final_do_young_roots
   (scanning_action act, scanning_action_flags fflags, void* fdata,
    caml_domain_state* d, int do_last_val)
 {
-  uintnat i;
   struct caml_final_info *f = d->final_info;
 
   CAMLassert (f->first.old <= f->first.young);
-  for (i = f->first.old; i < f->first.young; i++) {
+  for (uintnat i = f->first.old; i < f->first.young; i++) {
     Call_action (act, fdata, f->first.table[i].fun);
     Call_action (act, fdata, f->first.table[i].val);
   }
 
   CAMLassert (f->last.old <= f->last.old);
-  for (i = f->last.old; i < f->last.young; i++) {
+  for (uintnat i = f->last.old; i < f->last.young; i++) {
     Call_action (act, fdata, f->last.table[i].fun);
     if (do_last_val)
       Call_action (act, fdata, f->last.table[i].val);
@@ -233,12 +232,11 @@ void caml_final_do_young_roots
 static void generic_final_minor_update
   (caml_domain_state* d, struct finalisable * final)
 {
-  uintnat i, j, k;
   uintnat todo_count = 0;
   struct caml_final_info *fi = d->final_info;
 
   CAMLassert (final->old <= final->young);
-  for (i = final->old; i < final->young; i++){
+  for (uintnat i = final->old; i < final->young; i++){
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val) &&
         caml_get_header_val(final->table[i].val) != 0){
@@ -255,6 +253,7 @@ static void generic_final_minor_update
       - k : index in to_do_tl, next available slot.
   */
   if (todo_count > 0) {
+    uintnat i, j, k;
     caml_set_action_pending(d);
     alloc_todo (d, todo_count);
     k = 0;
@@ -282,7 +281,7 @@ static void generic_final_minor_update
   }
 
   /** update the minor value to the copied major value */
-  for (i = final->old; i < final->young; i++) {
+  for (uintnat i = final->old; i < final->young; i++) {
     CAMLassert (Is_block (final->table[i].val));
     if (Is_young(final->table[i].val)) {
       CAMLassert (caml_get_header_val(final->table[i].val) == 0);

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -69,9 +69,8 @@ void caml_load_code(int fd, asize_t len)
 
 void caml_fixup_endianness(code_t code, asize_t len)
 {
-  code_t p;
   len /= sizeof(opcode_t);
-  for (p = code; p < code + len; p++) {
+  for (code_t p = code; p < code + len; p++) {
     Reverse_32(p, p);
   }
 }
@@ -97,9 +96,7 @@ int* caml_init_opcode_nargs(void)
 {
   if( opcode_nargs == NULL ){
     int* l = (int*)caml_stat_alloc(sizeof(int) * FIRST_UNIMPLEMENTED_OP);
-    int i;
-
-    for (i = 0; i < FIRST_UNIMPLEMENTED_OP; i++) {
+    for (int i = 0; i < FIRST_UNIMPLEMENTED_OP; i++) {
       l [i] = 0;
     }
     /* Instructions with one operand */

--- a/runtime/gc_ctrl.c
+++ b/runtime/gc_ctrl.c
@@ -256,12 +256,11 @@ CAMLprim value caml_gc_major(value v)
 
 static caml_result gc_full_major_res(void)
 {
-  int i;
   CAML_EV_BEGIN(EV_EXPLICIT_GC_FULL_MAJOR);
   caml_gc_log ("Full Major GC requested");
   /* In general, it can require up to 3 GC cycles for a
      currently-unreachable object to be collected. */
-  for (i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     caml_finish_major_cycle(0);
     caml_result res = caml_process_pending_actions_res();
     if (caml_result_is_exception(res)) return res;
@@ -294,10 +293,9 @@ CAMLprim value caml_gc_compaction(value v)
   CAML_EV_BEGIN(EV_EXPLICIT_GC_COMPACT);
   CAMLassert (v == Val_unit);
   caml_result result = Result_unit;
-  int i;
   /* We do a full major before this compaction. See [caml_full_major_res] for
      why this needs three iterations. */
-  for (i = 0; i < 3; i++) {
+  for (int i = 0; i < 3; i++) {
     caml_finish_major_cycle(i == 2);
     result = caml_process_pending_actions_res();
     if (caml_result_is_exception(result)) break;

--- a/runtime/gc_stats.c
+++ b/runtime/gc_stats.c
@@ -142,7 +142,6 @@ void caml_collect_gc_stats_sample_stw(caml_domain_state* domain)
 /* Compute global stats for the whole runtime. */
 void caml_compute_gc_stats(struct gc_stats* buf)
 {
-  int i;
   intnat pool_max = 0, large_max = 0;
   int my_id = Caml_state->id;
   memset(buf, 0, sizeof(*buf));
@@ -162,7 +161,7 @@ void caml_compute_gc_stats(struct gc_stats* buf)
   pool_max = buf->heap_stats.pool_max_words;
   large_max = buf->heap_stats.large_max_words;
 
-  for (i=0; i<caml_params->max_domains; i++) {
+  for (int i = 0; i < caml_params->max_domains; i++) {
     /* For allocation stats, we use the live stats of the current domain
        and the sampled stats of other domains.
 

--- a/runtime/hash.c
+++ b/runtime/hash.c
@@ -190,7 +190,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
   intnat num;                   /* Max number of meaningful values to see */
   uint32_t h;                     /* Rolling hash */
   value v;
-  mlsize_t i, len;
+  mlsize_t len;
 
   sz = Long_val(limit);
   if (sz < 0 || sz > HASH_QUEUE_SIZE) sz = HASH_QUEUE_SIZE;
@@ -215,7 +215,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
         num--;
         break;
       case Double_array_tag:
-        for (i = 0, len = Wosize_val(v) / Double_wosize; i < len; i++) {
+        for (mlsize_t i = 0, len = Wosize_val(v) / Double_wosize; i < len; i++) {
           h = caml_hash_mix_double(h, Double_flat_field(v, i));
           num--;
           if (num <= 0) break;
@@ -233,7 +233,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
       case Forward_tag:
         /* PR#6361: we can have a loop here, so limit the number of
            Forward_tag links being followed */
-        for (i = MAX_FORWARD_DEREFERENCE; i > 0; i--) {
+        for (mlsize_t i = MAX_FORWARD_DEREFERENCE; i > 0; i--) {
           v = Forward_val(v);
           if (Is_long(v) || Tag_val(v) != Forward_tag)
             goto again;
@@ -254,7 +254,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
         }
         break;
       case Closure_tag: {
-        mlsize_t startenv;
+        mlsize_t i, startenv;
         len = Wosize_val(v);
         startenv = Start_env_closinfo(Closinfo_val(v));
         CAMLassert (startenv <= len);
@@ -282,7 +282,7 @@ CAMLprim value caml_hash(value count, value limit, value seed, value obj)
         /* Mix in the tag and size, but do not count this towards [num] */
         h = caml_hash_mix_uint32(h, Cleanhd_hd(Hd_val(v)));
         /* Copy fields into queue, not exceeding the total size [sz] */
-        for (i = 0, len = Wosize_val(v); i < len; i++) {
+        for (mlsize_t i = 0, len = Wosize_val(v); i < len; i++) {
           if (wr >= sz) break;
           queue[wr++] = Field(v, i);
         }

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -116,7 +116,6 @@ void caml_disasm_instr(code_t pc)
 void
 caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
 {
-  int i;
   fprintf (f, "%#" ARCH_INTNAT_PRINTF_FORMAT "x", v);
   if (!v)
     return;
@@ -142,7 +141,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
     case String_tag:
       l = caml_string_length (v);
       fprintf (f, "=string[s%dL%d]'", s, l);
-      for (i = 0; i < ((l>0x1f)?0x1f:l) ; i++) {
+      for (int i = 0; i < ((l>0x1f)?0x1f:l) ; i++) {
         if (isprint ((int) Byte (v, i)))
           putc (Byte (v, i), f);
         else
@@ -155,7 +154,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
       goto displayfields;
     case Double_array_tag:
       fprintf (f, "=floatarray[s%d]", s);
-      for (i = 0; i < ((s>0xf)?0xf:s); i++)
+      for (int i = 0; i < ((s>0xf)?0xf:s); i++)
         fprintf (f, " %g", Double_flat_field (v, i));
       goto displayfields;
     case Abstract_tag:
@@ -169,7 +168,7 @@ caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f)
     displayfields:
       if (s > 0)
         fputs ("=(", f);
-      for (i = 0; i < s; i++) {
+      for (int i = 0; i < s; i++) {
         if (i > 20) {
           fputs ("....", f);
           break;

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -303,7 +303,6 @@ static void readfloat(struct caml_intern_state* s,
 static void readfloats(struct caml_intern_state* s,
                        double * dest, mlsize_t len, unsigned int code)
 {
-  mlsize_t i;
   if (sizeof(double) != 8) {
     intern_cleanup(s);
     caml_invalid_argument("input_value: non-standard floats");
@@ -314,22 +313,22 @@ static void readfloats(struct caml_intern_state* s,
   /* Host is big-endian; fix up if data read is little-endian */
   if (code != CODE_DOUBLE_ARRAY8_BIG &&
       code != CODE_DOUBLE_ARRAY32_BIG) {
-    for (i = 0; i < len; i++) Reverse_64(dest + i, dest + i);
+    for (mlsize_t i = 0; i < len; i++) Reverse_64(dest + i, dest + i);
   }
 #elif ARCH_FLOAT_ENDIANNESS == 0x01234567
   /* Host is little-endian; fix up if data read is big-endian */
   if (code != CODE_DOUBLE_ARRAY8_LITTLE &&
       code != CODE_DOUBLE_ARRAY32_LITTLE) {
-    for (i = 0; i < len; i++) Reverse_64(dest + i, dest + i);
+    for (mlsize_t i = 0; i < len; i++) Reverse_64(dest + i, dest + i);
   }
 #else
   /* Host is neither big nor little; permute as appropriate */
   if (code == CODE_DOUBLE_ARRAY8_LITTLE ||
       code == CODE_DOUBLE_ARRAY32_LITTLE) {
-    for (i = 0; i < len; i++)
+    for (mlsize_t i = 0; i < len; i++)
       Permute_64(dest + i, ARCH_FLOAT_ENDIANNESS, dest + i, 0x01234567);
   } else {
-    for (i = 0; i < len; i++)
+    for (mlsize_t i = 0; i < len; i++)
       Permute_64(dest + i, ARCH_FLOAT_ENDIANNESS, dest + i, 0x76543210);
   }
 #endif

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -523,11 +523,10 @@ value caml_interprete(code_t prog, asize_t prog_size)
       int nargs = *pc++;
       int slotsize = *pc;
       value * newsp;
-      int i;
       /* Slide the nargs bottom words of the current frame to the top
          of the frame, and discard the remainder of the frame */
       newsp = sp + slotsize - nargs;
-      for (i = nargs - 1; i >= 0; i--) newsp[i] = sp[i];
+      for (int i = nargs - 1; i >= 0; i--) newsp[i] = sp[i];
       sp = newsp;
       pc = Code_val(accu);
       env = accu;
@@ -611,9 +610,8 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(RESTART): {
       int num_args = Wosize_val(env) - 3;
-      int i;
       sp -= num_args;
-      for (i = 0; i < num_args; i++) sp[i] = Field(env, i + 3);
+      for (int i = 0; i < num_args; i++) sp[i] = Field(env, i + 3);
       env = Field(env, 2);
       extra_args += num_args;
       Next;
@@ -625,11 +623,11 @@ value caml_interprete(code_t prog, asize_t prog_size)
         extra_args -= required;
         Next;
       } else {
-        mlsize_t num_args, i;
+        mlsize_t num_args;
         num_args = 1 + extra_args; /* arg1 + extra args */
         Alloc_small(accu, num_args + 3, Closure_tag, Enter_gc);
         Field(accu, 2) = env;
-        for (i = 0; i < num_args; i++) Field(accu, i + 3) = sp[i];
+        for (mlsize_t i = 0; i < num_args; i++) Field(accu, i + 3) = sp[i];
         Code_val(accu) = pc - 3; /* Point to the preceding RESTART instr. */
         Closinfo_val(accu) = Make_closinfo(0, 2);
         sp += num_args;
@@ -639,18 +637,17 @@ value caml_interprete(code_t prog, asize_t prog_size)
 
     Instruct(CLOSURE): {
       int nvars = *pc++;
-      int i;
       if (nvars > 0) *--sp = accu;
       if (nvars <= Max_young_wosize - 2) {
         /* nvars + 2 <= Max_young_wosize, can allocate in minor heap */
         Alloc_small(accu, 2 + nvars, Closure_tag, Enter_gc);
-        for (i = 0; i < nvars; i++) Field(accu, i + 2) = sp[i];
+        for (int i = 0; i < nvars; i++) Field(accu, i + 2) = sp[i];
       } else {
         /* PR#6385: must allocate in major heap */
         /* caml_alloc_shr and caml_initialize never trigger a GC,
            so no need to Setup_for_gc */
         accu = caml_alloc_shr(2 + nvars, Closure_tag);
-        for (i = 0; i < nvars; i++) caml_initialize(&Field(accu, i + 2), sp[i]);
+        for (int i = 0; i < nvars; i++) caml_initialize(&Field(accu, i + 2), sp[i]);
       }
       /* The code pointer is not in the heap, so no need to go through
          caml_initialize. */
@@ -666,20 +663,19 @@ value caml_interprete(code_t prog, asize_t prog_size)
       int nvars = *pc++;
       mlsize_t envofs = nfuncs * 3 - 1;
       mlsize_t blksize = envofs + nvars;
-      int i;
       volatile value * p;
       if (nvars > 0) *--sp = accu;
       if (blksize <= Max_young_wosize) {
         Alloc_small(accu, blksize, Closure_tag, Enter_gc);
         p = &Field(accu, envofs);
-        for (i = 0; i < nvars; i++, p++) *p = sp[i];
+        for (int i = 0; i < nvars; i++, p++) *p = sp[i];
       } else {
         /* PR#6385: must allocate in major heap */
         /* caml_alloc_shr and caml_initialize never trigger a GC,
            so no need to Setup_for_gc */
         accu = caml_alloc_shr(blksize, Closure_tag);
         p = &Field(accu, envofs);
-        for (i = 0; i < nvars; i++, p++) caml_initialize(p, sp[i]);
+        for (int i = 0; i < nvars; i++, p++) caml_initialize(p, sp[i]);
       }
       sp += nvars;
       /* The code pointers and infix headers are not in the heap,
@@ -688,7 +684,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
       p = &Field(accu, 0);
       *p++ = (value) (pc + pc[0]);
       *p++ = Make_closinfo(0, envofs);
-      for (i = 1; i < nfuncs; i++) {
+      for (int i = 1; i < nfuncs; i++) {
         *p++ = Make_header(i * 3, Infix_tag, 0); /* color irrelevant */
         *--sp = (value) p;
         *p++ = (value) (pc + pc[i]);
@@ -763,16 +759,15 @@ value caml_interprete(code_t prog, asize_t prog_size)
     Instruct(MAKEBLOCK): {
       mlsize_t wosize = *pc++;
       tag_t tag = *pc++;
-      mlsize_t i;
       value block;
       if (wosize <= Max_young_wosize) {
         Alloc_small(block, wosize, tag, Enter_gc);
         Field(block, 0) = accu;
-        for (i = 1; i < wosize; i++) Field(block, i) = *sp++;
+        for (mlsize_t i = 1; i < wosize; i++) Field(block, i) = *sp++;
       } else {
         block = caml_alloc_shr(wosize, tag);
         caml_initialize(&Field(block, 0), accu);
-        for (i = 1; i < wosize; i++) caml_initialize(&Field(block, i), *sp++);
+        for (mlsize_t i = 1; i < wosize; i++) caml_initialize(&Field(block, i), *sp++);
       }
       accu = block;
       Next;
@@ -808,7 +803,6 @@ value caml_interprete(code_t prog, asize_t prog_size)
     }
     Instruct(MAKEFLOATBLOCK): {
       mlsize_t size = *pc++;
-      mlsize_t i;
       value block;
       if (size <= Max_young_wosize / Double_wosize) {
         Alloc_small(block, size * Double_wosize, Double_array_tag, Enter_gc);
@@ -816,7 +810,7 @@ value caml_interprete(code_t prog, asize_t prog_size)
         block = caml_alloc_shr(size * Double_wosize, Double_array_tag);
       }
       Store_double_flat_field(block, 0, Double_val(accu));
-      for (i = 1; i < size; i++){
+      for (mlsize_t i = 1; i < size; i++){
         Store_double_flat_field(block, i, Double_val(*sp));
         ++ sp;
       }

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -403,13 +403,12 @@ CAMLexport unsigned char caml_getch(struct channel *channel)
 
 CAMLexport uint32_t caml_getword(struct channel *channel)
 {
-  int i;
   uint32_t res;
 
   if (! caml_channel_binary_mode(channel))
     caml_failwith("input_binary_int: not a binary channel");
   res = 0;
-  for(i = 0; i < 4; i++) {
+  for (int i = 0; i < 4; i++) {
     res = (res << 8) + Getch(channel);
   }
   return res;
@@ -661,12 +660,11 @@ CAMLprim value caml_ml_out_channels_list (value unit)
 {
   CAMLparam0 ();
   CAMLlocal3 (res, tail, chan);
-  struct channel * channel;
   struct channel_list *channel_list = NULL, *cl_tmp;
-  mlsize_t i, num_channels = 0;
+  mlsize_t num_channels = 0;
 
   caml_plat_lock_blocking(&caml_all_opened_channels_mutex);
-  for (channel = caml_all_opened_channels;
+  for (struct channel *channel = caml_all_opened_channels;
        channel != NULL;
        channel = channel->next) {
     CAMLassert(channel->flags & CHANNEL_FLAG_MANAGED_BY_GC);
@@ -687,7 +685,7 @@ CAMLprim value caml_ml_out_channels_list (value unit)
 
   res = Val_emptylist;
   cl_tmp = NULL;
-  for (i = 0; i < num_channels; i++) {
+  for (mlsize_t i = 0; i < num_channels; i++) {
     chan = caml_alloc_channel (channel_list->channel);
     tail = res;
     res = caml_alloc_2(Tag_cons, chan, tail);

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -827,8 +827,7 @@ static void realloc_mark_stack (struct mark_stack* stk)
      will not compress and because we are using a domain local heap bound we
      need to fit large blocks into the local mark stack. See PR#11284 */
   if (mark_stack_bsize >= local_heap_bsize / 32) {
-    uintnat i;
-    for (i = 0; i < stk->count; ++i) {
+    for (uintnat i = 0; i < stk->count; ++i) {
       mark_entry* me = &stk->stack[i];
       if (me->end - me->start > BITS_PER_WORD)
         mark_stack_large_bsize += sizeof(mark_entry);
@@ -2068,8 +2067,7 @@ static void mark_stack_prune(struct mark_stack* stk)
      unprocessed entries of the existing compressed stack into the new one. */
   uintnat old_compressed_entries = 0;
   struct addrmap new_compressed_stack = ADDRMAP_INIT;
-  addrmap_iterator it;
-  for (it = stk->compressed_stack_iter;
+  for (addrmap_iterator it = stk->compressed_stack_iter;
        caml_addrmap_iter_ok(&stk->compressed_stack, it);
        it = caml_addrmap_next(&stk->compressed_stack, it)) {
     value k = caml_addrmap_iter_key(&stk->compressed_stack, it);
@@ -2085,8 +2083,8 @@ static void mark_stack_prune(struct mark_stack* stk)
   stk->compressed_stack = new_compressed_stack;
 
   /* scan mark stack and compress entries */
-  uintnat i, new_stk_count = 0, compressed_entries = 0, total_words = 0;
-  for (i=0; i < stk->count; i++) {
+  uintnat new_stk_count = 0, compressed_entries = 0, total_words = 0;
+  for (uintnat i = 0; i < stk->count; i++) {
     mark_entry me = stk->stack[i];
     total_words += me.end - me.start;
     if (me.end - me.start > BITS_PER_WORD) {

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -411,10 +411,9 @@ CAMLprim value caml_atomic_fetch_add (value ref, value incr)
 
 CAMLexport void caml_set_fields (value obj, value v)
 {
-  int i;
   CAMLassert (Is_block(obj));
 
-  for (i = 0; i < Wosize_val(obj); i++) {
+  for (int i = 0; i < Wosize_val(obj); i++) {
     caml_modify(&Field(obj, i), v);
   }
 }
@@ -442,8 +441,7 @@ Caml_inline value alloc_shr(mlsize_t wosize, tag_t tag, reserved_t reserved,
 
 #ifdef DEBUG
   if (tag < No_scan_tag) {
-    mlsize_t i;
-    for (i = 0; i < wosize; i++)
+    for (mlsize_t i = 0; i < wosize; i++)
       Op_hp(v)[i] = Debug_uninit_major;
   }
 #endif
@@ -611,14 +609,13 @@ CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
   aligned_mem = (((uintnat) raw_mem / Page_size + 1) * Page_size);
 #ifdef DEBUG
   {
-    uintnat *p;
     uintnat *p0 = (void *) *b;
     uintnat *p1 = (void *) (aligned_mem - modulo);
     uintnat *p2 = (void *) (aligned_mem - modulo + sz);
     uintnat *p3 = (void *) ((char *) *b + sz + Page_size);
-    for (p = p0; p < p1; p++) *p = Debug_filler_align;
-    for (p = p1; p < p2; p++) *p = Debug_uninit_align;
-    for (p = p2; p < p3; p++) *p = Debug_filler_align;
+    for (uintnat *p = p0; p < p1; p++) *p = Debug_filler_align;
+    for (uintnat *p = p1; p < p2; p++) *p = Debug_uninit_align;
+    for (uintnat *p = p2; p < p3; p++) *p = Debug_filler_align;
   }
 #endif
   return (char *) (aligned_mem - modulo);
@@ -745,10 +742,9 @@ CAMLexport caml_stat_string caml_stat_strconcat(int n, ...)
   va_list args;
   char *result, *p;
   size_t len = 0;
-  int i;
 
   va_start(args, n);
-  for (i = 0; i < n; i++) {
+  for (int i = 0; i < n; i++) {
     const char *s = va_arg(args, const char*);
     len += strlen(s);
   }
@@ -758,7 +754,7 @@ CAMLexport caml_stat_string caml_stat_strconcat(int n, ...)
 
   va_start(args, n);
   p = result;
-  for (i = 0; i < n; i++) {
+  for (int i = 0; i < n; i++) {
     const char *s = va_arg(args, const char*);
     size_t l = strlen(s);
     memcpy(p, s, l);
@@ -777,10 +773,9 @@ CAMLexport wchar_t* caml_stat_wcsconcat(int n, ...)
   va_list args;
   wchar_t *result, *p;
   size_t len = 0;
-  int i;
 
   va_start(args, n);
-  for (i = 0; i < n; i++) {
+  for (int i = 0; i < n; i++) {
     const wchar_t *s = va_arg(args, const wchar_t*);
     len += wcslen(s);
   }
@@ -790,7 +785,7 @@ CAMLexport wchar_t* caml_stat_wcsconcat(int n, ...)
 
   va_start(args, n);
   p = result;
-  for (i = 0; i < n; i++) {
+  for (int i = 0; i < n; i++) {
     const wchar_t *s = va_arg(args, const wchar_t*);
     size_t l = wcslen(s);
     memcpy(p, s, l*sizeof(wchar_t));

--- a/runtime/memprof.c
+++ b/runtime/memprof.c
@@ -1045,9 +1045,8 @@ Caml_inline uint64_t splitmix64_next(uint64_t* x)
 
 static void xoshiro_init(memprof_domain_t domain, uint64_t seed)
 {
-  int i;
   uint64_t splitmix64_state = seed;
-  for (i = 0; i < RAND_BLOCK_SIZE; i++) {
+  for (int i = 0; i < RAND_BLOCK_SIZE; i++) {
     uint64_t t = splitmix64_next(&splitmix64_state);
     domain->xoshiro_state[0][i] = t & 0xFFFFFFFF;
     domain->xoshiro_state[1][i] = t >> 32;
@@ -1122,7 +1121,6 @@ __attribute__((optimize("tree-vectorize")))
 
 static void rand_batch(memprof_domain_t domain)
 {
-  int i;
   float one_log1m_lambda = One_log1m_lambda(domain->entries.config);
 
   /* Instead of using temporary buffers, we could use one big loop,
@@ -1132,18 +1130,18 @@ static void rand_batch(memprof_domain_t domain)
   float B[RAND_BLOCK_SIZE];
 
   /* Generate uniform variables in A using the xoshiro128+ PRNG. */
-  for (i = 0; i < RAND_BLOCK_SIZE; i++)
+  for (int i = 0; i < RAND_BLOCK_SIZE; i++)
     A[i] = xoshiro_next(domain, i);
 
   /* Generate exponential random variables by computing logarithms. */
-  for (i = 0; i < RAND_BLOCK_SIZE; i++)
+  for (int i = 0; i < RAND_BLOCK_SIZE; i++)
     B[i] = 1 + log_approx(A[i]) * one_log1m_lambda;
 
   /* We do the final flooring for generating geometric
      variables. Compilers are unlikely to use SIMD instructions for
      this loop, because it involves a conditional and variables of
      different sizes (32 and 64 bits). */
-  for (i = 0; i < RAND_BLOCK_SIZE; i++) {
+  for (int i = 0; i < RAND_BLOCK_SIZE; i++) {
     double f = B[i];
     CAMLassert (f >= 1);
     /* [Max_long+1] is a power of two => no rounding in the test. */

--- a/runtime/meta.c
+++ b/runtime/meta.c
@@ -131,7 +131,7 @@ CAMLprim value caml_static_release_bytecode(value bc)
 
 CAMLprim value caml_realloc_global(value size)
 {
-  mlsize_t requested_size, actual_size, i;
+  mlsize_t requested_size, actual_size;
   value new_global_data, old_global_data;
   old_global_data = caml_global_data;
 
@@ -143,9 +143,9 @@ CAMLprim value caml_realloc_global(value size)
                      ARCH_INTNAT_PRINTF_FORMAT "u entries\n",
                      requested_size);
     new_global_data = caml_alloc_shr(requested_size, 0);
-    for (i = 0; i < actual_size; i++)
+    for (mlsize_t i = 0; i < actual_size; i++)
       caml_initialize(&Field(new_global_data, i), Field(old_global_data, i));
-    for (i = actual_size; i < requested_size; i++){
+    for (mlsize_t i = actual_size; i < requested_size; i++){
       Field (new_global_data, i) = Val_long (0);
     }
     caml_modify_generational_global_root(&caml_global_data, new_global_data);
@@ -186,12 +186,11 @@ CAMLprim value caml_invoke_traced_function(value codeptr, value env, value arg)
        saved env */
 
   value * osp, * nsp;
-  int i;
 
   osp = Caml_state->current_stack->sp;
   Caml_state->current_stack->sp -= 4;
   nsp = Caml_state->current_stack->sp;
-  for (i = 0; i < 7; i++) nsp[i] = osp[i];
+  for (int i = 0; i < 7; i++) nsp[i] = osp[i];
   nsp[7] = (value) Nativeint_val(codeptr);
   nsp[8] = env;
   nsp[9] = Val_int(0);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -242,7 +242,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
   struct oldify_state* st = st_v;
   value result;
   header_t hd;
-  mlsize_t sz, i;
+  mlsize_t sz;
   mlsize_t infix_offset;
   tag_t tag;
 
@@ -317,8 +317,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
                                     caml_global_heap_state.MARKED);
       #ifdef DEBUG
       {
-        int c;
-        for( c = 0; c < sz ; c++ ) {
+        for (int c = 0; c < sz; c++) {
           Field(result, c) = Val_long(1);
         }
       }
@@ -329,7 +328,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
     sz = Wosize_hd (hd);
     st->live_bytes += Bhsize_hd(hd);
     result = alloc_shared(st->domain, sz, tag, Reserved_hd(hd));
-    for (i = 0; i < sz; i++) {
+    for (mlsize_t i = 0; i < sz; i++) {
       Field(result, i) = Field(v, i);
     }
     CAMLassert (infix_offset == 0);
@@ -338,7 +337,7 @@ static void oldify_one (void* st_v, value v, volatile value *p)
       *Hp_val(result) = Make_header(sz, No_scan_tag,
                                     caml_global_heap_state.MARKED);
       #ifdef DEBUG
-      for( i = 0; i < sz ; i++ ) {
+      for(mlsize_t i = 0; i < sz; i++) {
         Field(result, i) = Val_long(1);
       }
       #endif
@@ -388,7 +387,6 @@ CAMLno_tsan_for_perf
 static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
 {
   value v, new_v, f;
-  mlsize_t i;
   caml_domain_state* domain_state = st->domain;
   struct caml_ephe_ref_table ephe_ref_table =
                                     domain_state->minor_tables->ephe_ref;
@@ -409,7 +407,7 @@ again:
     if (Is_block (f) && Is_young(f)) {
       oldify_one (st, f, Op_val (new_v));
     }
-    for (i = 1; i < Wosize_val (new_v); i++){
+    for (mlsize_t i = 1; i < Wosize_val (new_v); i++){
       f = Field(v, i);
       CAMLassert (!Is_debug_tag(f));
       if (Is_block (f) && Is_young(f)) {
@@ -701,9 +699,9 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
    code, but they cannot have any pointers into our minor heap. */
 static void custom_finalize_minor (caml_domain_state * domain)
 {
-  struct caml_custom_elt *elt;
-  for (elt = domain->minor_tables->custom.base;
-       elt < domain->minor_tables->custom.ptr; elt++) {
+  for (struct caml_custom_elt *elt = domain->minor_tables->custom.base;
+       elt < domain->minor_tables->custom.ptr;
+       elt++) {
     value *v = &elt->block;
     if (Is_block(*v) && Is_young(*v)) {
       if (get_header_val(*v) == 0) { /* value copied to major heap */
@@ -808,7 +806,7 @@ caml_stw_empty_minor_heap_no_major_slice(caml_domain_state* domain,
 
 #ifdef DEBUG
   {
-    for (uintnat* p = initial_young_ptr; p < (uintnat*)domain->young_end; ++p)
+    for (uintnat *p = initial_young_ptr; p < (uintnat*)domain->young_end; ++p)
       *p = Debug_free_minor;
   }
 #endif

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -182,8 +182,7 @@ int caml_ext_table_add(struct ext_table * tbl, caml_stat_block data)
 
 void caml_ext_table_remove(struct ext_table * tbl, caml_stat_block data)
 {
-  int i;
-  for (i = 0; i < tbl->size; i++) {
+  for (int i = 0; i < tbl->size; i++) {
     if (tbl->contents[i] == data) {
       caml_stat_free(tbl->contents[i]);
       memmove(&tbl->contents[i], &tbl->contents[i + 1],
@@ -195,9 +194,8 @@ void caml_ext_table_remove(struct ext_table * tbl, caml_stat_block data)
 
 void caml_ext_table_clear(struct ext_table * tbl, int free_entries)
 {
-  int i;
   if (free_entries) {
-    for (i = 0; i < tbl->size; i++) caml_stat_free(tbl->contents[i]);
+    for (int i = 0; i < tbl->size; i++) caml_stat_free(tbl->contents[i]);
   }
   tbl->size = 0;
 }

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -134,7 +134,7 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
 {
   CAMLparam2 (new_tag_v, arg);
   CAMLlocal1 (res);
-  mlsize_t sz, i;
+  mlsize_t sz;
   tag_t tg;
 
   sz = Wosize_val(arg);
@@ -145,13 +145,13 @@ CAMLprim value caml_obj_with_tag(value new_tag_v, value arg)
     memcpy(Bp_val(res), Bp_val(arg), sz * sizeof(value));
   } else if (sz <= Max_young_wosize) {
     res = caml_alloc_small(sz, tg);
-    for (i = 0; i < sz; i++) Field(res, i) = Field(arg, i);
+    for (mlsize_t i = 0; i < sz; i++) Field(res, i) = Field(arg, i);
   } else {
     res = caml_alloc_shr(sz, tg);
     /* It is safe to use [caml_initialize] even if [tag == Closure_tag]
        and some of the "values" being copied are actually code pointers.
        That's because the new "value" does not point to the minor heap. */
-    for (i = 0; i < sz; i++) caml_initialize(&Field(res, i), Field(arg, i));
+    for (mlsize_t i = 0; i < sz; i++) caml_initialize(&Field(res, i), Field(arg, i));
     /* Give gc a chance to run, and run memprof callbacks */
     caml_process_pending_actions();
   }

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -272,7 +272,7 @@ void caml_plat_futex_free(caml_plat_futex* ftx) {
 
 #  elif 0 /* defined(__DragonFly__)
    TODO The following code for DragonFly is untested,
-   we currently use the fallback instead. */ */
+   we currently use the fallback instead. */
 #    define CAML_PLAT_FUTEX_WAIT(ftx, undesired)        \
   umtx_sleep((volatile const int*)ftx, undesired, 0)
 #    define CAML_PLAT_FUTEX_WAKE(ftx)               \

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -53,7 +53,7 @@ static void add_string(struct stringbuf *buf, const char *s)
 CAMLexport char * caml_format_exception(value exn)
 {
   Caml_check_caml_state();
-  mlsize_t start, i, len;
+  mlsize_t start, len;
   value bucket, v;
   struct stringbuf buf;
   char intbuf[64];
@@ -75,7 +75,7 @@ CAMLexport char * caml_format_exception(value exn)
       start = 1;
     }
     add_char(&buf, '(');
-    for (i = start; i < Wosize_val(bucket); i++) {
+    for (mlsize_t i = start; i < Wosize_val(bucket); i++) {
       if (i > start) add_string(&buf, ", ");
       v = Field(bucket, i);
       if (Is_long(v)) {

--- a/runtime/printexc.c
+++ b/runtime/printexc.c
@@ -53,7 +53,7 @@ static void add_string(struct stringbuf *buf, const char *s)
 CAMLexport char * caml_format_exception(value exn)
 {
   Caml_check_caml_state();
-  mlsize_t start, i;
+  mlsize_t start, i, len;
   value bucket, v;
   struct stringbuf buf;
   char intbuf[64];
@@ -95,10 +95,10 @@ CAMLexport char * caml_format_exception(value exn)
     add_string(&buf, String_val(Field(exn, 0)));
 
   *buf.ptr = 0;              /* Terminate string */
-  i = buf.ptr - buf.data + 1;
-  res = caml_stat_alloc_noexc(i);
+  len = buf.ptr - buf.data + 1;
+  res = caml_stat_alloc_noexc(len);
   if (res == NULL) return NULL;
-  memmove(res, buf.data, i);
+  memmove(res, buf.data, len);
   return res;
 }
 

--- a/runtime/roots.c
+++ b/runtime/roots.c
@@ -52,14 +52,10 @@ CAMLexport void caml_do_local_roots (
   struct stack_info *current_stack,
   value * v_gc_regs)
 {
-  struct caml__roots_block *lr;
-  int i, j;
-  value* sp;
-
-  for (lr = local_roots; lr != NULL; lr = lr->next) {
-    for (i = 0; i < lr->ntables; i++){
-      for (j = 0; j < lr->nitems; j++){
-        sp = &(lr->tables[i][j]);
+  for (struct caml__roots_block *lr = local_roots; lr != NULL; lr = lr->next) {
+    for (int i = 0; i < lr->ntables; i++) {
+      for (int j = 0; j < lr->nitems; j++) {
+        value* sp = &(lr->tables[i][j]);
         if (*sp != 0) {
           f (fdata, *sp, sp);
         }

--- a/runtime/runtime_events.c
+++ b/runtime/runtime_events.c
@@ -638,15 +638,13 @@ void caml_ev_alloc(uint64_t sz) {
 }
 
 void caml_ev_alloc_flush(void) {
-  int i;
-
   if ( !ring_is_active() )
     return;
 
   write_to_ring(EV_RUNTIME, (ev_message_type){.runtime=EV_ALLOC}, 0,
                   RUNTIME_EVENTS_NUM_ALLOC_BUCKETS, alloc_buckets, 0);
 
-  for (i = 1; i < RUNTIME_EVENTS_NUM_ALLOC_BUCKETS; i++) {
+  for (int i = 1; i < RUNTIME_EVENTS_NUM_ALLOC_BUCKETS; i++) {
     alloc_buckets[i] = 0;
   }
 }

--- a/runtime/signals.c
+++ b/runtime/signals.c
@@ -49,8 +49,7 @@ static caml_plat_mutex signal_install_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 CAMLexport int caml_check_pending_signals(void)
 {
-  int i;
-  for (i = 0; i < NSIG_WORDS; i++) {
+  for (int i = 0; i < NSIG_WORDS; i++) {
     if (atomic_load_relaxed(&caml_pending_signals[i]))
       return 1;
   }
@@ -61,7 +60,7 @@ CAMLexport int caml_check_pending_signals(void)
 
 CAMLexport caml_result caml_process_pending_signals_res(void)
 {
-  int i, j, signo;
+  int signo;
   uintnat curr, mask ;
 #ifdef POSIX_SIGNALS
   sigset_t set;
@@ -76,11 +75,11 @@ CAMLexport caml_result caml_process_pending_signals_res(void)
   pthread_sigmask(/* dummy */ SIG_BLOCK, NULL, &set);
 #endif
 
-  for (i = 0; i < NSIG_WORDS; i++) {
+  for (int i = 0; i < NSIG_WORDS; i++) {
     curr = atomic_load_relaxed(&caml_pending_signals[i]);
     if (curr == 0) goto next_word;
     /* Scan curr for bits set */
-    for (j = 0; j < BITS_PER_WORD; j++) {
+    for (int j = 0; j < BITS_PER_WORD; j++) {
       mask = (uintnat)1 << j;
       if ((curr & mask) == 0) goto next_bit;
       signo = i * BITS_PER_WORD + j + 1;
@@ -218,10 +217,8 @@ CAMLexport void caml_leave_blocking_section(void)
 static value caml_signal_handlers;
 
 void caml_init_signal_handling(void) {
-  mlsize_t i;
-
   caml_signal_handlers = caml_alloc_shr(NSIG, 0);
-  for (i = 0; i < NSIG; i++)
+  for (mlsize_t i = 0; i < NSIG; i++)
     Field(caml_signal_handlers, i) = Val_unit;
   caml_register_generational_global_root(&caml_signal_handlers);
 }
@@ -513,8 +510,7 @@ CAMLexport int caml_convert_signal_number(int signo)
 
 CAMLexport int caml_rev_convert_signal_number(int signo)
 {
-  int i;
-  for (i = 0; i < sizeof(posix_signals) / sizeof(int); i++)
+  for (int i = 0; i < sizeof(posix_signals) / sizeof(int); i++)
     if (signo == posix_signals[i]) return -i - 1;
   return signo;
 }

--- a/runtime/signals_nat.c
+++ b/runtime/signals_nat.c
@@ -63,7 +63,7 @@ void caml_garbage_collection(void)
   { /* Compute the total allocation size at this point,
        including allocations combined by Comballoc */
     unsigned char* alloc_len = (unsigned char*)(&d->live_ofs[d->num_live]);
-    int i, nallocs = *alloc_len++;
+    int nallocs = *alloc_len++;
     intnat allocsz = 0;
 
     if (nallocs == 0) {
@@ -73,7 +73,7 @@ void caml_garbage_collection(void)
     }
     else
     {
-      for (i = 0; i < nallocs; i++) {
+      for (int i = 0; i < nallocs; i++) {
         allocsz += Whsize_wosize(Wosize_encoded_alloc_len(alloc_len[i]));
       }
       /* We have computed whsize (including header)

--- a/runtime/skiplist.c
+++ b/runtime/skiplist.c
@@ -57,8 +57,7 @@ static int random_level(void)
 
 void caml_skiplist_init(struct skiplist * sk)
 {
-  int i;
-  for (i = 0; i < NUM_LEVELS; i++) sk->forward[i] = NULL;
+  for (int i = 0; i < NUM_LEVELS; i++) sk->forward[i] = NULL;
   sk->level = 0;
 }
 
@@ -66,11 +65,10 @@ void caml_skiplist_init(struct skiplist * sk)
 
 int caml_skiplist_find(struct skiplist * sk, uintnat key, uintnat * data)
 {
-  int i;
   struct skipcell ** e, * f;
 
   e = sk->forward;
-  for (i = sk->level; i >= 0; i--) {
+  for (int i = sk->level; i >= 0; i--) {
     while (1) {
       f = e[i];
       if (f == NULL || f->key > key) break;
@@ -87,11 +85,10 @@ int caml_skiplist_find(struct skiplist * sk, uintnat key, uintnat * data)
 int caml_skiplist_find_below(struct skiplist * sk, uintnat k,
                              uintnat * key, uintnat * data)
 {
-  int i;
   struct skipcell ** e, * f, * last = NULL;
 
   e = sk->forward;
-  for (i = sk->level; i >= 0; i--) {
+  for (int i = sk->level; i >= 0; i--) {
     while (1) {
       f = e[i];
       if (f == NULL || f->key > k) break;
@@ -113,12 +110,12 @@ int caml_skiplist_insert(struct skiplist * sk,
 {
   struct skipcell ** update[NUM_LEVELS];
   struct skipcell ** e, * f;
-  int i, new_level;
+  int new_level;
 
   /* Init "cursor" to list head */
   e = sk->forward;
   /* Find place to insert new node */
-  for (i = sk->level; i >= 0; i--) {
+  for (int i = sk->level; i >= 0; i--) {
     while (1) {
       f = e[i];
       if (f == NULL || f->key >= key) break;
@@ -135,7 +132,7 @@ int caml_skiplist_insert(struct skiplist * sk,
   /* Insert additional element, updating list level if necessary */
   new_level = random_level();
   if (new_level > sk->level) {
-    for (i = sk->level + 1; i <= new_level; i++)
+    for (int i = sk->level + 1; i <= new_level; i++)
       update[i] = &sk->forward[i];
     sk->level = new_level;
   }
@@ -143,7 +140,7 @@ int caml_skiplist_insert(struct skiplist * sk,
                       (new_level + 1) * sizeof(struct skipcell *));
   f->key = key;
   f->data = data;
-  for (i = 0; i <= new_level; i++) {
+  for (int i = 0; i <= new_level; i++) {
     f->forward[i] = *update[i];
     *update[i] = f;
   }
@@ -156,12 +153,11 @@ int caml_skiplist_remove(struct skiplist * sk, uintnat key)
 {
   struct skipcell ** update[NUM_LEVELS];
   struct skipcell ** e, * f;
-  int i;
 
   /* Init "cursor" to list head */
   e = sk->forward;
   /* Find element in list */
-  for (i = sk->level; i >= 0; i--) {
+  for (int i = sk->level; i >= 0; i--) {
     while (1) {
       f = e[i];
       if (f == NULL || f->key >= key) break;
@@ -173,7 +169,7 @@ int caml_skiplist_remove(struct skiplist * sk, uintnat key)
   /* If not found, nothing to do */
   if (f == NULL || f->key != key) return 0;
   /* Rebuild list without node */
-  for (i = 0; i <= sk->level; i++) {
+  for (int i = 0; i <= sk->level; i++) {
     if (*update[i] == f)
       *update[i] = f->forward[i];
   }
@@ -190,13 +186,10 @@ int caml_skiplist_remove(struct skiplist * sk, uintnat key)
 
 void caml_skiplist_empty(struct skiplist * sk)
 {
-  struct skipcell * e, * next;
-  int i;
-
-  for (e = sk->forward[0]; e != NULL; e = next) {
+  for (struct skipcell *e = sk->forward[0], *next; e != NULL; e = next) {
     next = e->forward[0];
     caml_stat_free(e);
   }
-  for (i = 0; i <= sk->level; i++) sk->forward[i] = NULL;
+  for (int i = 0; i <= sk->level; i++) sk->forward[i] = NULL;
   sk->level = 0;
 }

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -160,7 +160,7 @@ int caml_attempt_open(char_os **name, struct exec_trailer *trail,
 
 void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
 {
-  int toc_size, i;
+  int toc_size;
 
   toc_size = trail->num_sections * 8;
   trail->section = caml_stat_alloc(toc_size);
@@ -168,7 +168,7 @@ void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
   if (read(fd, (char *) trail->section, toc_size) != toc_size)
     caml_fatal_error("cannot read section table");
   /* Fixup endianness of lengths */
-  for (i = 0; i < trail->num_sections; i++)
+  for (int i = 0; i < trail->num_sections; i++)
     fixup_endianness_trailer(&(trail->section[i].len));
 }
 
@@ -180,10 +180,9 @@ int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
                                    char *name)
 {
   long ofs;
-  int i;
 
   ofs = TRAILER_SIZE + trail->num_sections * 8;
-  for (i = trail->num_sections - 1; i >= 0; i--) {
+  for (int i = trail->num_sections - 1; i >= 0; i--) {
     ofs += trail->section[i].len;
     if (strncmp(trail->section[i].name, name, 4) == 0) {
       lseek(fd, -ofs, SEEK_END);
@@ -301,7 +300,7 @@ static void do_print_help(void)
 
 static int parse_command_line(char_os **argv)
 {
-  int i, j, len, parsed;
+  int i, len, parsed;
   /* cast to make caml_params mutable; this assumes we are only called
      by one thread at startup */
   struct caml_params* params = (struct caml_params*)caml_params;
@@ -322,7 +321,7 @@ static int parse_command_line(char_os **argv)
         atomic_store_relaxed(&caml_verb_gc, 0x001+0x004+0x008+0x010+0x020);
         break;
       case 'p':
-        for (j = 0; caml_names_of_builtin_cprim[j] != NULL; j++)
+        for (int j = 0; caml_names_of_builtin_cprim[j] != NULL; j++)
           printf("%s\n", caml_names_of_builtin_cprim[j]);
         exit(0);
         break;
@@ -379,7 +378,6 @@ static int parse_command_line(char_os **argv)
    freed, since the runtime will terminate after calling this. */
 static void do_print_config(void)
 {
-  int i;
   char_os * dir;
 
   /* Print the runtime configuration */
@@ -423,7 +421,7 @@ static void do_print_config(void)
   /* Parse ld.conf and print the effective search path */
   puts("shared_libs_path:");
   caml_parse_ld_conf();
-  for (i = 0; i < caml_shared_libs_path.size; i++) {
+  for (int i = 0; i < caml_shared_libs_path.size; i++) {
     dir = caml_shared_libs_path.contents[i];
     if (dir[0] == 0)
 #ifdef _WIN32

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -52,11 +52,10 @@ static void init_segments(void)
 {
   extern struct segment caml_code_segments[];
   char * caml_code_area_start, * caml_code_area_end;
-  int i;
 
   caml_code_area_start = caml_code_segments[0].begin;
   caml_code_area_end = caml_code_segments[0].end;
-  for (i = 1; caml_code_segments[i].begin != 0; i++) {
+  for (int i = 1; caml_code_segments[i].begin != 0; i++) {
     if (caml_code_segments[i].begin < caml_code_area_start)
       caml_code_area_start = caml_code_segments[i].begin;
     if (caml_code_segments[i].end > caml_code_area_end)

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -643,7 +643,7 @@ int caml_unix_random_seed(intnat data[16])
 CAMLprim value caml_sys_random_seed (value unit)
 {
   intnat data[16];
-  int n, i;
+  int n;
   value res;
 #ifdef _WIN32
   n = caml_win32_random_seed(data);
@@ -652,7 +652,7 @@ CAMLprim value caml_sys_random_seed (value unit)
 #endif
   /* Convert to an OCaml array of ints */
   res = caml_alloc_small(n, 0);
-  for (i = 0; i < n; i++) Field(res, i) = Val_long(data[i]);
+  for (int i = 0; i < n; i++) Field(res, i) = Val_long(data[i]);
   return res;
 }
 

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -135,15 +135,13 @@ caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
 
 caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
 {
-  const char * p;
   char * dir, * fullname;
-  int i;
   struct stat st;
 
-  for (p = name; *p != 0; p++) {
+  for (const char *p = name; *p != 0; p++) {
     if (*p == '/') goto not_found;
   }
-  for (i = 0; i < path->size; i++) {
+  for (int i = 0; i < path->size; i++) {
     dir = path->contents[i];
     if (dir[0] == 0) dir = ".";  /* empty path component = current dir */
     fullname = caml_stat_strconcat(3, dir, "/", name);
@@ -175,14 +173,11 @@ static int cygwin_file_exists(const char * name)
 static caml_stat_string cygwin_search_exe_in_path(struct ext_table * path,
                                                   const char * name)
 {
-  const char * p;
   char * dir, * fullname;
-  int i;
-
-  for (p = name; *p != 0; p++) {
+  for (const char *p = name; *p != 0; p++) {
     if (*p == '/' || *p == '\\') goto not_found;
   }
-  for (i = 0; i < path->size; i++) {
+  for (int i = 0; i < path->size; i++) {
     dir = path->contents[i];
     if (dir[0] == 0) dir = ".";  /* empty path component = current dir */
     fullname = caml_stat_strconcat(3, dir, "/", name);

--- a/runtime/weak.c
+++ b/runtime/weak.c
@@ -46,7 +46,7 @@ struct caml_ephe_info* caml_alloc_ephe_info (void)
 /* [len] is a value that represents a number of words (fields) */
 CAMLprim value caml_ephe_create (value len)
 {
-  mlsize_t size, i;
+  mlsize_t size;
   value res;
   caml_domain_state* domain_state = Caml_state;
 
@@ -59,7 +59,7 @@ CAMLprim value caml_ephe_create (value len)
 
   Ephe_link(res) = domain_state->ephe_info->live;
   domain_state->ephe_info->live = res;
-  for (i = CAML_EPHE_DATA_OFFSET; i < size; i++)
+  for (mlsize_t i = CAML_EPHE_DATA_OFFSET; i < size; i++)
     Field(res, i) = caml_ephe_none;
   /* run memprof callbacks */
   return caml_process_pending_actions_with_root(res);
@@ -123,14 +123,14 @@ static void do_check_key_clean(value e, mlsize_t offset)
 void caml_ephe_clean (value v) {
   value child;
   int release_data = 0;
-  mlsize_t size, i;
+  mlsize_t size;
   header_t hd;
 
   if (caml_gc_phase != Phase_sweep_ephe) return;
 
   hd = Hd_val(v);
   size = Wosize_hd (hd);
-  for (i = CAML_EPHE_FIRST_KEY; i < size; i++) {
+  for (mlsize_t i = CAML_EPHE_FIRST_KEY; i < size; i++) {
     child = Field(v, i);
   ephemeron_again:
     if (child != caml_ephe_none && Is_block(child)) {
@@ -425,7 +425,6 @@ static value ephe_blit_field (value es, mlsize_t offset_s,
 {
   CAMLparam2(es,ed);
   CAMLlocal1(ar);
-  long i;
 
   if (length == 0) CAMLreturn(Val_unit);
 
@@ -436,11 +435,11 @@ static value ephe_blit_field (value es, mlsize_t offset_s,
   caml_ephe_clean(ed);
 
   if (offset_d < offset_s) {
-    for (i = 0; i < length; i++) {
+    for (long i = 0; i < length; i++) {
       do_set(ed, offset_d + i, Field(es, (offset_s + i)));
     }
   } else {
-    for (i = length - 1; i >= 0; i--) {
+    for (long i = length - 1; i >= 0; i--) {
       do_set(ed, offset_d + i, Field(es, (offset_s + i)));
     }
   }

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -154,14 +154,12 @@ wchar_t * caml_search_in_path(struct ext_table * path, const wchar_t * name)
 {
   wchar_t * dir, * fullname;
   char * u8;
-  const wchar_t * p;
-  int i;
   struct _stati64 st;
 
-  for (p = name; *p != 0; p++) {
+  for (const wchar_t *p = name; *p != 0; p++) {
     if (*p == '/' || *p == '\\') goto not_found;
   }
-  for (i = 0; i < path->size; i++) {
+  for (int i = 0; i < path->size; i++) {
     dir = path->contents[i];
     if (dir[0] == 0) continue;
          /* not sure what empty path components mean under Windows */
@@ -350,9 +348,7 @@ static void store_argument(wchar_t * arg)
 
 static void expand_argument(wchar_t * arg)
 {
-  wchar_t * p;
-
-  for (p = arg; *p != 0; p++) {
+  for (wchar_t *p = arg; *p != 0; p++) {
     if (*p == L'*' || *p == L'?') {
       expand_pattern(arg);
       return;
@@ -395,12 +391,11 @@ static void expand_pattern(wchar_t * pat)
 
 CAMLexport void caml_expand_command_line(int * argcp, wchar_t *** argvp)
 {
-  int i;
   argc = 0;
   argvsize = 16;
   argv = (wchar_t **) caml_stat_alloc_noexc(argvsize * sizeof(wchar_t *));
   if (argv == NULL) out_of_memory();
-  for (i = 0; i < *argcp; i++) expand_argument((*argvp)[i]);
+  for (int i = 0; i < *argcp; i++) expand_argument((*argvp)[i]);
   argv[argc] = NULL;
   *argcp = argc;
   *argvp = argv;

--- a/stdlib/header.c
+++ b/stdlib/header.c
@@ -50,21 +50,20 @@ static char * searchpath(char * name)
 {
   static char fullname[MAXPATHLEN + 1];
   char * path;
-  char * p;
-  char * q;
   struct stat st;
 
-  for (p = name; *p != 0; p++) {
+  for (char *p = name; *p != 0; p++) {
     if (*p == '/') return name;
   }
   path = getenv("PATH");
   if (path == NULL) return name;
   while(1) {
+    char * p;
     for (p = fullname; *path != 0 && *path != ':'; p++, path++)
       if (p < fullname + MAXPATHLEN) *p = *path;
     if (p != fullname && p < fullname + MAXPATHLEN)
       *p++ = '/';
-    for (q = name; *q != 0; p++, q++)
+    for (char *q = name; *q != 0; p++, q++)
       if (p < fullname + MAXPATHLEN) *p = *q;
     *p = 0;
     if (stat(fullname, &st) == 0 && S_ISREG(st.st_mode)) break;
@@ -90,14 +89,14 @@ static int file_ok(char * name)
 
 static char * searchpath(char * name)
 {
-  char * path, * fullname, * p;
+  char * path, * fullname;
 
   path = getenv("PATH");
   fullname = malloc(strlen(name) + (path == NULL ? 0 : strlen(path)) + 6);
   /* 6 = "/" plus ".exe" plus final "\0" */
   if (fullname == NULL) return name;
   /* Check for absolute path name */
-  for (p = name; *p != 0; p++) {
+  for (char *p = name; *p != 0; p++) {
     if (*p == '/' || *p == '\\') {
       if (file_ok(name)) return name;
       strcpy(fullname, name);
@@ -109,6 +108,7 @@ static char * searchpath(char * name)
   /* Search in path */
   if (path == NULL) return name;
   while(1) {
+    char * p;
     for (p = fullname; *path != 0 && *path != ':'; p++, path++) *p = *path;
     if (p != fullname) *p++ = '/';
     strcpy(p, name);
@@ -134,7 +134,7 @@ static char * read_runtime_path(int fd)
 {
   char buffer[TRAILER_SIZE];
   static char runtime_path[MAXPATHLEN];
-  int num_sections, i;
+  int num_sections;
   uint32_t path_size;
   long ofs;
 
@@ -144,7 +144,7 @@ static char * read_runtime_path(int fd)
   ofs = TRAILER_SIZE + num_sections * 8;
   lseek(fd, -ofs, SEEK_END);
   path_size = 0;
-  for (i = 0; i < num_sections; i++) {
+  for (int i = 0; i < num_sections; i++) {
     if (read(fd, buffer, 8) < 8) return NULL;
     if (buffer[0] == 'R' && buffer[1] == 'N' &&
         buffer[2] == 'T' && buffer[3] == 'M') {

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -49,7 +49,7 @@ static __inline char * read_runtime_path(HANDLE h)
   char buffer[TRAILER_SIZE];
   static char runtime_path[MAX_PATH];
   DWORD nread;
-  int num_sections, path_size, i;
+  int num_sections, path_size;
   long ofs;
 
   if (SetFilePointer(h, -TRAILER_SIZE, NULL, FILE_END) == -1) return NULL;
@@ -59,7 +59,7 @@ static __inline char * read_runtime_path(HANDLE h)
   ofs = TRAILER_SIZE + num_sections * 8;
   if (SetFilePointer(h, - ofs, NULL, FILE_END) == -1) return NULL;
   path_size = 0;
-  for (i = 0; i < num_sections; i++) {
+  for (int i = 0; i < num_sections; i++) {
     if (! ReadFile(h, buffer, 8, &nread, NULL) || nread != 8) return NULL;
     if (buffer[0] == 'R' && buffer[1] == 'N' &&
         buffer[2] == 'T' && buffer[3] == 'M') {

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -106,23 +106,22 @@ int main(int argc, char **argv)
     extern void call_gen_code(void (*)(long, long, long *), long, long, long *);
     long n;
     long * a, * b;
-    long i;
 
     srand(argc >= 3 ? atoi(argv[2]) : time((time_t *) 0));
     n = atoi(argv[1]);
     a = (long *) malloc(n * sizeof(long));
-    for (i = 0 ; i < n; i++) a[i] = rand() & 0xFFF;
+    for (long i = 0 ; i < n; i++) a[i] = rand() & 0xFFF;
 #ifdef DEBUG
-    for (i = 0; i < n; i++) printf("%ld ", a[i]); printf("\n");
+    for (long i = 0; i < n; i++) printf("%ld ", a[i]); printf("\n");
 #endif
     b = (long *) malloc(n * sizeof(long));
-    for (i = 0; i < n; i++) b[i] = a[i];
+    for (long i = 0; i < n; i++) b[i] = a[i];
     call_gen_code(FUN, 0, n-1, a);
 #ifdef DEBUG
-    for (i = 0; i < n; i++) printf("%ld ", a[i]); printf("\n");
+    for (long i = 0; i < n; i++) printf("%ld ", a[i]); printf("\n");
 #endif
     qsort(b, n, sizeof(long), cmpint);
-    for (i = 0; i < n; i++) {
+    for (long i = 0; i < n; i++) {
       if (a[i] != b[i]) { printf("Bug!\n"); return 2; }
     }
     printf("OK\n");

--- a/testsuite/tests/asmgen/mainarith.c
+++ b/testsuite/tests/asmgen/mainarith.c
@@ -309,7 +309,6 @@ static intnat rnd(void)
 
 int main(int argc, char **argv)
 {
-  int i;
   double weird[4];
 
   if (argc >= 5) {
@@ -339,7 +338,7 @@ int main(int argc, char **argv)
     }
   }
   printf("Testing %d random values\n", NUM_RANDOM_ITERATIONS);
-  for (i = 0; i < NUM_RANDOM_ITERATIONS; i++) {
+  for (int i = 0; i < NUM_RANDOM_ITERATIONS; i++) {
     X = rnd();
     Y = rnd();
     F = X / 1e3;

--- a/testsuite/tests/asmgen/mainimmed.c
+++ b/testsuite/tests/asmgen/mainimmed.c
@@ -72,7 +72,6 @@ static intnat rnd(void)
 
 int main(int argc, char **argv)
 {
-  int i;
-  for (i = 0; i < NUM_RANDOM_ITERATIONS; i++) do_test(rnd());
+  for (int i = 0; i < NUM_RANDOM_ITERATIONS; i++) do_test(rnd());
   return 0;
 }

--- a/testsuite/tests/frame-pointers/fp_backtrace.c
+++ b/testsuite/tests/frame-pointers/fp_backtrace.c
@@ -108,10 +108,11 @@ static void print_symbol(const char* symbol, const regmatch_t* match)
 void fp_backtrace(value argv0)
 {
   const char* execname = String_val(argv0);
-  struct frame_info* next = NULL;
   const char* symbol = NULL;
 
-  for (struct frame_info* fi = __builtin_frame_address(0); fi; fi = next) {
+  for (struct frame_info *fi = __builtin_frame_address(0), *next = NULL;
+       fi;
+       fi = next) {
     next = fi->prev;
 
     /* Detect the simplest kind of infinite loop */

--- a/testsuite/tests/gc-roots/globrootsprim.c
+++ b/testsuite/tests/gc-roots/globrootsprim.c
@@ -89,7 +89,6 @@ value gb_young2old(value _dummy) {
 value gb_static2young(value static_value, value full_major) {
   CAMLparam2 (static_value, full_major);
   CAMLlocal1(v);
-  int i;
 
   root = Val_unit;
   caml_register_generational_global_root(&root);
@@ -106,7 +105,7 @@ value gb_static2young(value static_value, value full_major) {
   caml_callback(full_major, Val_unit);
 
   /* Fill the minor heap to make sure the old block is overwritten */
-  for(i = 0; i < 1000000; i++)
+  for (int i = 0; i < 1000000; i++)
     caml_alloc_small(1, 0);
 
   v = Field(root, 0);

--- a/testsuite/tests/lib-bigarray-2/bigarrcstub.c
+++ b/testsuite/tests/lib-bigarray-2/bigarrcstub.c
@@ -24,18 +24,16 @@ double ctab[DIMX][DIMY];
 
 void filltab(void)
 {
-  int x, y;
-  for (x = 0; x < DIMX; x++)
-    for (y = 0; y < DIMY; y++)
+  for (int x = 0; x < DIMX; x++)
+    for (int y = 0; y < DIMY; y++)
       ctab[x][y] = x * 100 + y;
 }
 
 void printtab(double tab[DIMX][DIMY])
 {
-  int x, y;
-  for (x = 0; x < DIMX; x++) {
+  for (int x = 0; x < DIMX; x++) {
     printf("%3d", x);
-    for (y = 0; y < DIMY; y++)
+    for (int y = 0; y < DIMY; y++)
       printf("  %6.1f", tab[x][y]);
     printf("\n");
   }

--- a/testsuite/tests/lib-digest/blake2b_self_test_stubs.c
+++ b/testsuite/tests/lib-digest/blake2b_self_test_stubs.c
@@ -16,13 +16,12 @@
 
 static void selftest_seq(uint8_t *out, size_t len, uint32_t seed)
 {
-  size_t i;
   uint32_t t, a , b;
 
   a = 0xDEAD4BAD * seed;              // prime
   b = 1;
 
-  for (i = 0; i < len; i++) {         // fill the buf
+  for (size_t i = 0; i < len; i++) {         // fill the buf
     t = a + b;
     a = b;
     b = t;
@@ -59,16 +58,16 @@ int blake2b_selftest()
   const size_t b2b_md_len[4] = { 20, 32, 48, 64 };
   const size_t b2b_in_len[6] = { 0, 3, 128, 129, 255, 1024 };
 
-  size_t i, j, outlen, inlen;
+  size_t outlen, inlen;
   uint8_t in[1024], md[64], key[64];
   struct BLAKE2_context ctx;
 
   // 256-bit hash for testing
   caml_BLAKE2Init(&ctx, 32, 0, NULL);
 
-  for (i = 0; i < 4; i++) {
+  for (size_t i = 0; i < 4; i++) {
     outlen = b2b_md_len[i];
-    for (j = 0; j < 6; j++) {
+    for (size_t j = 0; j < 6; j++) {
       inlen = b2b_in_len[j];
 
       selftest_seq(in, inlen, inlen);     // unkeyed hash
@@ -83,7 +82,7 @@ int blake2b_selftest()
 
   // compute and compare the hash of hashes
   caml_BLAKE2Final(&ctx, 32, md);
-  for (i = 0; i < 32; i++) {
+  for (size_t i = 0; i < 32; i++) {
     if (md[i] != blake2b_res[i])
       return -1;
   }

--- a/testsuite/tests/lib-dynlink-native/factorial.c
+++ b/testsuite/tests/lib-dynlink-native/factorial.c
@@ -24,9 +24,8 @@ value factorial(value n){
 
   static char buf[256];
   int x = 1;
-  int i;
   int m = Int_val(n);
-  for (i = 1; i <= m; i++) x *= i;
+  for (int i = 1; i <= m; i++) x *= i;
   sprintf(buf,"%i",x);
   s = caml_copy_string(buf);
   CAMLreturn (s);


### PR DESCRIPTION
C99 allows declaring the for loop variable iterator inside the for, reducing the scope of the variable. I think this improves readability and reduces the cognitive load of tracking variables scope. Now, if a for loop doesn't define it's iterator, it's likely that the final value is needed out of the loop.

The diff was partly generated with variations of the following [Coccinelle](https://coccinelle.gitlabpages.inria.fr/website/) semantic patch (copyrighted by Richard Russon (flatcap) and released under the GPLv2):

```cocci
// Quite often, the loop variable in a 'for' loop isn't used elsewhere.
// C99 allows us to reduce the scope to *just* the 'for' loop.

@@
type T;
identifier I;
statement S;
expression E1, E2, E3;
@@

- T I;
  ... when != I
- for (I = E1; E2; E3)
+ for (T I = E1; E2; E3)
    S
  ... when != I
```

invoked as `for file in **/*.{c,h{,.in}}; do spatch -j8 --in-place --keep-comments --sp-file scoped-for-variable.cocci "$file"; done`. The script doesn't support nested for loops, loops reusing the same iterator, multiple variables defined in the for loop, so manual editing was needed afterwards.

I acknowledge that this is a behemoth of a PR, and would have preferred to be able to generate the diff automatically. To ease reviewer's life, I've kept it focused. There's no shadowing of variables, I'm not touching complex for loops (where there might be iterators of different types initialized and used). I'm not changing the type of anything.

No change entry needed.
