### PR TITLE
Annotate `caml_stat_*` functions with compiler attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Working version
 
 ### Runtime system:
 
+- #?????: Annotate caml_stat functions with compiler attributes for
+  static analysis.
+  (Antonin Décimo, review by ????)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/ocamltest/run_stubs.c
+++ b/ocamltest/run_stubs.c
@@ -39,7 +39,7 @@ static array cstringvect(value arg)
   mlsize_t size;
 
   size = Wosize_val(arg);
-  res = (array) caml_stat_alloc((size + 1) * sizeof(char_os *));
+  res = caml_stat_alloc((size + 1) * sizeof(char_os *));
   for (mlsize_t i = 0; i < size; i++)
     res[i] = caml_stat_strdup_to_os(String_val(Field(arg, i)));
   res[size] = NULL;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -311,7 +311,7 @@ static caml_thread_t caml_thread_new_info(void)
   caml_domain_state *domain_state = Caml_state;
   uintnat stack_wsize = caml_get_init_stack_wsize();
 
-  th = (caml_thread_t)caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
+  th = caml_stat_alloc_noexc(sizeof(struct caml_thread_struct));
   if (th == NULL) return NULL;
 
   th->descr = Val_unit;
@@ -527,7 +527,7 @@ static void caml_thread_domain_initialize_hook(void)
   caml_check_error(ret, "caml_thread_domain_initialize_hook");
 
   new_thread =
-    (caml_thread_t) caml_stat_alloc(sizeof(struct caml_thread_struct));
+    caml_stat_alloc(sizeof(struct caml_thread_struct));
 
   new_thread->domain_id = Caml_state->id;
   new_thread->descr = caml_thread_new_descriptor(Val_unit);

--- a/otherlibs/unix/closedir.c
+++ b/otherlibs/unix/closedir.c
@@ -29,10 +29,10 @@ CAMLprim value caml_unix_closedir(value vd)
 {
   CAMLparam1(vd);
   DIR * d = DIR_Val(vd);
-  if (d == (DIR *) NULL) caml_unix_error(EBADF, "closedir", Nothing);
+  if (d == NULL) caml_unix_error(EBADF, "closedir", Nothing);
   caml_enter_blocking_section();
   closedir(d);
   caml_leave_blocking_section();
-  DIR_Val(vd) = (DIR *) NULL;
+  DIR_Val(vd) = NULL;
   CAMLreturn(Val_unit);
 }

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -30,7 +30,7 @@ char_os ** caml_unix_cstringvect(value arg, char * cmdname)
   for (mlsize_t i = 0; i < size; i++)
     if (! caml_string_is_c_safe(Field(arg, i)))
       caml_unix_error(EINVAL, cmdname, Field(arg, i));
-  res = (char_os **) caml_stat_alloc((size + 1) * sizeof(char_os *));
+  res = caml_stat_alloc((size + 1) * sizeof(char_os *));
   for (mlsize_t i = 0; i < size; i++)
     res[i] = caml_stat_strdup_to_os(String_val(Field(arg, i)));
   res[size] = NULL;

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -124,7 +124,7 @@ CAMLprim value caml_unix_gethostbyaddr(value a)
   caml_leave_blocking_section();
   if (rc != 0) hp = NULL;
 #endif
-  if (hp == (struct hostent *) NULL) caml_raise_not_found();
+  if (hp == NULL) caml_raise_not_found();
   return alloc_host_entry(hp);
 }
 
@@ -168,7 +168,7 @@ CAMLprim value caml_unix_gethostbyname(value name)
 
   caml_stat_free(hostname);
 
-  if (hp == (struct hostent *) NULL) caml_raise_not_found();
+  if (hp == NULL) caml_raise_not_found();
   return alloc_host_entry(hp);
 }
 

--- a/otherlibs/unix/getproto.c
+++ b/otherlibs/unix/getproto.c
@@ -45,7 +45,7 @@ CAMLprim value caml_unix_getprotobyname(value name)
   struct protoent * entry;
   if (! caml_string_is_c_safe(name)) caml_raise_not_found();
   entry = getprotobyname(String_val(name));
-  if (entry == (struct protoent *) NULL) caml_raise_not_found();
+  if (entry == NULL) caml_raise_not_found();
   return alloc_proto_entry(entry);
 }
 
@@ -53,7 +53,7 @@ CAMLprim value caml_unix_getprotobynumber(value proto)
 {
   struct protoent * entry;
   entry = getprotobynumber(Int_val(proto));
-  if (entry == (struct protoent *) NULL) caml_raise_not_found();
+  if (entry == NULL) caml_raise_not_found();
   return alloc_proto_entry(entry);
 }
 

--- a/otherlibs/unix/getpw.c
+++ b/otherlibs/unix/getpw.c
@@ -53,7 +53,7 @@ CAMLprim value caml_unix_getpwnam(value name)
   if (! caml_string_is_c_safe(name)) caml_raise_not_found();
   errno = 0;
   entry = getpwnam(String_val(name));
-  if (entry == (struct passwd *) NULL) {
+  if (entry == NULL) {
     if (errno == EINTR) {
       caml_uerror("getpwnam", Nothing);
     } else {
@@ -68,7 +68,7 @@ CAMLprim value caml_unix_getpwuid(value uid)
   struct passwd * entry;
   errno = 0;
   entry = getpwuid(Int_val(uid));
-  if (entry == (struct passwd *) NULL) {
+  if (entry == NULL) {
     if (errno == EINTR) {
       caml_uerror("getpwuid", Nothing);
     } else {

--- a/otherlibs/unix/getserv.c
+++ b/otherlibs/unix/getserv.c
@@ -52,7 +52,7 @@ CAMLprim value caml_unix_getservbyname(value name, value proto)
   if (! (caml_string_is_c_safe(name) && caml_string_is_c_safe(proto)))
     caml_raise_not_found();
   entry = getservbyname(String_val(name), String_val(proto));
-  if (entry == (struct servent *) NULL) caml_raise_not_found();
+  if (entry == NULL) caml_raise_not_found();
   return alloc_service_entry(entry);
 }
 
@@ -61,7 +61,7 @@ CAMLprim value caml_unix_getservbyport(value port, value proto)
   struct servent * entry;
   if (! caml_string_is_c_safe(proto)) caml_raise_not_found();
   entry = getservbyport(htons(Int_val(port)), String_val(proto));
-  if (entry == (struct servent *) NULL) caml_raise_not_found();
+  if (entry == NULL) caml_raise_not_found();
   return alloc_service_entry(entry);
 }
 

--- a/otherlibs/unix/opendir.c
+++ b/otherlibs/unix/opendir.c
@@ -38,7 +38,7 @@ CAMLprim value caml_unix_opendir(value path)
   d = opendir(p);
   caml_leave_blocking_section();
   caml_stat_free(p);
-  if (d == (DIR *) NULL) caml_uerror("opendir", path);
+  if (d == NULL) caml_uerror("opendir", path);
   res = caml_alloc_small(1, Abstract_tag);
   DIR_Val(res) = d;
   CAMLreturn(res);

--- a/otherlibs/unix/readdir.c
+++ b/otherlibs/unix/readdir.c
@@ -33,10 +33,10 @@ CAMLprim value caml_unix_readdir(value vd)
   DIR * d;
   directory_entry * e;
   d = DIR_Val(vd);
-  if (d == (DIR *) NULL) caml_unix_error(EBADF, "readdir", Nothing);
+  if (d == NULL) caml_unix_error(EBADF, "readdir", Nothing);
   caml_enter_blocking_section();
   e = readdir((DIR *) d);
   caml_leave_blocking_section();
-  if (e == (directory_entry *) NULL) caml_raise_end_of_file();
+  if (e == NULL) caml_raise_end_of_file();
   return caml_copy_string(e->d_name);
 }

--- a/otherlibs/unix/rewinddir.c
+++ b/otherlibs/unix/rewinddir.c
@@ -29,7 +29,7 @@
 CAMLprim value caml_unix_rewinddir(value vd)
 {
   DIR * d = DIR_Val(vd);
-  if (d == (DIR *) NULL) caml_unix_error(EBADF, "rewinddir", Nothing);
+  if (d == NULL) caml_unix_error(EBADF, "rewinddir", Nothing);
   rewinddir(d);
   return Val_unit;
 }

--- a/otherlibs/unix/select_unix.c
+++ b/otherlibs/unix/select_unix.c
@@ -81,7 +81,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   if (retcode != 0) caml_unix_error(EINVAL, "select", Nothing);
   tm = Double_val(timeout);
   if (tm < 0.0)
-    tvp = (struct timeval *) NULL;
+    tvp = NULL;
   else {
     tv.tv_sec = (int) tm;
     tv.tv_usec = (int) (1e6 * (tm - tv.tv_sec));

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -184,7 +184,7 @@ static LPSELECTDATA select_data_new (LPSELECTDATA lpSelectData,
   /* Allocate the data structure */
   LPSELECTDATA res;
 
-  res = (LPSELECTDATA)caml_stat_alloc(sizeof(SELECTDATA));
+  res = caml_stat_alloc(sizeof(SELECTDATA));
 
   /* Init common data */
   caml_win32_list_init((LPLIST)res);
@@ -1063,7 +1063,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       exceptfds_len  = caml_list_length(exceptfds);
       hdsMax         = MAX(readfds_len, MAX(writefds_len, exceptfds_len));
 
-      hdsData = (HANDLE *)caml_stat_alloc(sizeof(HANDLE) * hdsMax);
+      hdsData = caml_stat_alloc(sizeof(HANDLE) * hdsMax);
 
       if (tm >= 0.0)
         {
@@ -1142,7 +1142,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       DEBUG_PRINT("Building events done array");
       nEventsMax   = caml_win32_list_length((LPLIST)lpSelectData);
       nEventsCount = 0;
-      lpEventsDone = (HANDLE *)caml_stat_alloc(sizeof(HANDLE) * nEventsMax);
+      lpEventsDone = caml_stat_alloc(sizeof(HANDLE) * nEventsMax);
 
       iterSelectData = lpSelectData;
       while (iterSelectData != NULL)

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -1030,7 +1030,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
         && fdlist_to_fdset(exceptfds, &except)) {
       DEBUG_PRINT("only sockets to select on, using classic select");
       if (tm < 0.0) {
-        tvp = (struct timeval *) NULL;
+        tvp = NULL;
       } else {
         tv.tv_sec = (int) tm;
         tv.tv_usec = (int) (1e6 * (tm - (int) tm));

--- a/otherlibs/unix/setgroups.c
+++ b/otherlibs/unix/setgroups.c
@@ -35,7 +35,7 @@ CAMLprim value caml_unix_setgroups(value groups)
   int n;
 
   size = Wosize_val(groups);
-  gidset = (gid_t *) caml_stat_alloc(size * sizeof(gid_t));
+  gidset = caml_stat_alloc(size * sizeof(gid_t));
   for (mlsize_t i = 0; i < size; i++) gidset[i] = Int_val(Field(groups, i));
 
   n = setgroups(size, gidset);

--- a/otherlibs/unix/symlink_win32.c
+++ b/otherlibs/unix/symlink_win32.c
@@ -130,7 +130,7 @@ CAMLprim value caml_unix_has_symlink(value unit)
 
       if (!GetTokenInformation(hProcess, TokenPrivileges, NULL, 0, &length)) {
         if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
-          TOKEN_PRIVILEGES* privileges = (TOKEN_PRIVILEGES*)caml_stat_alloc(length);
+          TOKEN_PRIVILEGES* privileges = caml_stat_alloc(length);
           if (GetTokenInformation(hProcess,
                                   TokenPrivileges,
                                   privileges,

--- a/otherlibs/unix/time.c
+++ b/otherlibs/unix/time.c
@@ -20,7 +20,7 @@
 
 double caml_unix_time_unboxed(value unit)
 {
-  return ((double) time((time_t *) NULL));
+  return ((double) time(NULL));
 }
 
 CAMLprim value caml_unix_time(value unit)

--- a/otherlibs/unix/utimes_unix.c
+++ b/otherlibs/unix/utimes_unix.c
@@ -38,7 +38,7 @@ CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
   at = Double_val(atime);
   mt = Double_val(mtime);
   if (at == 0.0 && mt == 0.0) {
-    t = (struct timeval *) NULL;
+    t = NULL;
   } else {
     tv[0].tv_sec = at;
     tv[0].tv_usec = (at - tv[0].tv_sec) * 1000000;

--- a/otherlibs/unix/winworker.c
+++ b/otherlibs/unix/winworker.c
@@ -96,7 +96,7 @@ LPWORKER caml_win32_worker_new (void)
 {
   LPWORKER lpWorker = NULL;
 
-  lpWorker = (LPWORKER)caml_stat_alloc(sizeof(WORKER));
+  lpWorker = caml_stat_alloc(sizeof(WORKER));
   caml_win32_list_init((LPLIST)lpWorker);
   lpWorker->hJobStarted  = CreateEvent(NULL, TRUE, FALSE, NULL);
   lpWorker->hJobStop     = CreateEvent(NULL, TRUE, FALSE, NULL);

--- a/runtime/callback.c
+++ b/runtime/callback.c
@@ -406,7 +406,7 @@ CAMLprim value caml_register_named_value(value vname, value val)
     }
   }
   if (!found) {
-    struct named_value * nv = (struct named_value *)
+    struct named_value * nv =
       caml_stat_alloc(sizeof(struct named_value) + namelen);
     memcpy(nv->name, name, namelen + 1);
     nv->val = val;

--- a/runtime/caml/memory.h
+++ b/runtime/caml/memory.h
@@ -79,16 +79,21 @@ CAMLextern void caml_stat_destroy_pool(void);
 
 #endif /* CAML_INTERNALS */
 
+/* [caml_stat_free(block)] deallocates the provided [block]. */
+CAMLextern void caml_stat_free(caml_stat_block);
+
 /* [caml_stat_alloc(size)] allocates a memory block of the requested [size]
    (in bytes) and returns a pointer to it. It throws an OCaml exception in case
    the request fails, and so requires the runtime lock to be held.
 */
+CAMLmalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern caml_stat_block caml_stat_alloc(asize_t);
 
 /* [caml_stat_alloc_noexc(size)] allocates a memory block of the requested
    [size] (in bytes) and returns a pointer to it, or NULL in case the request
    fails.
 */
+CAMLmalloc(caml_stat_free, 1)
 CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
 
 /* [caml_stat_alloc_aligned(size, modulo, block*)] allocates a memory block of
@@ -97,12 +102,14 @@ CAMLextern caml_stat_block caml_stat_alloc_noexc(asize_t);
    well as the unaligned [block] (as an output parameter). It throws an OCaml
    exception in case the request fails, and so requires the runtime lock.
 */
+CAMLaligned_alloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern void* caml_stat_alloc_aligned(asize_t, int modulo, caml_stat_block*);
 
 /* [caml_stat_alloc_aligned_noexc] is a variant of [caml_stat_alloc_aligned]
    that returns NULL in case the request fails, and doesn't require the runtime
    lock to be held.
 */
+CAMLaligned_alloc(caml_stat_free, 1)
 CAMLextern void* caml_stat_alloc_aligned_noexc(asize_t, int modulo,
                                                caml_stat_block*);
 
@@ -111,10 +118,8 @@ CAMLextern void* caml_stat_alloc_aligned_noexc(asize_t, int modulo,
    bits to zero, effectively allocating a zero-initialized memory block of
    [num * size] bytes. It returns NULL in case the request fails.
 */
+CAMLcalloc(caml_stat_free, 1)
 CAMLextern caml_stat_block caml_stat_calloc_noexc(asize_t, asize_t);
-
-/* [caml_stat_free(block)] deallocates the provided [block]. */
-CAMLextern void caml_stat_free(caml_stat_block);
 
 /* [caml_stat_resize(block, size)] changes the size of the provided [block] to
    [size] bytes. The function may move the memory block to a new location (whose
@@ -124,11 +129,13 @@ CAMLextern void caml_stat_free(caml_stat_block);
    portion is indeterminate. The function throws an OCaml exception in case the
    request fails, and so requires the runtime lock to be held.
 */
+CAMLrealloc() CAMLreturns_nonnull()
 CAMLextern caml_stat_block caml_stat_resize(caml_stat_block, asize_t);
 
 /* [caml_stat_resize_noexc] is a variant of [caml_stat_resize] that returns NULL
    in case the request fails, and doesn't require the runtime lock.
 */
+CAMLrealloc()
 CAMLextern caml_stat_block caml_stat_resize_noexc(caml_stat_block, asize_t);
 
 
@@ -139,11 +146,17 @@ typedef char* caml_stat_string;
    copy of the null-terminated string [s]. It throws an OCaml exception in case
    the request fails, and so requires the runtime lock to be held.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern caml_stat_string caml_stat_strdup(const char *s);
+#ifdef _WIN32
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
+CAMLextern wchar_t* caml_stat_wcsdup(const wchar_t *s);
+#endif
 
 /* [caml_stat_strdup_noexc] is a variant of [caml_stat_strdup] that returns NULL
    in case the request fails, and doesn't require the runtime lock.
 */
+CAMLalloc(caml_stat_free, 1)
 CAMLextern caml_stat_string caml_stat_strdup_noexc(const char *s);
 
 #ifdef _WIN32
@@ -160,8 +173,10 @@ CAMLextern wchar_t* caml_stat_wcsdup_noexc(const wchar_t *s);
    except for the very last one. It throws an OCaml exception in case the
    request fails, and so requires the runtime lock to be held.
 */
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern caml_stat_string caml_stat_strconcat(int n, ...);
 #ifdef _WIN32
+CAMLalloc(caml_stat_free, 1) CAMLreturns_nonnull()
 CAMLextern wchar_t* caml_stat_wcsconcat(int n, ...);
 #endif
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -220,6 +220,33 @@ CAMLdeprecated_typedef(addr, char *);
 #endif
 #endif /* CAML_INTERNALS */
 
+#if __has_attribute(malloc) && __has_attribute(warn_unused_result) &&   \
+  __has_attribute(alloc_size) && __has_attribute(alloc_align) &&        \
+  __has_attribute(returns_nonnull)
+  #define CAMLreturns_nonnull() __attribute__ ((returns_nonnull))
+  #define CAMLrealloc(...) __attribute__ ((warn_unused_result,alloc_size(2)))
+  #if defined(__GNUC__) && !defined(__llvm__)
+    #define CAMLalloc(deallocator,ptr_index,...)                            \
+      __attribute__ ((malloc,malloc(deallocator,ptr_index),warn_unused_result))
+  #else
+    #define CAMLalloc(deallocator,ptr_index,...)    \
+      __attribute__ ((malloc,warn_unused_result))
+  #endif
+  #define CAMLmalloc(deallocator,ptr_index,...)                           \
+    CAMLalloc(deallocator,ptr_index) __attribute__ ((alloc_size(1)))
+  #define CAMLcalloc(deallocator,ptr_index,...)                           \
+    CAMLalloc(deallocator,ptr_index) __attribute__ ((alloc_size(1,2)))
+  #define CAMLaligned_alloc(deallocator,ptr_index,...)                    \
+    CAMLmalloc(deallocator,ptr_index) __attribute__ ((alloc_align(2)))
+#else
+  #define CAMLreturns_nonnull()
+  #define CAMLrealloc(...)
+  #define CAMLalloc(...)
+  #define CAMLmalloc(...)
+  #define CAMLcalloc(...)
+  #define CAMLaligned_alloc(...)
+#endif
+
 /* GC timing hooks. These can be assigned by the user. These hooks
    must not allocate, change any heap value, nor call OCaml code. They
    can obtain the domain id with Caml_state->id. These functions must

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -89,8 +89,7 @@ void caml_remove_code_fragment(struct code_fragment *cf) {
     for [caml_remove_code_fragment] to be called concurrently and we need
     to ensure that only one code_fragment is put on to the garbage list */
   if (caml_lf_skiplist_remove(&code_fragments_by_num, cf->fragnum)) {
-    cf_cell = (struct code_fragment_garbage *)caml_stat_alloc(
-        sizeof(struct code_fragment_garbage));
+    cf_cell = caml_stat_alloc(sizeof(struct code_fragment_garbage));
 
     cf_cell->cf = cf;
 

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -613,8 +613,7 @@ static void domain_create(uintnat initial_minor_heap_wsize,
   */
   if (d->state == NULL) {
     /* FIXME: Never freed. Not clear when to. */
-    domain_state = (caml_domain_state*)
-      caml_stat_calloc_noexc(1, sizeof(caml_domain_state));
+    domain_state = caml_stat_calloc_noexc(1, sizeof(caml_domain_state));
     if (domain_state == NULL)
       goto domain_init_complete;
     d->state = domain_state;
@@ -1285,9 +1284,7 @@ CAMLprim value caml_domain_spawn(value callback, value term_sync)
   p.parent = domain_self;
   p.status = Dom_starting;
 
-  p.ml_values =
-      (struct domain_ml_values*) caml_stat_alloc(
-                                    sizeof(struct domain_ml_values));
+  p.ml_values = caml_stat_alloc(sizeof(struct domain_ml_values));
   init_domain_ml_values(p.ml_values, callback, term_sync);
 
   err = pthread_create(&th, 0, domain_thread_func, (void*)&p);

--- a/runtime/fiber.c
+++ b/runtime/fiber.c
@@ -87,8 +87,7 @@ void caml_change_max_stack_size (uintnat new_max_wsize)
 struct stack_info** caml_alloc_stack_cache (void)
 {
   struct stack_info** stack_cache =
-    (struct stack_info**)caml_stat_alloc_noexc(sizeof(struct stack_info*) *
-                                               NUM_STACK_SIZE_CLASSES);
+    caml_stat_alloc_noexc(sizeof(struct stack_info*) * NUM_STACK_SIZE_CLASSES);
   if (stack_cache == NULL)
     return NULL;
 

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -50,7 +50,7 @@ void caml_init_code_fragments(void) {
 void caml_load_code(int fd, asize_t len)
 {
   caml_code_size = len;
-  caml_start_code = (code_t) caml_stat_alloc(caml_code_size);
+  caml_start_code = caml_stat_alloc(caml_code_size);
   if (read(fd, (char *) caml_start_code, caml_code_size) != caml_code_size)
     caml_fatal_error("truncated bytecode file");
   caml_init_code_fragments();
@@ -95,7 +95,7 @@ static int* opcode_nargs = NULL;
 int* caml_init_opcode_nargs(void)
 {
   if( opcode_nargs == NULL ){
-    int* l = (int*)caml_stat_alloc(sizeof(int) * FIRST_UNIMPLEMENTED_OP);
+    int* l = caml_stat_alloc(sizeof(int) * FIRST_UNIMPLEMENTED_OP);
     for (int i = 0; i < FIRST_UNIMPLEMENTED_OP; i++) {
       l [i] = 0;
     }

--- a/runtime/frame_descriptors.c
+++ b/runtime/frame_descriptors.c
@@ -221,8 +221,7 @@ static void add_frame_descriptors(
     table->mask = tblsize - 1;
 
     if (table->descriptors != NULL) caml_stat_free(table->descriptors);
-    table->descriptors =
-      (frame_descr **) caml_stat_calloc_noexc(tblsize, sizeof(frame_descr *));
+    table->descriptors = caml_stat_calloc_noexc(tblsize, sizeof(frame_descr *));
     if (table->descriptors == NULL) caml_raise_out_of_memory();
 
     fill_hashtable(table, new_frametables);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -405,8 +405,7 @@ static void intern_alloc_storage(struct caml_intern_state* s, mlsize_t whsize,
   }
   s->obj_counter = 0;
   if (num_objects > 0) {
-    s->intern_obj_table =
-      (value *) caml_stat_alloc_noexc(num_objects * sizeof(value));
+    s->intern_obj_table = caml_stat_alloc_noexc(num_objects * sizeof(value));
     if (s->intern_obj_table == NULL) {
       intern_cleanup(s);
       caml_raise_out_of_memory();

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -170,8 +170,8 @@ CAMLexport struct channel * caml_open_descriptor_in(int fd)
 {
   struct channel * channel;
 
-  channel = (struct channel *) caml_stat_alloc(sizeof(struct channel));
-  channel->buff = (char *) caml_stat_alloc_noexc(IO_BUFFER_SIZE);
+  channel = caml_stat_alloc(sizeof(struct channel));
+  channel->buff = caml_stat_alloc_noexc(IO_BUFFER_SIZE);
   if (channel->buff == NULL){
     caml_stat_free(channel);
     caml_raise_out_of_memory();

--- a/runtime/memory.c
+++ b/runtime/memory.c
@@ -599,7 +599,7 @@ CAMLexport void* caml_stat_alloc_aligned_noexc(asize_t sz, int modulo,
   uintnat aligned_mem;
   CAMLassert(0 <= modulo);
   CAMLassert(modulo < Page_size);
-  raw_mem = (char *) caml_stat_alloc_noexc(sz + Page_size);
+  raw_mem = caml_stat_alloc_noexc(sz + Page_size);
   if (raw_mem == NULL) return NULL;
   *b = raw_mem;
   raw_mem += modulo;                /* Address to be aligned */

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -60,8 +60,7 @@ static void alloc_generic_table (struct generic_table *tbl, asize_t sz,
 
   tbl->size = sz;
   tbl->reserve = rsv;
-  new_table = (void *) caml_stat_alloc_noexc((tbl->size + tbl->reserve) *
-                                             element_size);
+  new_table = caml_stat_alloc_noexc((tbl->size + tbl->reserve) * element_size);
   if (new_table == NULL) caml_fatal_error ("not enough memory");
   if (tbl->base != NULL) caml_stat_free (tbl->base);
   tbl->base = new_table;

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -996,7 +996,7 @@ void caml_probe_win32_version(void)
   BYTE* versionInfo;
   fileName[size] = 0;
   size = GetFileVersionInfoSize(fileName, &dwHandle);
-  versionInfo = (BYTE*)malloc(size * sizeof(BYTE));
+  versionInfo = malloc(size * sizeof(BYTE));
   if (GetFileVersionInfo(fileName, 0, size, versionInfo)) {
     UINT len = 0;
     VS_FIXEDFILEINFO* vsfi = NULL;

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -339,8 +339,7 @@ static void store_argument(wchar_t * arg)
 {
   if (argc + 1 >= argvsize) {
     argvsize *= 2;
-    argv =
-      (wchar_t **) caml_stat_resize_noexc(argv, argvsize * sizeof(wchar_t *));
+    argv = caml_stat_resize_noexc(argv, argvsize * sizeof(wchar_t *));
     if (argv == NULL) out_of_memory();
   }
   argv[argc++] = arg;
@@ -393,7 +392,7 @@ CAMLexport void caml_expand_command_line(int * argcp, wchar_t *** argvp)
 {
   argc = 0;
   argvsize = 16;
-  argv = (wchar_t **) caml_stat_alloc_noexc(argvsize * sizeof(wchar_t *));
+  argv = caml_stat_alloc_noexc(argvsize * sizeof(wchar_t *));
   if (argv == NULL) out_of_memory();
   for (int i = 0; i < *argcp; i++) expand_argument((*argvp)[i]);
   argv[argc] = NULL;

--- a/testsuite/tests/asmgen/main.c
+++ b/testsuite/tests/asmgen/main.c
@@ -109,12 +109,12 @@ int main(int argc, char **argv)
 
     srand(argc >= 3 ? atoi(argv[2]) : time((time_t *) 0));
     n = atoi(argv[1]);
-    a = (long *) malloc(n * sizeof(long));
+    a = malloc(n * sizeof(long));
     for (long i = 0 ; i < n; i++) a[i] = rand() & 0xFFF;
 #ifdef DEBUG
     for (long i = 0; i < n; i++) printf("%ld ", a[i]); printf("\n");
 #endif
-    b = (long *) malloc(n * sizeof(long));
+    b = malloc(n * sizeof(long));
     for (long i = 0; i < n; i++) b[i] = a[i];
     call_gen_code(FUN, 0, n-1, a);
 #ifdef DEBUG


### PR DESCRIPTION
This helps the C compiler optimize code, and static analysis by detecting potential mismatches in alloc/free pairs.

- `malloc`

  > The `malloc` attribute indicates that the function acts like a system memory allocation function, returning a pointer to allocated storage disjoint from the storage for any other object accessible to the caller.

  https://clang.llvm.org/docs/AttributeReference.html#malloc

  > Associating a function with a deallocator helps detect calls to mismatched allocation and deallocation functions and diagnose them under the control of options such as `-Wmismatched-dealloc`. It also makes it possible to diagnose attempts to deallocate objects that were not allocated dynamically, by `-Wfree-nonheap-object`. To indicate that an allocation function both satisifies the nonaliasing property and has a deallocator associated with it, both the plain form of the attribute and the one with the deallocator argument must be used.

  > The warnings guarded by `-fanalyzer` respect allocation and deallocation pairs marked with the `malloc` attribute.

  https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-malloc-function-attribute

  Note that the `malloc` attribute can only be applied to functions returning pointers. The OCaml `value` type is a typedef to an integer type, and the C compiler will refuse applying the attribute to a function returning an OCaml value.

- `nodiscard` / `warn_unused_result`

  Prevent memory leaks by warning if the result of an allocation is ignored.

  https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result

- `alloc_align`

  > GCC uses this information to improve pointer alignment analysis.

  https://clang.llvm.org/docs/AttributeReference.html#alloc-align
  https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005falign-function-attribute

- `alloc_size`

  > GCC uses this information to improve the results of `__builtin_object_size`.

  https://clang.llvm.org/docs/AttributeReference.html#alloc-size
  https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-alloc_005fsize-function-attribute

- `returns_nonnull`

  > lets the compiler optimize callers based on the knowledge that the return value will never be null.

  > The analyzer considers the possibility that an allocation function could fail and return null. […] If the allocator always returns non-null, use `__attribute__ ((returns_nonnull))` to suppress these warnings.

  https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-returns_005fnonnull-function-attribute

The first two commits remove unnecessary casts of the return type of alloc functions returning `void *`.