### PR TITLE
Enable and fix issues reported by the `-Wwrite-string` warning

### DIFF
--- a/Changes
+++ b/Changes
@@ -549,6 +549,9 @@ _______________
   oversight. No known program triggers the bug.
   (Richard Eisenberg, review by Florian Angeletti)
 
+- #13385: Fix memory leaks in bytecode backtraces debug information.
+  (Antonin Décimo, review by Miod Vallat)
+
 OCaml 5.2.0 (13 May 2024)
 -------------------------
 

--- a/configure
+++ b/configure
@@ -14058,6 +14058,50 @@ fi
 
 done
 
+# Give string constants the type `const char[length]` so that copying
+# the address of one into a non-`const char *` pointer produces a
+# warning.
+as_CACHEVAR=`printf "%s\n" "ax_cv_check_cflags_$warn_error_flag_-Wwrite-string" | $as_tr_sh`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts -Wwrite-string" >&5
+printf %s "checking whether the C compiler accepts -Wwrite-string... " >&6; }
+if eval test \${$as_CACHEVAR+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+
+  ax_check_save_flags=$CFLAGS
+  CFLAGS="$CFLAGS $warn_error_flag -Wwrite-string"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  eval "$as_CACHEVAR=yes"
+else $as_nop
+  eval "$as_CACHEVAR=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+  CFLAGS=$ax_check_save_flags
+fi
+eval ac_res=\$$as_CACHEVAR
+	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+printf "%s\n" "$ac_res" >&6; }
+if eval test \"x\$"$as_CACHEVAR"\" = x"yes"
+then :
+  internal_cflags="$internal_cflags -Wwrite-string"
+else $as_nop
+  :
+fi
+
+
 case $enable_warn_error,true in #(
   yes,*|,true) :
     cc_warnings="$cc_warnings $warn_error_flag" ;; #(

--- a/configure.ac
+++ b/configure.ac
@@ -856,6 +856,12 @@ for flag in '-Wimplicit-fallthrough=5' '-Wimplicit-fallthrough'; do
     [cc_warnings="$cc_warnings $flag"; break], [], [$warn_error_flag])
 done
 
+# Give string constants the type `const char[length]` so that copying
+# the address of one into a non-`const char *` pointer produces a
+# warning.
+AX_CHECK_COMPILE_FLAG([-Wwrite-string],
+  [internal_cflags="$internal_cflags -Wwrite-string"], [], [$warn_error_flag])
+
 AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
   [yes,*|,true],
     [cc_warnings="$cc_warnings $warn_error_flag"])

--- a/ocamltest/run_common.h
+++ b/ocamltest/run_common.h
@@ -30,7 +30,7 @@ static void defaultLogger(void *where, const char *format, va_list ap)
   vfprintf(stderr, format, ap);
 }
 
-static void mylog(Logger *logger, void *loggerData, char *fmt, ...)
+static void mylog(Logger *logger, void *loggerData, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -249,7 +249,6 @@ static int handle_process_termination(
   pid_t pid, int status, const char *corefilename_prefix)
 {
   int signal, core = 0;
-  char *corestr;
 
   if (WIFEXITED(status)) return WEXITSTATUS(status);
 
@@ -262,10 +261,9 @@ static int handle_process_termination(
 #ifdef WCOREDUMP
   core = WCOREDUMP(status);
 #endif /* WCOREDUMP */
-  corestr = core ? "" : "no ";
   fprintf(stderr,
     "Process %lld got signal %d(%s), %score dumped\n",
-    (long long) pid, signal, strsignal(signal), corestr
+    (long long) pid, signal, strsignal(signal), core ? "" : "no "
   );
 
   if (core)

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -111,7 +111,7 @@ extern void caml_unix_check_path(value path, const char * cmdname);
 
 #define DIR_Val(v) *((DIR **) &Field(v, 0))
 
-extern char_os ** caml_unix_cstringvect(value arg, char * cmdname);
+extern char_os ** caml_unix_cstringvect(value arg, const char * cmdname);
 extern void caml_unix_cstringvect_free(char_os **);
 
 extern int caml_unix_cloexec_default;
@@ -123,8 +123,8 @@ extern int caml_win32_set_inherit(HANDLE fd, BOOL inherit);
 #define caml_win32_set_cloexec(fd, cloexec) \
   caml_win32_set_inherit((fd), ! caml_unix_cloexec_p((cloexec)))
 #else
-extern void caml_unix_set_cloexec(int fd, char * cmdname, value arg);
-extern void caml_unix_clear_cloexec(int fd, char * cmdname, value arg);
+extern void caml_unix_set_cloexec(int fd, const char * cmdname, value arg);
+extern void caml_unix_clear_cloexec(int fd, const char * cmdname, value arg);
 #endif /* _WIN32 */
 
 /* Compatibility definitions for the pre-5.0 names of these functions */

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -21,7 +21,7 @@
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 
-char_os ** caml_unix_cstringvect(value arg, char * cmdname)
+char_os ** caml_unix_cstringvect(value arg, const char * cmdname)
 {
   char_os ** res;
   mlsize_t size;

--- a/otherlibs/unix/unixsupport_unix.c
+++ b/otherlibs/unix/unixsupport_unix.c
@@ -336,7 +336,7 @@ int caml_unix_cloexec_p(value cloexec)
     return caml_unix_cloexec_default;
 }
 
-void caml_unix_set_cloexec(int fd, char *cmdname, value cmdarg)
+void caml_unix_set_cloexec(int fd, const char *cmdname, value cmdarg)
 {
   int flags = fcntl(fd, F_GETFD, 0);
   if (flags == -1 ||
@@ -344,7 +344,7 @@ void caml_unix_set_cloexec(int fd, char *cmdname, value cmdarg)
     caml_uerror(cmdname, cmdarg);
 }
 
-void caml_unix_clear_cloexec(int fd, char *cmdname, value cmdarg)
+void caml_unix_clear_cloexec(int fd, const char *cmdname, value cmdarg)
 {
   int flags = fcntl(fd, F_GETFD, 0);
   if (flags == -1 ||

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -63,8 +63,8 @@ CAMLprim value caml_backtrace_status(value vunit)
    implementation. */
 static void print_location(struct caml_loc_info * li, int index)
 {
-  char * info;
-  char * inlined;
+  const char * info;
+  const char * inlined;
 
   /* Ignore compiler-inserted raise */
   if (!li->loc_valid && li->loc_is_raise) return;

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -235,7 +235,6 @@ value caml_add_debug_info(code_t code_start, value code_size, value events_heap)
 value caml_remove_debug_info(code_t start)
 {
   CAMLparam0();
-  CAMLlocal2(dis, prev);
 
   for (int i = 0; i < caml_debug_info.size; i++) {
     struct debug_info *di = caml_debug_info.contents[i];

--- a/runtime/backtrace_byt.c
+++ b/runtime/backtrace_byt.c
@@ -132,6 +132,8 @@ static int cmp_ev_info(const void *a, const void *b)
   return 0;
 }
 
+static const char defname_old_bytecode[] = "<old bytecode>";
+
 static struct ev_info *process_debug_events(code_t code_start,
                                             value events_heap,
                                             mlsize_t *num_events)
@@ -179,7 +181,7 @@ static struct ev_info *process_debug_events(code_t code_start,
         if (events[j].ev_defname == NULL)
           caml_fatal_error ("caml_add_debug_info: out of memory");
       } else {
-        events[j].ev_defname = "<old bytecode>";
+        events[j].ev_defname = (char *)defname_old_bytecode;
       }
 
       events[j].ev_start_lnum = Int_val(Field(ev_start, POS_LNUM));
@@ -239,6 +241,13 @@ value caml_remove_debug_info(code_t start)
   for (int i = 0; i < caml_debug_info.size; i++) {
     struct debug_info *di = caml_debug_info.contents[i];
     if (di->start == start) {
+      for (mlsize_t j = 0; j < di->num_events; j++) {
+        struct ev_info *event = &di->events[j];
+        caml_stat_free(event->ev_filename);
+        if (event->ev_defname != defname_old_bytecode)
+          caml_stat_free(event->ev_defname);
+      }
+      caml_stat_free(di->events);
       /* note that caml_ext_table_remove calls caml_stat_free on the
          removed resource, bracketing the caml_stat_alloc call in
          caml_add_debug_info. */

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -42,7 +42,7 @@ extern void caml_build_primitive_table_builtin(void);
 extern void caml_free_shared_libs(void);
 
 /* Return the effective location of the standard library */
-extern char_os * caml_get_stdlib_location(void);
+extern const char_os * caml_get_stdlib_location(void);
 
 /* Parse ld.conf and add the lines read to caml_shared_libs_path */
 extern char_os * caml_parse_ld_conf(void);

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -209,7 +209,7 @@ CAMLextern void caml_deserialize_block_4(void * data, intnat len);
 CAMLextern void caml_deserialize_block_8(void * data, intnat len);
 CAMLextern void caml_deserialize_block_float_8(void * data, intnat len);
 
-CAMLnoret CAMLextern void caml_deserialize_error(char * msg);
+CAMLnoret CAMLextern void caml_deserialize_error(const char * msg);
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -96,8 +96,8 @@ CAMLextern void caml_flush (struct channel *);
 CAMLextern void caml_flush_if_unbuffered (struct channel *);
 CAMLextern void caml_putch(struct channel *, int);
 CAMLextern void caml_putword (struct channel *, uint32_t);
-CAMLextern int caml_putblock (struct channel *, char *, intnat);
-CAMLextern void caml_really_putblock (struct channel *, char *, intnat);
+CAMLextern int caml_putblock (struct channel *, const char *, intnat);
+CAMLextern void caml_really_putblock (struct channel *, const char *, intnat);
 
 CAMLextern unsigned char caml_refill (struct channel *);
 CAMLextern unsigned char caml_getch(struct channel *);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -279,7 +279,7 @@ typedef char char_os;
    from the callsite, making debuggers able to see it. */
 #define CAMLassert(x) \
   (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
-CAMLextern void caml_failed_assert (char *, char_os *, int)
+CAMLextern void caml_failed_assert (const char *, const char_os *, int)
 #if defined(__has_feature)
   /* However, we do inform clang-analyzer that this function never returns,
      since that improves analysis without breaking debugging */
@@ -346,11 +346,11 @@ void caml_alloc_point_here(void);
 
    This function must be reentrant. */
 #ifndef __cplusplus
-typedef void (*fatal_error_hook) (char *msg, va_list args);
+typedef void (*fatal_error_hook) (const char *msg, va_list args);
 extern _Atomic fatal_error_hook caml_fatal_error_hook;
 #endif
 
-CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
+CAMLnoret CAMLextern void caml_fatal_error (const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
 #endif
@@ -538,13 +538,13 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 extern atomic_uintnat caml_verb_gc;
 
-void caml_gc_log (char *, ...)
+void caml_gc_log (const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
 
-void caml_gc_message (int, char *, ...)
+void caml_gc_message (int, const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 2, 3)))
 #endif

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -44,9 +44,9 @@ extern int caml_attempt_open(char_os **name, struct exec_trailer *trail,
 extern int caml_read_trailer(int fd, struct exec_trailer *trail);
 extern void caml_read_section_descriptors(int fd, struct exec_trailer *trail);
 extern int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
-                                        char *name);
+                                          const char *name);
 extern int32_t caml_seek_section(int fd, struct exec_trailer *trail,
-                                 char *name);
+                                 const char *name);
 
 enum caml_byte_program_mode
   {

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -33,7 +33,7 @@ CAMLnoret CAMLextern void caml_sys_error (value);
 CAMLnoret CAMLextern void caml_sys_io_error (value);
 
 CAMLextern double caml_sys_time_unboxed(value);
-CAMLextern void caml_sys_init (char_os * exe_name, char_os ** argv);
+CAMLextern void caml_sys_init (const char_os * exe_name, char_os ** argv);
 
 CAMLnoret CAMLextern void caml_do_exit (int);
 

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -83,9 +83,9 @@ static c_primitive lookup_primitive(char * name)
 
 #define LD_CONF_NAME T("ld.conf")
 
-CAMLexport char_os * caml_get_stdlib_location(void)
+CAMLexport const char_os * caml_get_stdlib_location(void)
 {
-  char_os * stdlib;
+  const char_os * stdlib;
   stdlib = caml_secure_getenv(T("OCAMLLIB"));
   if (stdlib == NULL) stdlib = caml_secure_getenv(T("CAMLLIB"));
   if (stdlib == NULL) stdlib = OCAML_STDLIB_DIR;
@@ -94,7 +94,8 @@ CAMLexport char_os * caml_get_stdlib_location(void)
 
 CAMLexport char_os * caml_parse_ld_conf(void)
 {
-  char_os * stdlib, * ldconfname, * wconfig, * p, * q;
+  const char_os * stdlib;
+  char_os * ldconfname, * wconfig, * p, * q;
   char * config;
 #ifdef _WIN32
   struct _stati64 st;

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -170,9 +170,11 @@ _Bool (*caml_extern_compress_output)(struct caml_output_block **) = NULL;
 CAMLnoret static void extern_out_of_memory(struct caml_extern_state* s);
 
 CAMLnoret static
-void extern_invalid_argument(struct caml_extern_state* s, char *msg);
+void extern_invalid_argument(struct caml_extern_state* s,
+                             const char *msg);
 
-CAMLnoret static void extern_failwith(struct caml_extern_state* s, char *msg);
+CAMLnoret static void extern_failwith(struct caml_extern_state* s,
+                                      const char *msg);
 
 CAMLnoret static void extern_stack_overflow(struct caml_extern_state* s);
 
@@ -441,13 +443,14 @@ static void extern_out_of_memory(struct caml_extern_state* s)
   caml_raise_out_of_memory();
 }
 
-static void extern_invalid_argument(struct caml_extern_state *s, char *msg)
+static void extern_invalid_argument(struct caml_extern_state *s,
+                                    const char *msg)
 {
   free_extern_output(s);
   caml_invalid_argument(msg);
 }
 
-static void extern_failwith(struct caml_extern_state* s, char *msg)
+static void extern_failwith(struct caml_extern_state* s, const char *msg)
 {
   free_extern_output(s);
   caml_failwith(msg);

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -230,7 +230,7 @@ CAMLprim value caml_hexstring_of_float(value arg, value vprec, value vstyle)
   }
   /* Treat special cases */
   if (exp == 0x7FF) {
-    char * txt;
+    const char * txt;
     if (m == 0) txt = "infinity"; else txt = "nan";
     memcpy(p, txt, strlen(txt));
     p[strlen(txt)] = 0;

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -1207,7 +1207,7 @@ CAMLexport void caml_deserialize_block_float_8(void * data, intnat len)
 #endif
 }
 
-CAMLexport void caml_deserialize_error(char * msg)
+CAMLexport void caml_deserialize_error(const char * msg)
 {
   struct caml_intern_state* s = get_intern_state ();
   intern_cleanup(s);

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -142,7 +142,7 @@ CAMLprim value caml_int_of_string(value s)
 #define FORMAT_BUFFER_SIZE 32
 
 static char parse_format(value fmt,
-                         char * suffix,
+                         const char * suffix,
                          char format_string[FORMAT_BUFFER_SIZE])
 {
   char * p;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -311,7 +311,7 @@ CAMLexport void caml_putword(struct channel *channel, uint32_t w)
   caml_putch(channel, w);
 }
 
-CAMLexport int caml_putblock(struct channel *channel, char *p, intnat len)
+CAMLexport int caml_putblock(struct channel *channel, const char *p, intnat len)
 {
   int n, free;
 
@@ -333,7 +333,7 @@ CAMLexport int caml_putblock(struct channel *channel, char *p, intnat len)
 }
 
 CAMLexport void caml_really_putblock(struct channel *channel,
-                                     char *p, intnat len)
+                                     const char *p, intnat len)
 {
   int written;
   while (len > 0) {

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -956,7 +956,7 @@ CAMLexport value caml_check_urgent_gc (value extra_root)
 static void realloc_generic_table
 (struct generic_table *tbl, asize_t element_size,
  ev_runtime_counter ev_counter_name,
- char *msg_threshold, char *msg_growing, char *msg_error)
+ const char *msg_threshold, const char *msg_growing, const char *msg_error)
 {
   CAMLassert (tbl->ptr == tbl->limit);
   CAMLassert (tbl->limit <= tbl->end);

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -37,7 +37,7 @@ _Atomic caml_timing_hook caml_finalise_end_hook = (caml_timing_hook)NULL;
 
 #ifdef DEBUG
 
-void caml_failed_assert (char * expr, char_os * file_os, int line)
+void caml_failed_assert (const char * expr, const char_os * file_os, int line)
 {
   char* file = caml_stat_strdup_of_os(file_os);
   fprintf(stderr, "[%02d] file %s; line %d ### Assertion failed: %s\n",
@@ -72,7 +72,7 @@ void caml_alloc_point_here(void)
 
 atomic_uintnat caml_verb_gc = 0;
 
-void caml_gc_log (char *msg, ...)
+void caml_gc_log (const char *msg, ...)
 {
   if ((atomic_load_relaxed(&caml_verb_gc) & 0x800) != 0) {
     char fmtbuf[GC_LOG_LENGTH];
@@ -86,7 +86,7 @@ void caml_gc_log (char *msg, ...)
   }
 }
 
-void caml_gc_message (int level, char *msg, ...)
+void caml_gc_message (int level, const char *msg, ...)
 {
   if ((atomic_load_relaxed(&caml_verb_gc) & level) != 0){
     va_list ap;
@@ -99,7 +99,7 @@ void caml_gc_message (int level, char *msg, ...)
 
 _Atomic fatal_error_hook caml_fatal_error_hook = (fatal_error_hook)NULL;
 
-CAMLexport void caml_fatal_error (char *msg, ...)
+CAMLexport void caml_fatal_error (const char *msg, ...)
 {
   va_list ap;
   fatal_error_hook hook;

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -103,7 +103,7 @@ enum input_codes {
 
 /* Auxiliary for printing token just read */
 
-static char * token_name(char * names, int number)
+static const char * token_name(const char * names, int number)
 {
   for (/*nothing*/; number > 0; number--) {
     if (names[0] == 0) return "<unknown token>";

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -165,7 +165,7 @@ int caml_startup_aux(int pooling)
   return 1;
 }
 
-static void call_registered_value(char* name)
+static void call_registered_value(const char* name)
 {
   const value *f = caml_named_value(name);
   if (f != NULL)

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -75,7 +75,7 @@
 static char magicstr[EXEC_MAGIC_LENGTH+1];
 
 /* Print the specified error message followed by an end-of-line and exit */
-static void error(char *msg, ...)
+static void error(const char *msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
@@ -177,7 +177,7 @@ void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
    found with that name. */
 
 int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
-                                   char *name)
+                                   const char *name)
 {
   long ofs;
 
@@ -195,7 +195,8 @@ int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
 /* Position fd at the beginning of the section having the given name.
    Return the length of the section data in bytes. */
 
-int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
+int32_t caml_seek_section(int fd, struct exec_trailer *trail,
+                          const char *name)
 {
   int32_t len = caml_seek_optional_section(fd, trail, name);
   if (len == -1)
@@ -206,7 +207,8 @@ int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
 /* Read and return the contents of the section having the given name.
    Add a terminating 0.  Return NULL if no such section. */
 
-static char * read_section(int fd, struct exec_trailer *trail, char *name)
+static char * read_section(int fd, struct exec_trailer *trail,
+                           const char *name)
 {
   int32_t len;
   char * data;
@@ -223,7 +225,7 @@ static char * read_section(int fd, struct exec_trailer *trail, char *name)
 #ifdef _WIN32
 
 static char_os * read_section_to_os(int fd, struct exec_trailer *trail,
-                                    char *name)
+                                    const char *name)
 {
   int32_t len, wlen;
   char * data;
@@ -378,7 +380,7 @@ static int parse_command_line(char_os **argv)
    freed, since the runtime will terminate after calling this. */
 static void do_print_config(void)
 {
-  char_os * dir;
+  const char_os * dir;
 
   /* Print the runtime configuration */
   printf("version: %s\n", OCAML_VERSION_STRING);

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -85,7 +85,7 @@ extern void caml_install_invalid_parameter_handler(void);
 
 value caml_startup_common(char_os **argv, int pooling)
 {
-  char_os * exe_name, * proc_self_exe;
+  const char_os * exe_name, * proc_self_exe;
   value res;
 
   /* Determine options */

--- a/runtime/sync_posix.h
+++ b/runtime/sync_posix.h
@@ -118,7 +118,7 @@ Caml_inline int sync_condvar_wait(sync_condvar c, sync_mutex m)
 
 /* Reporting errors */
 
-static void sync_check_error(int retcode, char * msg)
+static void sync_check_error(int retcode, const char * msg)
 {
   char * err;
   char buf[1024];

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -478,7 +478,7 @@ CAMLprim value caml_sys_executable_name(value unit)
   return caml_copy_string_of_os(caml_params->exe_name);
 }
 
-void caml_sys_init(char_os * exe_name, char_os **argv)
+void caml_sys_init(const char_os * exe_name, char_os **argv)
 {
 #ifdef _WIN32
   /* Initialises the caml_win32_* globals on Windows with the version of

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -135,7 +135,8 @@ caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
 
 caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
 {
-  char * dir, * fullname;
+  const char * dir;
+  char * fullname;
   struct stat st;
 
   for (const char *p = name; *p != 0; p++) {

--- a/stdlib/header.c
+++ b/stdlib/header.c
@@ -160,7 +160,7 @@ static char * read_runtime_path(int fd)
   return runtime_path;
 }
 
-static void errwrite(char * msg)
+static void errwrite(const char * msg)
 {
   fputs(msg, stderr);
 }

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -227,7 +227,7 @@ extern char eflag;
 extern char big_endian;
 
 /* myname should be UTF-8 encoded */
-extern char *myname;
+extern const char *myname;
 extern char *cptr;
 extern char *line;
 extern int lineno;
@@ -238,7 +238,7 @@ extern int outline;
 extern char_os *action_file_name;
 extern char_os *entry_file_name;
 extern char_os *code_file_name;
-extern char_os *input_file_name;
+extern const char_os *input_file_name;
 extern char_os *output_file_name;
 extern char_os *text_file_name;
 extern char_os *verbose_file_name;
@@ -316,8 +316,8 @@ extern short final_state;
 /* global functions */
 
 extern char *allocate(unsigned int n);
-extern bucket *lookup(char *name);
-extern bucket *make_bucket(char *name);
+extern bucket *lookup(const char *name);
+extern bucket *make_bucket(const char *name);
 extern action *parse_actions(int stateno);
 extern action *get_shifts(int stateno);
 extern action *add_reductions(int stateno, action *actions);
@@ -327,7 +327,7 @@ extern void create_symbol_table (void);
 CAMLnoret extern void default_action_error (void);
 CAMLnoret extern void done (int k);
 CAMLnoret extern void entry_without_type (char *s);
-CAMLnoret extern void fatal (char *msg);
+CAMLnoret extern void fatal (const char *msg);
 extern void finalize_closure (void);
 extern void free_parser (void);
 extern void free_symbol_table (void);
@@ -339,7 +339,7 @@ extern void lr0 (void);
 extern void make_parser (void);
 CAMLnoret extern void no_grammar (void);
 CAMLnoret extern void no_space (void);
-CAMLnoret extern void open_error (char_os *filename);
+CAMLnoret extern void open_error (const char_os *filename);
 extern void output (void);
 extern void prec_redeclared (void);
 CAMLnoret extern void polymorphic_entry_point(char *s);
@@ -365,7 +365,7 @@ CAMLnoret extern void unterminated_string (int s_lineno, char *s_line, char *s_c
 CAMLnoret extern void unterminated_text (int t_lineno, char *t_line, char *t_cptr);
 CAMLnoret extern void used_reserved (char *s);
 extern void verbose (void);
-extern void write_section (char **section);
+extern void write_section (char const * const * section);
 CAMLnoret extern void invalid_literal(int s_lineno, char *s_line, char *s_cptr);
 
 #endif /* YACC_DEFS_H */

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -20,9 +20,9 @@
 #include "defs.h"
 
 /* String displayed if we can't malloc a buffer for the UTF-8 conversion */
-static char *unknown = "<unknown; out of memory>";
+static const char *unknown = "<unknown; out of memory>";
 
-void fatal(char *msg)
+void fatal(const char *msg)
 {
     fprintf(stderr, "%s: f - %s\n", myname, msg);
     done(2);
@@ -36,7 +36,7 @@ void no_space(void)
 }
 
 
-void open_error(char_os *filename)
+void open_error(const char_os *filename)
 {
     char *u8 = caml_stat_strdup_of_os(filename);
     fprintf(stderr, "%s: f - cannot open \"%s\"\n", myname, (u8 ? u8 : unknown));
@@ -77,7 +77,8 @@ static void print_pos(char *st_line, char *st_cptr)
 }
 
 
-CAMLnoret static void gen_error(int st_lineno, char *st_line, char *st_cptr, char *msg)
+CAMLnoret static void gen_error(int st_lineno, char *st_line, char *st_cptr,
+                                const char *msg)
 {
     fprintf(stderr, "File \"%s\", line %d: %s\n",
             virtual_input_file_name, st_lineno, msg);

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -37,7 +37,7 @@ char sflag;
 char big_endian;
 
 char_os *file_prefix = 0;
-char *myname = "yacc";
+const char *myname = "yacc";
 char_os temp_form[] = T("yacc.XXXXXXX");
 
 #ifdef _WIN32
@@ -57,7 +57,7 @@ char_os *entry_file_name;
 char_os *code_file_name;
 char *code_file_name_disp, *interface_file_name_disp;
 char_os *interface_file_name;
-char_os *input_file_name = T("");
+const char_os *input_file_name = T("");
 char *input_file_name_disp;
 char_os *output_file_name;
 char_os *text_file_name;
@@ -287,7 +287,7 @@ allocate(unsigned int n)
 void create_file_names(void)
 {
     int i, len;
-    char_os *tmpdir;
+    const char_os *tmpdir;
 
 #ifdef _WIN32
     tmpdir = _wgetenv(L"TEMP");

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -183,7 +183,7 @@ void getargs(int argc, char_os **argv)
         {
         case '\0':
             input_file = stdin;
-            file_prefix = T("stdin");
+            file_prefix = (char_os *)T("stdin");
             if (i + 1 < argc) usage();
             return;
 

--- a/yacc/output.c
+++ b/yacc/output.c
@@ -61,7 +61,7 @@ int pack_vector (int vector);
 
 void output(void)
 {
-  extern char *header[], *define_tables[];
+  extern char const * const header[], * const define_tables[];
 
   free_itemsets();
   free_shifts();

--- a/yacc/reader.c
+++ b/yacc/reader.c
@@ -1522,7 +1522,7 @@ pack_symbols(void)
     symbol_value[0] = 0;
     symbol_prec[0] = 0;
     symbol_assoc[0] = TOKEN;
-    symbol_tag[0] = "";
+    symbol_tag[0] = (char *)"";
     symbol_true_token[0] = 0;
     for (i = 1; i < ntokens; ++i)
     {
@@ -1537,7 +1537,7 @@ pack_symbols(void)
     symbol_value[start_symbol] = -1;
     symbol_prec[start_symbol] = 0;
     symbol_assoc[start_symbol] = TOKEN;
-    symbol_tag[start_symbol] = "";
+    symbol_tag[start_symbol] = (char *)"";
     symbol_true_token[start_symbol] = 0;
     for (++i; i < nsyms; ++i)
     {

--- a/yacc/skeleton.c
+++ b/yacc/skeleton.c
@@ -17,14 +17,14 @@
 
 #include "defs.h"
 
-char *header[] =
+char const * const header[] =
 {
   "open Parsing",
   "let _ = parse_error;;", /* avoid warning 33 (PR#5719) */
   0
 };
 
-char *define_tables[] =
+char const * const define_tables[] =
 {
   "let yytables =",
   "  { Parsing.actions=yyact;",
@@ -46,7 +46,7 @@ char *define_tables[] =
   0
 };
 
-void write_section(char **section)
+void write_section(char const * const * section)
 {
     int i;
     FILE *fp;

--- a/yacc/symtab.c
+++ b/yacc/symtab.c
@@ -25,9 +25,9 @@ bucket *last_symbol;
 
 
 int
-hash(char *name)
+hash(const char *name)
 {
-    char *s;
+    const char *s;
     int c, k;
 
     assert(name && *name);
@@ -41,7 +41,7 @@ hash(char *name)
 
 
 bucket *
-make_bucket(char *name)
+make_bucket(const char *name)
 {
     bucket *bp;
 
@@ -69,7 +69,7 @@ make_bucket(char *name)
 
 
 bucket *
-lookup(char *name)
+lookup(const char *name)
 {
     bucket *bp, **bpp;
 


### PR DESCRIPTION
I've tried yet another warning from GCC/clang, `-Wwrite-string`.

> When compiling C, give string constants the type `const char[length]` so that copying the address of one into a non-`const char *` pointer produces a warning. These warnings help you find at compile time code that can try to write into a string constant, but only if you have been very careful about using `const` in declarations and prototypes.

https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wwrite-strings

> Note: enabling this warning in C will change the semantic behavior of the program by treating all string literals as having type `const char *` instead of `char *`. This can cause unexpected behaviors with type-sensitive constructs like `_Generic`.

https://clang.llvm.org/docs/DiagnosticsReference.html#wwrite-strings

This leads to tagging more parameters as taking `const` strings.

If I'm not mistaken I've also found and fixed a memory leak: events data associated with the debug info in a bytecode backtrace were never freed.

In 2 occurrences in ocamlyacc we're mixing heap-allocated strings with static constant strings. It's ok to cast away the string constness, because we're also never freeing these strings, so `free` isn't called on static strings.

Note that we're also not using C11 `_Generic`.