### PR TITLE
Provide a `system(3)` replacement on Android (+ build OCaml on Android)

### DIFF
--- a/Changes
+++ b/Changes
@@ -25,6 +25,10 @@ Working version
 
 ### Bug fixes:
 
+- #13380, #?????: Provide a system(3) replacement on Android, allowing
+  to build OCaml on Android with Termux, and use Sys.command.
+  (Antonin Décimo, review by ?????)
+
 OCaml 5.3.0
 ___________
 

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -466,7 +466,11 @@ extern double caml_log1p(double);
 #define chdir_os chdir
 #define mkdir_os mkdir
 #define getcwd_os getcwd
+#ifdef __ANDROID__
+#define system_os caml_sys_system
+#else
 #define system_os system
+#endif
 #define rmdir_os rmdir
 #define putenv_os putenv
 #define chmod_os chmod

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -505,6 +505,51 @@ void caml_sys_init(char_os * exe_name, char_os **argv)
 #endif
 #endif
 
+#ifdef __ANDROID__
+/* Android 8 Oreo and later seem to block system(3). Provide a
+ * replacement, taken from POSIX.1-2024.
+ * https://pubs.opengroup.org/onlinepubs/9799919799/functions/system.html */
+int caml_sys_system(const char *cmd)
+{
+  int stat;
+  pid_t pid;
+  struct sigaction sa, savintr, savequit;
+  sigset_t saveblock;
+  if (cmd == NULL)
+    return(1);
+  sa.sa_handler = SIG_IGN;
+  sigemptyset(&sa.sa_mask);
+  sa.sa_flags = 0;
+  sigemptyset(&savintr.sa_mask);
+  sigemptyset(&savequit.sa_mask);
+  sigaction(SIGINT, &sa, &savintr);
+  sigaction(SIGQUIT, &sa, &savequit);
+  sigaddset(&sa.sa_mask, SIGCHLD);
+  pthread_sigmask(SIG_BLOCK, &sa.sa_mask, &saveblock);
+  if ((pid = fork()) == 0) {
+    sigaction(SIGINT, &savintr, (struct sigaction *)0);
+    sigaction(SIGQUIT, &savequit, (struct sigaction *)0);
+    sigprocmask(SIG_SETMASK, &saveblock, (sigset_t *)0);
+    execl("/bin/sh", "sh", "-c", "--", cmd, (char *)0);
+    _exit(127);
+  }
+  if (pid == -1) {
+    stat = -1; /* errno comes from fork() */
+  } else {
+    while (waitpid(pid, &stat, 0) == -1) {
+      if (errno != EINTR){
+        stat = -1;
+        break;
+      }
+    }
+  }
+  sigaction(SIGINT, &savintr, (struct sigaction *)0);
+  sigaction(SIGQUIT, &savequit, (struct sigaction *)0);
+  sigprocmask(SIG_SETMASK, &saveblock, (sigset_t *)0);
+  return(stat);
+}
+#endif
+
 #ifdef HAS_SYSTEM
 CAMLprim value caml_sys_system_command(value command)
 {


### PR DESCRIPTION
I investigated issue 13380, where an user reported a failure to build OCaml on Android with Termux. I found out that OCaml internally calls [system()](https://pubs.opengroup.org/onlinepubs/9799919799/functions/system.html) ([bionic source](https://android.googlesource.com/platform/bionic.git/+/refs/heads/main/libc/bionic/system.cpp)) in [caml_sys_system_command](https://github.com/ocaml/ocaml/blob/55ee0e0eaf83e6f4276754ac16883855f800f968/runtime/sys.c#L509-L530) via [Ccomp.command](https://github.com/ocaml/ocaml/blob/55ee0e0eaf83e6f4276754ac16883855f800f968/utils/ccomp.ml#L18-L26) and [Pparse.call_external_preprocessor](https://github.com/ocaml/ocaml/blob/55ee0e0eaf83e6f4276754ac16883855f800f968/driver/pparse.ml#L26-L35). The problem is that `system` seems to have been blocked for security reasons, and thus `ocamlc` fails at invoking `gawk` as an external preprocessor (but note that `gawk` can still be called from the shell):

```console
$ make -j1 V=1
/data/data/com.termux/files/usr/bin/make coldstart
make[1]: Entering directory '/data/data/com.termux/files/home/ocaml'
/data/data/com.termux/files/usr/bin/make -C stdlib OCAMLRUN='$(ROOTDIR)/boot/ocamlrun' USE_BOOT_OCAMLC=true all
make[2]: Entering directory '/data/data/com.termux/files/home/ocaml/stdlib'
../boot/ocamlrun ../boot/ocamlc -strict-sequence -absname -w +a-4-9-41-42-44-45-48 -g -warn-error +A -bin-annot -nostdlib -principal  -nopervasives -no-alias-deps -w -49  -pp "$AWK -f ./expand_module_aliases.awk" -c stdlib.mli
sh: /data/data/com.termux/files/usr/bin/gawk: Permission denied
File "/data/data/com.termux/files/home/ocaml/stdlib/stdlib.mli", line 1:
Error: Error while running external preprocessor
Command line: gawk -f ./expand_module_aliases.awk 'stdlib.mli' > /data/data/com.termux/files/usr/tmp/ocamlpp102f05

make[2]: *** [Makefile:118: stdlib.cmi] Error 2
make[2]: Leaving directory '/data/data/com.termux/files/home/ocaml/stdlib'
make[1]: *** [Makefile:687: coldstart] Error 2
make[1]: Leaving directory '/data/data/com.termux/files/home/ocaml'
make: *** [Makefile:846: world.opt] Error 2

$ gawk -f ./expand_module_aliases.awk stdlib.mli > /data/data/com.termux/files/usr/tmp/ocamlpp102f05
$ ls -l /data/data/com.termux/files/usr/bin/gawk
-rwx------ 1 u0_a199 u0_a199 557672 Aug 23 12:15 /data/data/com.termux/files/usr/bin/gawk
```

Android hasn't disabled classic ways of spawning processes, and we can re-implement `system(3)`, which this PR does, with code directly taken from the POSIX spec (are there licensing issues?).
Do let me know if supporting Android is an interesting target.
I'm not sure if this implementation of `caml_sys_system` should do smarter things, like unload the runtime after the fork or other cleanups.
Is there another way to circumvent this problem?