### PR TITLE
win32unix: use `GetTempPath2` for `Filename.get_temp_dir_name`

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,13 @@ Working version
   `Thread.sigmask` using `Unix.sigprocmask`.
   (Xavier Leroy, review by Antonin Décimo, Gabriel Scherer, Miod Vallat)
 
+* #13435: On Windows, use system calls for `Filename.get_temp_dir_name` instead
+  of directly reading the environment, which in particular improves the security
+  of OCaml processes running in the SYSTEM security context by mitigating
+  privileged file operation attacks. For all other processes running with the
+  default environment (where `TEMP` is set), there is no discernible change.
+  (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
+
 ### Tools:
 
 ### Manual and documentation:

--- a/runtime/caml/osdeps.h
+++ b/runtime/caml/osdeps.h
@@ -142,6 +142,8 @@ CAMLextern clock_t caml_win32_clock(void);
 
 CAMLextern value caml_win32_xdg_defaults(void);
 
+CAMLextern value caml_win32_get_temp_path(void);
+
 #endif /* _WIN32 */
 
 /* Returns the current value of a counter that increments once per nanosecond.

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -770,3 +770,15 @@ CAMLprim value caml_xdg_defaults(value unit)
   return Val_emptylist;
 #endif
 }
+
+/* On Windows, returns the path to a directory suitable for storing
+   temporary files. On Unix, this path is more easily computed in
+   OCaml, so the string returned by the primitive is empty. */
+CAMLprim value caml_sys_temp_dir_name(value unit)
+{
+#ifdef _WIN32
+  return caml_win32_get_temp_path();
+#else
+  return caml_copy_string("");
+#endif
+}

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -17,10 +17,9 @@
 
 /* Win32-specific stuff */
 
-/* FILE_INFO_BY_HANDLE_CLASS and FILE_NAME_INFO are only available from Windows
-   Vista onwards */
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+/* FILE_INFO_BY_HANDLE_CLASS, FILE_NAME_INFO, and INIT_ONCE are only
+   available from Windows Vista onwards */
+#define _WIN32_WINNT 0x0600 /* _WIN32_WINNT_VISTA */
 
 #define WIN32_LEAN_AND_MEAN
 #include <wtypes.h>
@@ -1257,4 +1256,35 @@ value caml_win32_xdg_defaults(void)
   CoTaskMemFree(wpath);
 
   CAMLreturn(result);
+}
+
+static INIT_ONCE get_temp_path_init_once = INIT_ONCE_STATIC_INIT;
+static BOOL CALLBACK get_temp_path_init_function(PINIT_ONCE InitOnce,
+                                                 PVOID Parameter,
+                                                 PVOID *lpContext)
+{
+  FARPROC pGetTempPath2W =
+    GetProcAddress(GetModuleHandle(L"KERNEL32.DLL"), "GetTempPath2W");
+  if (pGetTempPath2W)
+    *lpContext = pGetTempPath2W;
+  else
+    *lpContext = GetTempPath;
+  return TRUE;
+}
+
+value caml_win32_get_temp_path(void)
+{
+  CAMLparam0();
+  CAMLlocal1(path);
+  wchar_t buf[MAX_PATH+1];
+  DWORD (WINAPI *get_temp_path)(DWORD, LPWSTR);
+
+  InitOnceExecuteOnce(&get_temp_path_init_once, get_temp_path_init_function,
+                      NULL, (LPVOID *) &get_temp_path);
+
+  if (!get_temp_path(MAX_PATH+1, buf))
+    caml_win32_sys_error(GetLastError());
+  else
+    path = caml_copy_string_of_utf16(buf);
+  CAMLreturn(path);
 }

--- a/stdlib/filename.ml
+++ b/stdlib/filename.ml
@@ -160,9 +160,9 @@ module Win32 : SYSDEPS = struct
     else
       None
 
+  external temp_dir_name: unit -> string = "caml_sys_temp_dir_name"
+  let temp_dir_name = temp_dir_name ()
 
-  let temp_dir_name =
-    try Sys.getenv "TEMP" with Not_found -> "."
   let quote s =
     let l = String.length s in
     let b = Buffer.create (l + 20) in

--- a/stdlib/filename.mli
+++ b/stdlib/filename.mli
@@ -183,9 +183,15 @@ val get_temp_dir_name : unit -> string
 (** The name of the temporary directory:
     Under Unix, the value of the [TMPDIR] environment variable, or "/tmp"
     if the variable is not set.
-    Under Windows, the value of the [TEMP] environment variable, or "."
-    if the variable is not set.
+
+    Under Windows, the value returned by [GetTempPath2] (if available)
+    or [GetTempPath].
+
     The temporary directory can be changed with {!Filename.set_temp_dir_name}.
+
+    Under Windows, before OCaml 5.4, it would return the value of the
+    [TEMP] environment variable, or "." if the variable was not set.
+
     @since 4.00
 *)
 


### PR DESCRIPTION
We can use the WinAPI to get the temporary directory. It's what [Rust](https://github.com/search?q=repo%3Arust-lang%2Frust%20GetTempPath&type=code) and [Golang](https://github.com/search?q=repo%3Agolang%2Fgo%20GetTempPath&type=code) do.
A caveat is that [`GetTempPath2`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2w) is only available since Windows 10 21H1. As older Windows 10 versions are still supported by Microsoft, we need to fallback to [`GetTempPath`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppathw) if `GetTempPath2` isn't found.
I use a [one-time initialization](https://learn.microsoft.com/en-us/windows/win32/sync/using-one-time-initialization) object (available since Vista) to avoid races when initializing the function pointer to either `GetTempPath2` or `GetTempPath`.