### PR TITLE
Constify function parameters and variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -11,6 +11,10 @@ Working version
   available in older, now unsupported Windows versions.
   (Antonin Décimo, review by Nicolás Ojeda Bär and David Allsopp)
 
+- #?????: Constify some function parameters, flags tables, and some
+  pointers in C code (take 3).
+  (Antonin Décimo, review by ???)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/Makefile
+++ b/Makefile
@@ -1372,7 +1372,7 @@ runtime/caml/opnames.h : runtime/caml/instruct.h
 	$(V_GEN)tr -d '\r' < $< | \
 	sed -e '/\/\*/d' \
 	    -e '/^#/d' \
-	    -e 's/enum /static char * names_of_/' \
+	    -e 's/enum /static char const * const names_of_/' \
 	    -e 's/{$$/[] = {/' \
 	    -e 's/\([[:upper:]][[:upper:]_0-9]*\)/"\1"/g' > $@
 

--- a/ocamltest/run_common.h
+++ b/ocamltest/run_common.h
@@ -30,7 +30,7 @@ static void defaultLogger(void *where, const char *format, va_list ap)
   vfprintf(stderr, format, ap);
 }
 
-static void mylog(Logger *logger, void *loggerData, char *fmt, ...)
+static void mylog(Logger *logger, void *loggerData, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -249,7 +249,6 @@ static int handle_process_termination(
   pid_t pid, int status, const char *corefilename_prefix)
 {
   int signal, core = 0;
-  char *corestr;
 
   if (WIFEXITED(status)) return WEXITSTATUS(status);
 
@@ -262,10 +261,9 @@ static int handle_process_termination(
 #ifdef WCOREDUMP
   core = WCOREDUMP(status);
 #endif /* WCOREDUMP */
-  corestr = core ? "" : "no ";
   fprintf(stderr,
     "Process %lld got signal %d(%s), %score dumped\n",
-    (long long) pid, signal, strsignal(signal), corestr
+    (long long) pid, signal, strsignal(signal), core ? "" : "no "
   );
 
   if (core)

--- a/ocamltest/run_unix.c
+++ b/ocamltest/run_unix.c
@@ -136,7 +136,7 @@ static int paths_same_file(
 static void update_environment(array local_env)
 {
   for (array envp = local_env; *envp != NULL; envp++) {
-    char *pos_eq = strchr(*envp, '=');
+    const char *pos_eq = strchr(*envp, '=');
     if (pos_eq != NULL) {
       char *name, *value;
       int name_length = pos_eq - *envp;

--- a/otherlibs/runtime_events/runtime_events_consumer.c
+++ b/otherlibs/runtime_events/runtime_events_consumer.c
@@ -465,7 +465,7 @@ caml_runtime_events_read_poll(struct caml_runtime_events_cursor *cursor,
         return E_CORRUPT_STREAM;
     }
 
-    struct runtime_events_buffer_header *runtime_events_buffer_header =
+    const struct runtime_events_buffer_header *runtime_events_buffer_header =
         (struct runtime_events_buffer_header *)(
           get_map_offset(cursor, cursor->metadata.headers_offset,
                          domain_num,

--- a/otherlibs/str/strstubs.c
+++ b/otherlibs/str/strstubs.c
@@ -124,12 +124,12 @@ static const unsigned char re_word_letters[32] = {
    Beginning of group #N is at 2N, end is at 2N+1.
    Take position = -1 when group wasn't matched. */
 
-static value re_alloc_groups(value re, unsigned char * starttxt,
+static value re_alloc_groups(value re, const unsigned char * starttxt,
                              struct re_group * groups)
 {
   value res;
   int n = Numgroups(re);
-  struct re_group * group;
+  const struct re_group * group;
 
   res = caml_alloc(n * 2, 0);
   for (int i = 0; i < n; i++) {
@@ -149,9 +149,9 @@ static value re_alloc_groups(value re, unsigned char * starttxt,
    Return Caml array of matched groups on success, 0 on failure. */
 
 static value re_match(value re,
-                      unsigned char * starttxt,
+                      const unsigned char * starttxt,
                       register unsigned char * txt,
-                      register unsigned char * endtxt,
+                      register const unsigned char * endtxt,
                       int accept_partial_match)
 {
   /* Fields of [re] */
@@ -212,7 +212,7 @@ static value re_match(value re,
       txt++;
       break;
     case STRING: {
-      unsigned char * s =
+      const unsigned char * s =
         (unsigned char *) String_val(Field(cpool, Arg(instr)));
       while ((c = *s++) != 0) {
         if (txt == endtxt) goto prefix_match;
@@ -222,7 +222,7 @@ static value re_match(value re,
       break;
     }
     case STRINGNORM: {
-      unsigned char * s =
+      const unsigned char * s =
         (unsigned char *) String_val(Field(cpool, Arg(instr)));
       while ((c = *s++) != 0) {
         if (txt == endtxt) goto prefix_match;
@@ -423,10 +423,9 @@ CAMLprim value re_partial_match(value re, value str, value pos)
 
 CAMLprim value re_search_forward(value re, value str, value startpos)
 {
-  unsigned char * starttxt = &Byte_u(str, 0);
+  const unsigned char * starttxt = &Byte_u(str, 0);
   unsigned char * txt = &Byte_u(str, Long_val(startpos));
   unsigned char * endtxt = &Byte_u(str, caml_string_length(str));
-  unsigned char * startchars;
   value res;
 
   if (txt < starttxt || txt > endtxt)
@@ -439,7 +438,7 @@ CAMLprim value re_search_forward(value re, value str, value startpos)
     } while (txt <= endtxt);
     return Atom(0);
   } else {
-    startchars =
+    const unsigned char * startchars =
       (unsigned char *) String_val(Field(Cpool(re), Startchars(re)));
     do {
       while (txt < endtxt && startchars[*txt] == 0) txt++;
@@ -455,8 +454,7 @@ CAMLprim value re_search_backward(value re, value str, value startpos)
 {
   unsigned char * starttxt = &Byte_u(str, 0);
   unsigned char * txt = &Byte_u(str, Long_val(startpos));
-  unsigned char * endtxt = &Byte_u(str, caml_string_length(str));
-  unsigned char * startchars;
+  const unsigned char * endtxt = &Byte_u(str, caml_string_length(str));
   value res;
 
   if (txt < starttxt || txt > endtxt)
@@ -469,7 +467,7 @@ CAMLprim value re_search_backward(value re, value str, value startpos)
     } while (txt >= starttxt);
     return Atom(0);
   } else {
-    startchars =
+    const unsigned char * startchars =
       (unsigned char *) String_val(Field(Cpool(re), Startchars(re)));
     do {
       while (txt > starttxt && startchars[*txt] == 0) txt--;

--- a/otherlibs/systhreads/st_stubs.c
+++ b/otherlibs/systhreads/st_stubs.c
@@ -198,9 +198,8 @@ static void caml_thread_scan_roots(
   scanning_action action, scanning_action_flags fflags, void *fdata,
   caml_domain_state *domain_state)
 {
-  caml_thread_t active, th;
-
-  active = th = thread_table[domain_state->id].active_thread;
+  const caml_thread_t active = thread_table[domain_state->id].active_thread;
+  caml_thread_t th = active;
 
   /* The GC could be triggered before [active_thread] is initialized,
      or after [caml_thread_domain_stop_hook] has been called; in this

--- a/otherlibs/unix/caml/unixsupport.h
+++ b/otherlibs/unix/caml/unixsupport.h
@@ -111,7 +111,7 @@ extern void caml_unix_check_path(value path, const char * cmdname);
 
 #define DIR_Val(v) *((DIR **) &Field(v, 0))
 
-extern char_os ** caml_unix_cstringvect(value arg, char * cmdname);
+extern char_os ** caml_unix_cstringvect(value arg, const char * cmdname);
 extern void caml_unix_cstringvect_free(char_os **);
 
 extern int caml_unix_cloexec_default;
@@ -123,8 +123,8 @@ extern int caml_win32_set_inherit(HANDLE fd, BOOL inherit);
 #define caml_win32_set_cloexec(fd, cloexec) \
   caml_win32_set_inherit((fd), ! caml_unix_cloexec_p((cloexec)))
 #else
-extern void caml_unix_set_cloexec(int fd, char * cmdname, value arg);
-extern void caml_unix_clear_cloexec(int fd, char * cmdname, value arg);
+extern void caml_unix_set_cloexec(int fd, const char * cmdname, value arg);
+extern void caml_unix_clear_cloexec(int fd, const char * cmdname, value arg);
 #endif /* _WIN32 */
 
 /* Compatibility definitions for the pre-5.0 names of these functions */

--- a/otherlibs/unix/cstringv.c
+++ b/otherlibs/unix/cstringv.c
@@ -21,7 +21,7 @@
 #include <caml/osdeps.h>
 #include "caml/unixsupport.h"
 
-char_os ** caml_unix_cstringvect(value arg, char * cmdname)
+char_os ** caml_unix_cstringvect(value arg, const char * cmdname)
 {
   char_os ** res;
   mlsize_t size;

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -101,7 +101,8 @@ int caml_unix_execvpe_emulation(const char * name,
                            char * const argv[],
                            char * const envp[])
 {
-  char * searchpath, * p, * q, * fullname;
+  const char * searchpath, * p, * q;
+  char * fullname;
   size_t namelen, dirlen;
   int r, got_eacces;
 

--- a/otherlibs/unix/gethost.c
+++ b/otherlibs/unix/gethost.c
@@ -79,7 +79,7 @@ static value alloc_host_entry(struct hostent *entry)
 
 CAMLprim value caml_unix_gethostbyaddr(value a)
 {
-  char * adr;
+  const char * adr;
   struct in_addr in4;
   struct hostent * hp;
   int addr_type = AF_INET;

--- a/otherlibs/unix/itimer.c
+++ b/otherlibs/unix/itimer.c
@@ -45,7 +45,7 @@ static value caml_unix_convert_itimer(struct itimerval *tp)
 #undef Get_timeval
 }
 
-static int itimers[3] = { ITIMER_REAL, ITIMER_VIRTUAL, ITIMER_PROF };
+static const int itimers[3] = { ITIMER_REAL, ITIMER_VIRTUAL, ITIMER_PROF };
 
 CAMLprim value caml_unix_setitimer(value which, value newval)
 {

--- a/otherlibs/unix/signals.c
+++ b/otherlibs/unix/signals.c
@@ -50,7 +50,7 @@ static value encode_sigset(sigset_t * set)
   CAMLreturn(res);
 }
 
-static int sigprocmask_cmd[3] = { SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK };
+static const int sigprocmask_cmd[3] = { SIG_SETMASK, SIG_BLOCK, SIG_UNBLOCK };
 
 CAMLprim value caml_unix_sigprocmask(value vaction, value vset)
 {

--- a/otherlibs/unix/unixsupport_unix.c
+++ b/otherlibs/unix/unixsupport_unix.c
@@ -336,7 +336,7 @@ int caml_unix_cloexec_p(value cloexec)
     return caml_unix_cloexec_default;
 }
 
-void caml_unix_set_cloexec(int fd, char *cmdname, value cmdarg)
+void caml_unix_set_cloexec(int fd, const char *cmdname, value cmdarg)
 {
   int flags = fcntl(fd, F_GETFD, 0);
   if (flags == -1 ||
@@ -344,7 +344,7 @@ void caml_unix_set_cloexec(int fd, char *cmdname, value cmdarg)
     caml_uerror(cmdname, cmdarg);
 }
 
-void caml_unix_clear_cloexec(int fd, char *cmdname, value cmdarg)
+void caml_unix_clear_cloexec(int fd, const char *cmdname, value cmdarg)
 {
   int flags = fcntl(fd, F_GETFD, 0);
   if (flags == -1 ||

--- a/runtime/addrmap.c
+++ b/runtime/addrmap.c
@@ -30,7 +30,7 @@ Caml_inline uintnat pos_initial(struct addrmap* t, value key)
   return pos & (t->size - 1);
 }
 
-Caml_inline uintnat pos_next(struct addrmap* t, uintnat pos)
+Caml_inline uintnat pos_next(const struct addrmap* t, uintnat pos)
 {
   return (pos + 1) & (t->size - 1);
 }

--- a/runtime/afl.c
+++ b/runtime/afl.c
@@ -85,7 +85,7 @@ static uint32_t afl_read(void)
 
 CAMLexport value caml_setup_afl(value unit)
 {
-  char* shm_id_str;
+  const char* shm_id_str;
   char* shm_id_end;
   long int shm_id;
   uint32_t startup_msg = 0;

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -63,8 +63,8 @@ CAMLprim value caml_backtrace_status(value vunit)
    implementation. */
 static void print_location(struct caml_loc_info * li, int index)
 {
-  char * info;
-  char * inlined;
+  const char * info;
+  const char * inlined;
 
   /* Ignore compiler-inserted raise */
   if (!li->loc_valid && li->loc_is_raise) return;

--- a/runtime/backtrace.c
+++ b/runtime/backtrace.c
@@ -61,7 +61,7 @@ CAMLprim value caml_backtrace_status(value vunit)
    0, then li->loc_is_raise is always 1, so the latter test is
    useless. We kept it to keep code identical to the runtime/
    implementation. */
-static void print_location(struct caml_loc_info * li, int index)
+static void print_location(const struct caml_loc_info * li, int index)
 {
   const char * info;
   const char * inlined;

--- a/runtime/backtrace_nat.c
+++ b/runtime/backtrace_nat.c
@@ -101,7 +101,7 @@ static debuginfo debuginfo_extract(frame_descr *d, ptrdiff_t alloc_idx);
    TODO: Consider rewriting this to use get_callstack, so we only have
    one body of code capturing callstacks.
 */
-void caml_stash_backtrace(value exn, uintnat pc, char * sp, char* trapsp)
+void caml_stash_backtrace(value exn, uintnat pc, char * sp, const char* trapsp)
 {
   caml_domain_state* domain_state = Caml_state;
   caml_frame_descrs* fds;

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -182,7 +182,7 @@ CAMLexport uintnat caml_ba_num_elts(struct caml_ba_array * b)
 
 /* Size in bytes of a bigarray element, indexed by bigarray kind */
 
-CAMLexport int caml_ba_element_size[] =
+CAMLexport const int caml_ba_element_size[] =
 { 4 /*FLOAT32*/, 8 /*FLOAT64*/,
   1 /*SINT8*/, 1 /*UINT8*/,
   2 /*SINT16*/, 2 /*UINT16*/,

--- a/runtime/bigarray.c
+++ b/runtime/bigarray.c
@@ -329,7 +329,7 @@ CAMLexport int caml_ba_compare(value v1, value v2)
   num_elts = caml_ba_num_elts(b1);
 
 #define DO_INTEGER_COMPARISON(type) \
-  { type * p1 = b1->data; type * p2 = b2->data; \
+  { const type * p1 = b1->data; const type * p2 = b2->data; \
     for (uintnat n = 0; n < num_elts; n++) { \
       type e1 = *p1++; type e2 = *p2++; \
       if (e1 < e2) return -1; \
@@ -338,7 +338,7 @@ CAMLexport int caml_ba_compare(value v1, value v2)
     return 0; \
   }
 #define DO_GENERIC_UNORDERED_COMPARISON(ptype, etype, conv) \
-  { ptype * p1 = b1->data; ptype * p2 = b2->data; \
+  { const ptype * p1 = b1->data; const ptype * p2 = b2->data; \
     for (uintnat n = 0; n < num_elts; n++) { \
       etype e1 = conv(*p1++); etype e2 = conv(*p2++); \
       if (e1 < e2) return -1; \
@@ -747,10 +747,10 @@ value caml_ba_get_N(value vb, volatile value * vind, int nind)
   case CAML_BA_CAML_INT:
     return Val_long(((intnat *) b->data)[offset]);
   case CAML_BA_COMPLEX32:
-    { float * p = ((float *) b->data) + offset * 2;
+    { const float * p = ((float *) b->data) + offset * 2;
       return copy_two_doubles((double) p[0], (double) p[1]); }
   case CAML_BA_COMPLEX64:
-    { double * p = ((double *) b->data) + offset * 2;
+    { const double * p = ((double *) b->data) + offset * 2;
       return copy_two_doubles(p[0], p[1]); }
   case CAML_BA_CHAR:
     return Val_int(((unsigned char *) b->data)[offset]);

--- a/runtime/caml/bigarray.h
+++ b/runtime/caml/bigarray.h
@@ -109,7 +109,7 @@ CAMLextern uintnat caml_ba_num_elts(struct caml_ba_array * b);
 
 #ifdef CAML_INTERNALS
 
-CAMLextern int caml_ba_element_size[];
+CAMLextern const int caml_ba_element_size[];
 CAMLextern void caml_ba_finalize(value v);
 CAMLextern int caml_ba_compare(value v1, value v2);
 CAMLextern intnat caml_ba_hash(value v);

--- a/runtime/caml/dynlink.h
+++ b/runtime/caml/dynlink.h
@@ -42,7 +42,7 @@ extern void caml_build_primitive_table_builtin(void);
 extern void caml_free_shared_libs(void);
 
 /* Return the effective location of the standard library */
-extern char_os * caml_get_stdlib_location(void);
+extern const char_os * caml_get_stdlib_location(void);
 
 /* Parse ld.conf and add the lines read to caml_shared_libs_path */
 extern char_os * caml_parse_ld_conf(void);

--- a/runtime/caml/intext.h
+++ b/runtime/caml/intext.h
@@ -209,7 +209,7 @@ CAMLextern void caml_deserialize_block_4(void * data, intnat len);
 CAMLextern void caml_deserialize_block_8(void * data, intnat len);
 CAMLextern void caml_deserialize_block_float_8(void * data, intnat len);
 
-CAMLnoret CAMLextern void caml_deserialize_error(char * msg);
+CAMLnoret CAMLextern void caml_deserialize_error(const char * msg);
 
 #ifdef __cplusplus
 }

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -96,8 +96,8 @@ CAMLextern void caml_flush (struct channel *);
 CAMLextern void caml_flush_if_unbuffered (struct channel *);
 CAMLextern void caml_putch(struct channel *, int);
 CAMLextern void caml_putword (struct channel *, uint32_t);
-CAMLextern int caml_putblock (struct channel *, char *, intnat);
-CAMLextern void caml_really_putblock (struct channel *, char *, intnat);
+CAMLextern int caml_putblock (struct channel *, const char *, intnat);
+CAMLextern void caml_really_putblock (struct channel *, const char *, intnat);
 
 CAMLextern unsigned char caml_refill (struct channel *);
 CAMLextern unsigned char caml_getch(struct channel *);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -279,7 +279,7 @@ typedef char char_os;
    from the callsite, making debuggers able to see it. */
 #define CAMLassert(x) \
   (CAMLlikely(x) ? (void) 0 : caml_failed_assert ( #x , __OSFILE__, __LINE__))
-CAMLextern void caml_failed_assert (char *, char_os *, int)
+CAMLextern void caml_failed_assert (const char *, const char_os *, int)
 #if defined(__has_feature)
   /* However, we do inform clang-analyzer that this function never returns,
      since that improves analysis without breaking debugging */
@@ -308,7 +308,7 @@ CAMLextern void caml_failed_assert (char *, char_os *, int)
 #endif
 
 #ifdef DEBUG
-CAMLnoret CAMLextern void caml_debug_abort(char_os *, int);
+CAMLnoret CAMLextern void caml_debug_abort(const char_os *, int);
 #define CAMLunreachable() (caml_debug_abort(__OSFILE__, __LINE__))
 #else
 #define CAMLunreachable() (caml_abort())
@@ -357,11 +357,11 @@ void caml_alloc_point_here(void);
 
    This function must be reentrant. */
 #ifndef __cplusplus
-typedef void (*fatal_error_hook) (char *msg, va_list args);
+typedef void (*fatal_error_hook) (const char *msg, va_list args);
 extern _Atomic fatal_error_hook caml_fatal_error_hook;
 #endif
 
-CAMLnoret CAMLextern void caml_fatal_error (char *, ...)
+CAMLnoret CAMLextern void caml_fatal_error (const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
 #endif
@@ -553,13 +553,13 @@ CAMLextern int caml_read_directory(char_os * dirname,
 
 extern atomic_uintnat caml_verb_gc;
 
-void caml_gc_log (char *, ...)
+void caml_gc_log (const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 ;
 
-void caml_gc_message (int, char *, ...)
+void caml_gc_message (int, const char *, ...)
 #if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 2, 3)))
 #endif

--- a/runtime/caml/startup.h
+++ b/runtime/caml/startup.h
@@ -44,9 +44,9 @@ extern int caml_attempt_open(char_os **name, struct exec_trailer *trail,
 extern int caml_read_trailer(int fd, struct exec_trailer *trail);
 extern void caml_read_section_descriptors(int fd, struct exec_trailer *trail);
 extern int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
-                                        char *name);
+                                          const char *name);
 extern int32_t caml_seek_section(int fd, struct exec_trailer *trail,
-                                 char *name);
+                                 const char *name);
 
 enum caml_byte_program_mode
   {

--- a/runtime/caml/sys.h
+++ b/runtime/caml/sys.h
@@ -33,7 +33,7 @@ CAMLnoret CAMLextern void caml_sys_error (value);
 CAMLnoret CAMLextern void caml_sys_io_error (value);
 
 CAMLextern double caml_sys_time_unboxed(value);
-CAMLextern void caml_sys_init (char_os * exe_name, char_os ** argv);
+CAMLextern void caml_sys_init (const char_os * exe_name, char_os ** argv);
 
 CAMLnoret CAMLextern void caml_do_exit (int);
 

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -152,7 +152,7 @@ struct code_fragment *
 caml_find_code_fragment_by_digest(unsigned char digest[16]) {
   FOREACH_LF_SKIPLIST_ELEMENT(e, &code_fragments_by_pc, {
     struct code_fragment *cf = (struct code_fragment *)e->data;
-    unsigned char *d = caml_digest_of_code_fragment(cf);
+    const unsigned char *d = caml_digest_of_code_fragment(cf);
     if (d != NULL && memcmp(digest, d, 16) == 0)
       return cf;
   })

--- a/runtime/compare.c
+++ b/runtime/compare.c
@@ -57,8 +57,8 @@ CAMLnoret static void compare_stack_overflow(struct compare_stack* stk)
 }
 
 /* Grow the compare stack */
-static struct compare_item * compare_resize_stack(struct compare_stack* stk,
-                                                  struct compare_item * sp)
+static struct compare_item *
+compare_resize_stack(struct compare_stack* stk, const struct compare_item * sp)
 {
   asize_t newsize;
   asize_t sp_offset = sp - stk->stack;
@@ -97,7 +97,7 @@ static intnat compare_val(value v1, value v2, int total)
 }
 
 static void run_pending_actions(struct compare_stack* stk,
-                                struct compare_item* sp)
+                                const struct compare_item* sp)
 {
   caml_result result;
   value* roots_start = (value*)(stk->stack);

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -83,9 +83,9 @@ static c_primitive lookup_primitive(char * name)
 
 #define LD_CONF_NAME T("ld.conf")
 
-CAMLexport char_os * caml_get_stdlib_location(void)
+CAMLexport const char_os * caml_get_stdlib_location(void)
 {
-  char_os * stdlib;
+  const char_os * stdlib;
   stdlib = caml_secure_getenv(T("OCAMLLIB"));
   if (stdlib == NULL) stdlib = caml_secure_getenv(T("CAMLLIB"));
   if (stdlib == NULL) stdlib = OCAML_STDLIB_DIR;
@@ -94,7 +94,8 @@ CAMLexport char_os * caml_get_stdlib_location(void)
 
 CAMLexport char_os * caml_parse_ld_conf(void)
 {
-  char_os * stdlib, * ldconfname, * wconfig, * p, * q;
+  const char_os * stdlib;
+  char_os * ldconfname, * wconfig, * p, * q;
   char * config;
 #ifdef _WIN32
   struct _stati64 st;

--- a/runtime/dynlink.c
+++ b/runtime/dynlink.c
@@ -63,7 +63,7 @@ struct ext_table caml_shared_libs_path;
 
 /* Look up the given primitive name in the built-in primitive table,
    then in the opened shared libraries (shared_libs) */
-static c_primitive lookup_primitive(char * name)
+static c_primitive lookup_primitive(const char * name)
 {
   void * res;
 

--- a/runtime/dynlink_nat.c
+++ b/runtime/dynlink_nat.c
@@ -79,7 +79,7 @@ CAMLprim value caml_natdynlink_open(value filename, value global)
 {
   CAMLparam2 (filename, global);
   CAMLlocal3 (res, handle, header);
-  void *sym;
+  const void *sym;
   void *dlhandle;
   char_os *p;
   int global_dup;

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -170,9 +170,11 @@ _Bool (*caml_extern_compress_output)(struct caml_output_block **) = NULL;
 CAMLnoret static void extern_out_of_memory(struct caml_extern_state* s);
 
 CAMLnoret static
-void extern_invalid_argument(struct caml_extern_state* s, char *msg);
+void extern_invalid_argument(struct caml_extern_state* s,
+                             const char *msg);
 
-CAMLnoret static void extern_failwith(struct caml_extern_state* s, char *msg);
+CAMLnoret static void extern_failwith(struct caml_extern_state* s,
+                                      const char *msg);
 
 CAMLnoret static void extern_stack_overflow(struct caml_extern_state* s);
 
@@ -441,13 +443,14 @@ static void extern_out_of_memory(struct caml_extern_state* s)
   caml_raise_out_of_memory();
 }
 
-static void extern_invalid_argument(struct caml_extern_state *s, char *msg)
+static void extern_invalid_argument(struct caml_extern_state *s,
+                                    const char *msg)
 {
   free_extern_output(s);
   caml_invalid_argument(msg);
 }
 
-static void extern_failwith(struct caml_extern_state* s, char *msg)
+static void extern_failwith(struct caml_extern_state* s, const char *msg)
 {
   free_extern_output(s);
   caml_failwith(msg);

--- a/runtime/extern.c
+++ b/runtime/extern.c
@@ -190,7 +190,7 @@ static void extern_free_stack(struct caml_extern_state* s)
 }
 
 static struct extern_item * extern_resize_stack(struct caml_extern_state* s,
-                                                struct extern_item * sp)
+                                                const struct extern_item * sp)
 {
   asize_t newsize = 2 * (s->extern_stack_limit - s->extern_stack);
   asize_t sp_offset = sp - s->extern_stack;

--- a/runtime/fix_code.c
+++ b/runtime/fix_code.c
@@ -127,7 +127,7 @@ int* caml_init_opcode_nargs(void)
 void caml_thread_code (code_t code, asize_t len)
 {
   code_t p;
-  int* l = caml_init_opcode_nargs();
+  const int* l = caml_init_opcode_nargs();
   len /= sizeof(opcode_t);
   for (p = code; p < code + len; /*nothing*/) {
     opcode_t instr = *p;

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -230,7 +230,7 @@ CAMLprim value caml_hexstring_of_float(value arg, value vprec, value vstyle)
   }
   /* Treat special cases */
   if (exp == 0x7FF) {
-    char * txt;
+    const char * txt;
     if (m == 0) txt = "infinity"; else txt = "nan";
     memcpy(p, txt, strlen(txt));
     p[strlen(txt)] = 0;

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -215,7 +215,8 @@ static void scan_native_globals(scanning_action f, void* fdata)
 
 /* Iterate a GC scanning action over a global root list */
 Caml_inline void caml_iterate_global_roots(scanning_action f,
-                                      struct skiplist * rootlist, void* fdata)
+                                           const struct skiplist * rootlist,
+                                           void* fdata)
 {
   FOREACH_SKIPLIST_ELEMENT(e, rootlist, {
       value * r = (value *) (e->key);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -1207,7 +1207,7 @@ CAMLexport void caml_deserialize_block_float_8(void * data, intnat len)
 #endif
 }
 
-CAMLexport void caml_deserialize_error(char * msg)
+CAMLexport void caml_deserialize_error(const char * msg)
 {
   struct caml_intern_state* s = get_intern_state ();
   intern_cleanup(s);

--- a/runtime/intern.c
+++ b/runtime/intern.c
@@ -343,7 +343,7 @@ CAMLnoret static void intern_stack_overflow(struct caml_intern_state* s)
 }
 
 static struct intern_item * intern_resize_stack(struct caml_intern_state* s,
-                                                struct intern_item * sp)
+                                                const struct intern_item * sp)
 {
   asize_t newsize = 2 * (s->intern_stack_limit - s->intern_stack);
   asize_t sp_offset = sp - s->intern_stack;
@@ -1052,7 +1052,7 @@ CAMLprim value caml_marshal_data_size(value buff, value ofs)
 static char * intern_resolve_code_pointer(unsigned char digest[16],
                                           asize_t offset)
 {
-  struct code_fragment * cf = caml_find_code_fragment_by_digest(digest);
+  const struct code_fragment * cf = caml_find_code_fragment_by_digest(digest);
   if (cf != NULL && cf->code_start + offset < cf->code_end)
     return cf->code_start + offset;
   else

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -263,9 +263,9 @@ value caml_interprete(code_t prog, asize_t prog_size)
 #endif
 #if defined(THREADED_CODE) && defined(ARCH_SIXTYFOUR) && !defined(ARCH_CODE32)
 #ifdef JUMPTBL_BASE_REG
-  register char * jumptbl_base JUMPTBL_BASE_REG;
+  register const char * jumptbl_base JUMPTBL_BASE_REG;
 #else
-  register char * jumptbl_base;
+  register const char * jumptbl_base;
 #endif
 #endif
   value env;

--- a/runtime/ints.c
+++ b/runtime/ints.c
@@ -142,7 +142,7 @@ CAMLprim value caml_int_of_string(value s)
 #define FORMAT_BUFFER_SIZE 32
 
 static char parse_format(value fmt,
-                         char * suffix,
+                         const char * suffix,
                          char format_string[FORMAT_BUFFER_SIZE])
 {
   char * p;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -311,7 +311,7 @@ CAMLexport void caml_putword(struct channel *channel, uint32_t w)
   caml_putch(channel, w);
 }
 
-CAMLexport int caml_putblock(struct channel *channel, char *p, intnat len)
+CAMLexport int caml_putblock(struct channel *channel, const char *p, intnat len)
 {
   int n, free;
 
@@ -333,7 +333,7 @@ CAMLexport int caml_putblock(struct channel *channel, char *p, intnat len)
 }
 
 CAMLexport void caml_really_putblock(struct channel *channel,
-                                     char *p, intnat len)
+                                     const char *p, intnat len)
 {
   int written;
   while (len > 0) {

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -578,8 +578,8 @@ void caml_finalize_channel(value vchan)
 
 static int compare_channel(value vchan1, value vchan2)
 {
-  struct channel * chan1 = Channel(vchan1);
-  struct channel * chan2 = Channel(vchan2);
+  const struct channel * chan1 = Channel(vchan1);
+  const struct channel * chan2 = Channel(vchan2);
   return (chan1 == chan2) ? 0 : (chan1 < chan2) ? -1 : 1;
 }
 
@@ -843,7 +843,7 @@ CAMLprim value caml_ml_set_buffered(value vchannel, value mode)
 
 CAMLprim value caml_ml_is_buffered(value vchannel)
 {
-  struct channel * channel = Channel(vchannel);
+  const struct channel * channel = Channel(vchannel);
   return Val_bool( ! (channel->flags & CHANNEL_FLAG_UNBUFFERED));
 }
 

--- a/runtime/lexing.c
+++ b/runtime/lexing.c
@@ -143,7 +143,7 @@ static void run_mem(char *pc, value mem, value curr_pos) {
   }
 }
 
-static void run_tag(char *pc, value mem) {
+static void run_tag(const char *pc, value mem) {
   for (;;) {
     unsigned char dst, src ;
 

--- a/runtime/lf_skiplist.c
+++ b/runtime/lf_skiplist.c
@@ -288,7 +288,7 @@ static struct lf_skipcell *lf_skiplist_lookup(struct lf_skiplist *sk,
 /* Search a skip list */
 
 int caml_lf_skiplist_find(struct lf_skiplist *sk, uintnat key, uintnat *data) {
-  struct lf_skipcell *found_cell = lf_skiplist_lookup(sk, key, NULL);
+  const struct lf_skipcell *found_cell = lf_skiplist_lookup(sk, key, NULL);
 
   if (found_cell->key == key) {
     if (data) {
@@ -304,7 +304,7 @@ int caml_lf_skiplist_find_below(struct lf_skiplist *sk, uintnat k, uintnat *key,
                                 uintnat *data) {
   struct lf_skipcell *pred;
   struct lf_skipcell *curr = lf_skiplist_lookup(sk, k, &pred);
-  struct lf_skipcell *found_cell;
+  const struct lf_skipcell *found_cell;
 
   if (curr->key == k) {
     found_cell = curr;
@@ -486,7 +486,7 @@ int caml_lf_skiplist_remove(struct lf_skiplist *sk, uintnat key) {
 void caml_lf_skiplist_free_garbage(struct lf_skiplist *sk) {
   struct lf_skipcell *curr = atomic_load_acquire(&sk->garbage_head);
 
-  struct lf_skipcell *head = sk->head;
+  const struct lf_skipcell *head = sk->head;
   while (curr != head) {
     struct lf_skipcell *next = atomic_load_relaxed(&curr->garbage_next);
     // acquire not useful, if executed in STW

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -956,7 +956,7 @@ CAMLexport value caml_check_urgent_gc (value extra_root)
 static void realloc_generic_table
 (struct generic_table *tbl, asize_t element_size,
  ev_runtime_counter ev_counter_name,
- char *msg_threshold, char *msg_growing, char *msg_error)
+ const char *msg_threshold, const char *msg_growing, const char *msg_error)
 {
   CAMLassert (tbl->ptr == tbl->limit);
   CAMLassert (tbl->limit <= tbl->end);

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -473,7 +473,7 @@ void caml_empty_minor_heap_promote(caml_domain_state* domain,
                                    int participating_count,
                                    caml_domain_state** participating)
 {
-  struct caml_minor_tables *self_minor_tables = domain->minor_tables;
+  const struct caml_minor_tables *self_minor_tables = domain->minor_tables;
   value* young_ptr = domain->young_ptr;
   value* young_end = domain->young_end;
   uintnat minor_allocated_bytes = (uintnat)young_end - (uintnat)young_ptr;

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -36,14 +36,14 @@ _Atomic caml_timing_hook caml_finalise_begin_hook = (caml_timing_hook)NULL;
 _Atomic caml_timing_hook caml_finalise_end_hook = (caml_timing_hook)NULL;
 
 #ifdef DEBUG
-void caml_print_loc(char_os *file_os, int line) {
+void caml_print_loc(const char_os *file_os, int line) {
   char* file = caml_stat_strdup_of_os(file_os);
   fprintf(stderr, "[%02d] file %s; line %d ### ",
           (Caml_state_opt != NULL) ? Caml_state_opt->id : -1, file, line);
   caml_stat_free(file);
 }
 
-void caml_failed_assert (char * expr, char_os * file_os, int line)
+void caml_failed_assert (const char * expr, const char_os * file_os, int line)
 {
   caml_print_loc(file_os, line);
   fprintf(stderr, "Assertion failed: %s\n", expr);
@@ -51,7 +51,7 @@ void caml_failed_assert (char * expr, char_os * file_os, int line)
   caml_abort();
 }
 
-CAMLnoret void caml_debug_abort(char_os * file_os, int line) {
+CAMLnoret void caml_debug_abort(const char_os * file_os, int line) {
   caml_print_loc(file_os, line);
   fprintf(stderr, "Abort\n");
   fflush(stderr);
@@ -80,7 +80,7 @@ void caml_alloc_point_here(void)
 
 atomic_uintnat caml_verb_gc = 0;
 
-void caml_gc_log (char *msg, ...)
+void caml_gc_log (const char *msg, ...)
 {
   if ((atomic_load_relaxed(&caml_verb_gc) & 0x800) != 0) {
     char fmtbuf[GC_LOG_LENGTH];
@@ -94,7 +94,7 @@ void caml_gc_log (char *msg, ...)
   }
 }
 
-void caml_gc_message (int level, char *msg, ...)
+void caml_gc_message (int level, const char *msg, ...)
 {
   if ((atomic_load_relaxed(&caml_verb_gc) & level) != 0){
     va_list ap;
@@ -107,7 +107,7 @@ void caml_gc_message (int level, char *msg, ...)
 
 _Atomic fatal_error_hook caml_fatal_error_hook = (fatal_error_hook)NULL;
 
-CAMLexport void caml_fatal_error (char *msg, ...)
+CAMLexport void caml_fatal_error (const char *msg, ...)
 {
   va_list ap;
   fatal_error_hook hook;

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -103,7 +103,7 @@ enum input_codes {
 
 /* Auxiliary for printing token just read */
 
-static char * token_name(char * names, int number)
+static const char * token_name(const char * names, int number)
 {
   for (/*nothing*/; number > 0; number--) {
     if (names[0] == 0) return "<unknown token>";

--- a/runtime/parsing.c
+++ b/runtime/parsing.c
@@ -112,7 +112,8 @@ static const char * token_name(const char * names, int number)
   return names;
 }
 
-static void print_token(struct parser_tables *tables, int state, value tok)
+static void print_token(const struct parser_tables *tables, int state,
+                        value tok)
 {
   value v;
 

--- a/runtime/startup_aux.c
+++ b/runtime/startup_aux.c
@@ -165,7 +165,7 @@ int caml_startup_aux(int pooling)
   return 1;
 }
 
-static void call_registered_value(char* name)
+static void call_registered_value(const char* name)
 {
   const value *f = caml_named_value(name);
   if (f != NULL)

--- a/runtime/startup_byt.c
+++ b/runtime/startup_byt.c
@@ -75,7 +75,7 @@
 static char magicstr[EXEC_MAGIC_LENGTH+1];
 
 /* Print the specified error message followed by an end-of-line and exit */
-static void error(char *msg, ...)
+static void error(const char *msg, ...)
 {
   va_list ap;
   va_start(ap, msg);
@@ -177,7 +177,7 @@ void caml_read_section_descriptors(int fd, struct exec_trailer *trail)
    found with that name. */
 
 int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
-                                   char *name)
+                                   const char *name)
 {
   long ofs;
 
@@ -195,7 +195,8 @@ int32_t caml_seek_optional_section(int fd, struct exec_trailer *trail,
 /* Position fd at the beginning of the section having the given name.
    Return the length of the section data in bytes. */
 
-int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
+int32_t caml_seek_section(int fd, struct exec_trailer *trail,
+                          const char *name)
 {
   int32_t len = caml_seek_optional_section(fd, trail, name);
   if (len == -1)
@@ -206,7 +207,8 @@ int32_t caml_seek_section(int fd, struct exec_trailer *trail, char *name)
 /* Read and return the contents of the section having the given name.
    Add a terminating 0.  Return NULL if no such section. */
 
-static char * read_section(int fd, struct exec_trailer *trail, char *name)
+static char * read_section(int fd, struct exec_trailer *trail,
+                           const char *name)
 {
   int32_t len;
   char * data;
@@ -223,7 +225,7 @@ static char * read_section(int fd, struct exec_trailer *trail, char *name)
 #ifdef _WIN32
 
 static char_os * read_section_to_os(int fd, struct exec_trailer *trail,
-                                    char *name)
+                                    const char *name)
 {
   int32_t len, wlen;
   char * data;
@@ -378,7 +380,7 @@ static int parse_command_line(char_os **argv)
    freed, since the runtime will terminate after calling this. */
 static void do_print_config(void)
 {
-  char_os * dir;
+  const char_os * dir;
 
   /* Print the runtime configuration */
   printf("version: %s\n", OCAML_VERSION_STRING);

--- a/runtime/startup_nat.c
+++ b/runtime/startup_nat.c
@@ -85,7 +85,7 @@ extern void caml_install_invalid_parameter_handler(void);
 
 value caml_startup_common(char_os **argv, int pooling)
 {
-  char_os * exe_name, * proc_self_exe;
+  const char_os * exe_name, * proc_self_exe;
   value res;
 
   /* Determine options */

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -478,7 +478,7 @@ CAMLprim value caml_sys_executable_name(value unit)
   return caml_copy_string_of_os(caml_params->exe_name);
 }
 
-void caml_sys_init(char_os * exe_name, char_os **argv)
+void caml_sys_init(const char_os * exe_name, char_os **argv)
 {
 #ifdef _WIN32
   /* Initialises the caml_win32_* globals on Windows with the version of

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -135,7 +135,8 @@ caml_stat_string caml_decompose_path(struct ext_table * tbl, char * path)
 
 caml_stat_string caml_search_in_path(struct ext_table * path, const char * name)
 {
-  char * dir, * fullname;
+  const char * dir;
+  char * fullname;
   struct stat st;
 
   for (const char *p = name; *p != 0; p++) {

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -334,9 +334,9 @@ CAMLexport int caml_read_directory(char * dirname, struct ext_table * contents)
 {
   DIR * d;
 #ifdef HAS_DIRENT
-  struct dirent * e;
+  const struct dirent * e;
 #else
-  struct direct * e;
+  const struct direct * e;
 #endif
 
   d = opendir(dirname);

--- a/stdlib/header.c
+++ b/stdlib/header.c
@@ -160,7 +160,7 @@ static char * read_runtime_path(int fd)
   return runtime_path;
 }
 
-static void errwrite(char * msg)
+static void errwrite(const char * msg)
 {
   fputs(msg, stderr);
 }

--- a/yacc/defs.h
+++ b/yacc/defs.h
@@ -227,7 +227,7 @@ extern char eflag;
 extern char big_endian;
 
 /* myname should be UTF-8 encoded */
-extern char *myname;
+extern const char *myname;
 extern char *cptr;
 extern char *line;
 extern int lineno;
@@ -238,7 +238,7 @@ extern int outline;
 extern char_os *action_file_name;
 extern char_os *entry_file_name;
 extern char_os *code_file_name;
-extern char_os *input_file_name;
+extern const char_os *input_file_name;
 extern char_os *output_file_name;
 extern char_os *text_file_name;
 extern char_os *verbose_file_name;
@@ -316,8 +316,8 @@ extern short final_state;
 /* global functions */
 
 extern char *allocate(unsigned int n);
-extern bucket *lookup(char *name);
-extern bucket *make_bucket(char *name);
+extern bucket *lookup(const char *name);
+extern bucket *make_bucket(const char *name);
 extern action *parse_actions(int stateno);
 extern action *get_shifts(int stateno);
 extern action *add_reductions(int stateno, action *actions);
@@ -327,7 +327,7 @@ extern void create_symbol_table (void);
 CAMLnoret extern void default_action_error (void);
 CAMLnoret extern void done (int k);
 CAMLnoret extern void entry_without_type (char *s);
-CAMLnoret extern void fatal (char *msg);
+CAMLnoret extern void fatal (const char *msg);
 extern void finalize_closure (void);
 extern void free_parser (void);
 extern void free_symbol_table (void);
@@ -339,7 +339,7 @@ extern void lr0 (void);
 extern void make_parser (void);
 CAMLnoret extern void no_grammar (void);
 CAMLnoret extern void no_space (void);
-CAMLnoret extern void open_error (char_os *filename);
+CAMLnoret extern void open_error (const char_os *filename);
 extern void output (void);
 extern void prec_redeclared (void);
 CAMLnoret extern void polymorphic_entry_point(char *s);
@@ -365,7 +365,7 @@ CAMLnoret extern void unterminated_string (int s_lineno, char *s_line, char *s_c
 CAMLnoret extern void unterminated_text (int t_lineno, char *t_line, char *t_cptr);
 CAMLnoret extern void used_reserved (char *s);
 extern void verbose (void);
-extern void write_section (char **section);
+extern void write_section (char const * const * section);
 CAMLnoret extern void invalid_literal(int s_lineno, char *s_line, char *s_cptr);
 
 #endif /* YACC_DEFS_H */

--- a/yacc/error.c
+++ b/yacc/error.c
@@ -20,9 +20,9 @@
 #include "defs.h"
 
 /* String displayed if we can't malloc a buffer for the UTF-8 conversion */
-static char *unknown = "<unknown; out of memory>";
+static const char *unknown = "<unknown; out of memory>";
 
-void fatal(char *msg)
+void fatal(const char *msg)
 {
     fprintf(stderr, "%s: f - %s\n", myname, msg);
     done(2);
@@ -36,7 +36,7 @@ void no_space(void)
 }
 
 
-void open_error(char_os *filename)
+void open_error(const char_os *filename)
 {
     char *u8 = caml_stat_strdup_of_os(filename);
     fprintf(stderr, "%s: f - cannot open \"%s\"\n", myname, (u8 ? u8 : unknown));
@@ -77,7 +77,8 @@ static void print_pos(char *st_line, char *st_cptr)
 }
 
 
-CAMLnoret static void gen_error(int st_lineno, char *st_line, char *st_cptr, char *msg)
+CAMLnoret static void gen_error(int st_lineno, char *st_line, char *st_cptr,
+                                const char *msg)
 {
     fprintf(stderr, "File \"%s\", line %d: %s\n",
             virtual_input_file_name, st_lineno, msg);

--- a/yacc/main.c
+++ b/yacc/main.c
@@ -37,7 +37,7 @@ char sflag;
 char big_endian;
 
 char_os *file_prefix = 0;
-char *myname = "yacc";
+const char *myname = "yacc";
 char_os temp_form[] = T("yacc.XXXXXXX");
 
 #ifdef _WIN32
@@ -57,7 +57,7 @@ char_os *entry_file_name;
 char_os *code_file_name;
 char *code_file_name_disp, *interface_file_name_disp;
 char_os *interface_file_name;
-char_os *input_file_name = T("");
+const char_os *input_file_name = T("");
 char *input_file_name_disp;
 char_os *output_file_name;
 char_os *text_file_name;
@@ -287,7 +287,7 @@ allocate(unsigned int n)
 void create_file_names(void)
 {
     int i, len;
-    char_os *tmpdir;
+    const char_os *tmpdir;
 
 #ifdef _WIN32
     tmpdir = _wgetenv(L"TEMP");

--- a/yacc/output.c
+++ b/yacc/output.c
@@ -61,7 +61,7 @@ int pack_vector (int vector);
 
 void output(void)
 {
-  extern char *header[], *define_tables[];
+  extern char const * const header[], * const define_tables[];
 
   free_itemsets();
   free_shifts();

--- a/yacc/skeleton.c
+++ b/yacc/skeleton.c
@@ -17,14 +17,14 @@
 
 #include "defs.h"
 
-char *header[] =
+char const * const header[] =
 {
   "open Parsing",
   "let _ = parse_error;;", /* avoid warning 33 (PR#5719) */
   0
 };
 
-char *define_tables[] =
+char const * const define_tables[] =
 {
   "let yytables =",
   "  { Parsing.actions=yyact;",
@@ -46,7 +46,7 @@ char *define_tables[] =
   0
 };
 
-void write_section(char **section)
+void write_section(char const * const * section)
 {
     int i;
     FILE *fp;

--- a/yacc/symtab.c
+++ b/yacc/symtab.c
@@ -25,9 +25,9 @@ bucket *last_symbol;
 
 
 int
-hash(char *name)
+hash(const char *name)
 {
-    char *s;
+    const char *s;
     int c, k;
 
     assert(name && *name);
@@ -41,7 +41,7 @@ hash(char *name)
 
 
 bucket *
-make_bucket(char *name)
+make_bucket(const char *name)
 {
     bucket *bp;
 
@@ -69,7 +69,7 @@ make_bucket(char *name)
 
 
 bucket *
-lookup(char *name)
+lookup(const char *name)
 {
     bucket *bp, **bpp;
 


### PR DESCRIPTION
Aided by the compiler and [cppcheck][], I've found some function parameters and variables that can be made `const`.

These public functions have had some of their parameters constified. I've checked using opam-grep if opam packages were affected (for instance, if they were re-declaring the symbol). This should be rare, as most of them are protected by `CAML_INTERNALS` and the manual explicitly makes no compatibility guarantees. 

- [x] `caml_unix_cstringvect`
- [x] `caml_unix_set_cloexec`
- [x] `caml_unix_clear_cloexec`
- [x] `caml_get_stdlib_location`
- [x] `caml_deserialize_error`
- [x] `caml_putblock`
  + [`gsl`](https://github.com/mmottl/gsl-ocaml) copies the `io.h` header;
- [x] `caml_really_putblock`
  + [`gsl`](https://github.com/mmottl/gsl-ocaml) copies the `io.h` header;
- [x] `caml_failed_assert`
- [x] `caml_debug_abort`
- [x] `caml_fatal_error`
- [x] `caml_gc_log`
- [x] `caml_gc_message`
- [x] `caml_seek_optional_section`
- [x] `caml_seek_section`
- [x] `caml_sys_init`

Changed typedef:
- [x] `fatal_error_hook`

[cppcheck]: https://cppcheck.sourceforge.io/