### PR TITLE
Use `nanosleep` instead of `usleep`, if available

### DIFF
--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -469,9 +469,14 @@ void caml_mem_unmap(void* mem, uintnat size)
 #endif
 }
 
-#define Min_sleep_ns       10000 // 10 us
-#define Slow_sleep_ns    1000000 //  1 ms
-#define Max_sleep_ns  1000000000 //  1 s
+#define POW10_3 1000
+#define POW10_4 10000
+#define POW10_6 1000000
+#define POW10_9 1000000000
+
+#define Min_sleep_ns     POW10_4 // 10 us
+#define Slow_sleep_ns    POW10_6 //  1 ms
+#define Max_sleep_ns     POW10_9 //  1 s
 
 unsigned caml_plat_spin_back_off(unsigned sleep_ns,
                                  const struct caml_plat_srcloc* loc)
@@ -484,9 +489,14 @@ unsigned caml_plat_spin_back_off(unsigned sleep_ns,
                 loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
-  Sleep(sleep_ns/1000000);
+  Sleep(sleep_ns / POW10_6);
+#elif defined (HAS_NANOSLEEP)
+  const struct timespec req = {
+    .tv_sec = sleep_ns / POW10_9,
+    .tv_nsec = sleep_ns % POW10_9 };
+  nanosleep(&req, NULL);
 #else
-  usleep(sleep_ns/1000);
+  usleep(sleep_ns / POW_3);
 #endif
   return next_sleep_ns;
 }

--- a/testsuite/tests/tsan/waitgroup_stubs.c
+++ b/testsuite/tests/tsan/waitgroup_stubs.c
@@ -6,7 +6,7 @@
 #include <caml/tsan.h>
 
 #define MAX_WAITGROUP   8
-#define SPIN_WAIT_MS    10
+#define SPIN_WAIT_US    10
 
 /* waitgroup inspired by Golang's `sync.WaitGroup`. This version does *not*
  * allow to restart a waitgroup. */
@@ -52,7 +52,14 @@ CAMLno_tsan value wg_wait(value t)
    * checkpoint. This allows TSan to always generate a report with a
    * 'As if synchronized via sleep' section. */
   do {
-    usleep(SPIN_WAIT_MS);
+#ifdef HAS_NANOSLEEP
+    const struct timespec ts = {
+      .tv_sec = SPIN_WAIT_US / 1000,
+      .tv_nsec = SPIN_WAIT_US % 1000 };
+    nanosleep(&ts, NULL);
+#else
+    usleep(SPIN_WAIT_US);
+#endif
   }
   while (wg->count != wg->limit);
   return Val_unit;


### PR DESCRIPTION
`usleep()` is deprecated in favor of `nanosleep()`. The `nanosleep()` function conforms to IEEE Std 1003.1b-1993 ("POSIX.1b").