### PR TITLE
Stop using `GetProcAddress` to load always available functions

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,10 @@ Working version
 
 ### Runtime system:
 
+- #?????: Stop using GetProcAddress to load functions that were not
+  available in older, now unsupported Windows versions.
+  (Antonin Décimo, review by ????)
+
 ### Code generation and optimizations:
 
 ### Standard library:

--- a/otherlibs/unix/link_win32.c
+++ b/otherlibs/unix/link_win32.c
@@ -23,35 +23,21 @@
 #include <errno.h>
 #include <windows.h>
 
-typedef
-BOOL (WINAPI *tCreateHardLink)(
-  LPCWSTR lpFileName,
-  LPCWSTR lpExistingFileName,
-  LPSECURITY_ATTRIBUTES lpSecurityAttributes
-);
-
 CAMLprim value caml_unix_link(value follow, value path1, value path2)
 {
-  HMODULE hModKernel32;
-  tCreateHardLink pCreateHardLink;
   BOOL result;
   wchar_t * wpath1, * wpath2;
   if (Is_some(follow) && !Bool_val(Some_val(follow))) {
     errno = ENOSYS;
     caml_uerror("link", path2);
   }
-  hModKernel32 = GetModuleHandle(L"KERNEL32.DLL");
-  pCreateHardLink =
-    (tCreateHardLink) GetProcAddress(hModKernel32, "CreateHardLinkW");
-  if (pCreateHardLink == NULL)
-    caml_invalid_argument("Unix.link not implemented");
   caml_unix_check_path(path1, "link");
   caml_unix_check_path(path2, "link");
 
   wpath1 = caml_stat_strdup_to_utf16(String_val(path1));
   wpath2 = caml_stat_strdup_to_utf16(String_val(path2));
 
-  result = pCreateHardLink(wpath2, wpath1, NULL);
+  result = CreateHardLink(wpath2, wpath1, NULL);
 
   caml_stat_free(wpath1);
   caml_stat_free(wpath2);

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1029,31 +1029,17 @@ void caml_restore_win32_terminal(void)
 /* Detect if a named pipe corresponds to a Cygwin/MSYS pty: see
    https://github.com/mirror/newlib-cygwin/blob/00e9bf2/winsup/cygwin/dtable.cc#L932
 */
-typedef
-BOOL (WINAPI *tGetFileInformationByHandleEx)(HANDLE, FILE_INFO_BY_HANDLE_CLASS,
-                                             LPVOID, DWORD);
-
 static int caml_win32_is_cygwin_pty(HANDLE hFile)
 {
   char buffer[1024];
   FILE_NAME_INFO * nameinfo = (FILE_NAME_INFO *) buffer;
-  static tGetFileInformationByHandleEx pGetFileInformationByHandleEx =
-    INVALID_HANDLE_VALUE;
-
-  if (pGetFileInformationByHandleEx == INVALID_HANDLE_VALUE)
-    pGetFileInformationByHandleEx =
-      (tGetFileInformationByHandleEx)GetProcAddress(
-        GetModuleHandle(L"KERNEL32.DLL"), "GetFileInformationByHandleEx");
-
-  if (pGetFileInformationByHandleEx == NULL)
-    return 0;
 
   /* Get pipe name. GetFileInformationByHandleEx does not NULL-terminate the
      string, so reduce the buffer size to allow for adding one. */
-  if (! pGetFileInformationByHandleEx(hFile,
-                                      FileNameInfo,
-                                      buffer,
-                                      sizeof(buffer) - sizeof(WCHAR)))
+  if (! GetFileInformationByHandleEx(hFile,
+                                     FileNameInfo,
+                                     buffer,
+                                     sizeof(buffer) - sizeof(WCHAR)))
     return 0;
 
   nameinfo->FileName[nameinfo->FileNameLength / sizeof(WCHAR)] = L'\0';


### PR DESCRIPTION
They were not available in older, now unsupported Windows versions, but they're now always available.

- `CreateHardLink` is available since Windows XP;
- `GetFileInformationByHandleEx` is available since Windows Vista.