### PR TITLE
Create symlinks on Windows when available

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -57,6 +57,7 @@ META.in                  typo.missing-header
 
 # Github templates and scripts lack headers, have long lines
 /.github/**              typo.missing-header typo.long-line=may typo.very-long-line=may
+/.github/workflows/build-msvc.yml typo.utf8
 
 /.mailmap                typo.long-line typo.missing-header typo.non-ascii
 /CONTRIBUTING.md         typo.non-ascii=may

--- a/.github/workflows/build-msvc.yml
+++ b/.github/workflows/build-msvc.yml
@@ -95,10 +95,12 @@ jobs:
           CC: ${{ matrix.cc }}
         run: >-
           eval $(tools/msvs-promote-path) ;
-          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC ; then
+          if ! ./configure --cache-file=config.cache --host=$HOST CC=$CC
+          --prefix "$PROGRAMFILES/Бактріан🐫"; then
           rm -rf config.cache ;
           failed=0 ;
-          ./configure --cache-file=config.cache --host=$HOST CC=$CC \
+          ./configure --cache-file=config.cache --host=$HOST CC=$CC
+          --prefix "$PROGRAMFILES/Бактріан🐫"
           || failed=$?;
           if ((failed)) ; then cat config.log ; exit $failed ; fi ;
           fi ;
@@ -136,3 +138,7 @@ jobs:
         run: >-
           eval $(tools/msvs-promote-path) ;
           make -j tests ;
+
+      - name: Install the compiler
+        shell: bash
+        run: make install

--- a/Makefile
+++ b/Makefile
@@ -692,7 +692,7 @@ coldstart: boot/ocamlrun$(EXE) runtime/libcamlrun.$(A)
 	$(MAKE) -C stdlib OCAMLRUN='$$(ROOTDIR)/$<' USE_BOOT_OCAMLC=true all
 	rm -f $(addprefix boot/, libcamlrun.$(A) $(LIBFILES))
 	cp $(addprefix stdlib/, $(LIBFILES)) boot
-	cd boot; $(LN) ../runtime/libcamlrun.$(A) .
+	cd boot && $(LN_S) ../runtime/libcamlrun.$(A) .
 
 # Recompile the core system using the bootstrap compiler
 .PHONY: coreall
@@ -884,7 +884,7 @@ flexlink.opt$(EXE): \
 	  OCAMLOPT='$(FLEXLINK_OCAMLOPT) -nostdlib -I ../stdlib' flexlink.exe
 	cp $(FLEXDLL_SOURCE_DIR)/flexlink.exe $@
 	rm -f $(OPT_BINDIR)/flexlink$(EXE)
-	cd $(OPT_BINDIR); $(LN) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
+	cd $(OPT_BINDIR) && $(LN_S) $(call ROOT_FROM, $(OPT_BINDIR))/$@ flexlink$(EXE)
 	cp $(addprefix $(BYTE_BINDIR)/, $(FLEXDLL_OBJECTS)) $(OPT_BINDIR)
 
 else
@@ -1071,7 +1071,7 @@ endif
 # to add otherlibs/dynlink/native to the search path as well
 
 otherlibs/dynlink/dynlink.cmx : otherlibs/dynlink/native/dynlink.cmx
-	cd otherlibs/dynlink; $(LN) native/dynlink.cmx .
+	cd otherlibs/dynlink && $(LN_S) native/dynlink.cmx .
 
 DYNLINK_DEPEND_DUMMY_FILES = \
   otherlibs/dynlink/dynlink.ml \
@@ -1116,28 +1116,28 @@ beforedepend:: lambda/runtimedef.ml
 # Choose the right machine-dependent files
 
 asmcomp/arch.mli: asmcomp/$(ARCH)/arch.mli
-	@cd asmcomp; $(LN) $(ARCH)/arch.mli .
+	@cd asmcomp && $(LN_S) $(ARCH)/arch.mli .
 
 asmcomp/arch.ml: asmcomp/$(ARCH)/arch.ml
-	@cd asmcomp; $(LN) $(ARCH)/arch.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/arch.ml .
 
 asmcomp/proc.ml: asmcomp/$(ARCH)/proc.ml
-	@cd asmcomp; $(LN) $(ARCH)/proc.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/proc.ml .
 
 asmcomp/selection.ml: asmcomp/$(ARCH)/selection.ml
-	@cd asmcomp; $(LN) $(ARCH)/selection.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/selection.ml .
 
 asmcomp/CSE.ml: asmcomp/$(ARCH)/CSE.ml
-	@cd asmcomp; $(LN) $(ARCH)/CSE.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/CSE.ml .
 
 asmcomp/reload.ml: asmcomp/$(ARCH)/reload.ml
-	@cd asmcomp; $(LN) $(ARCH)/reload.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/reload.ml .
 
 asmcomp/scheduling.ml: asmcomp/$(ARCH)/scheduling.ml
-	@cd asmcomp; $(LN) $(ARCH)/scheduling.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/scheduling.ml .
 
 asmcomp/stackframe.ml: asmcomp/$(ARCH)/stackframe.ml
-	@cd asmcomp; $(LN) $(ARCH)/stackframe.ml .
+	@cd asmcomp && $(LN_S) $(ARCH)/stackframe.ml .
 
 # Preprocess the code emitters
 cvt_emit = tools/cvt_emit$(EXE)
@@ -1610,7 +1610,7 @@ runtime: stdlib/libcamlrun.$(A)
 .PHONY: makeruntime
 makeruntime: runtime-all
 stdlib/libcamlrun.$(A): runtime-all
-	cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libcamlrun.$(A) .
 clean::
 	rm -f $(addprefix runtime/, *.o *.obj *.a *.lib *.so *.dll ld.conf)
 	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
@@ -1628,9 +1628,9 @@ runtimeopt: stdlib/libasmrun.$(A)
 .PHONY: makeruntimeopt
 makeruntimeopt: runtime-allopt
 stdlib/libasmrun.$(A): runtime-allopt
-	cd stdlib; $(LN) ../runtime/libasmrun.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libasmrun.$(A) .
 stdlib/libcomprmarsh.$(A): runtime/libcomprmarsh.$(A)
-	cd stdlib; $(LN) ../runtime/libcomprmarsh.$(A) .
+	cd stdlib && $(LN_S) ../runtime/libcomprmarsh.$(A) .
 
 clean::
 	rm -f stdlib/libasmrun.a stdlib/libasmrun.lib
@@ -2689,9 +2689,9 @@ ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	  $(INSTALL_PROG) "tools/$$i$(EXE)" "$(INSTALL_BINDIR)/$$i.byte$(EXE)";\
 	  if test -f "tools/$$i".opt$(EXE); then \
 	    $(INSTALL_PROG) "tools/$$i.opt$(EXE)" "$(INSTALL_BINDIR)" && \
-	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN_S) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  else \
-	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.byte$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN_S) "$$i.byte$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 else
@@ -2699,7 +2699,7 @@ else
 	do \
 	  if test -f "tools/$$i".opt$(EXE); then \
 	    $(INSTALL_PROG) "tools/$$i.opt$(EXE)" "$(INSTALL_BINDIR)"; \
-	    (cd "$(INSTALL_BINDIR)" && $(LN) "$$i.opt$(EXE)" "$$i$(EXE)"); \
+	    (cd "$(INSTALL_BINDIR)" && $(LN_S) "$$i.opt$(EXE)" "$$i$(EXE)"); \
 	  fi; \
 	done
 endif
@@ -2814,10 +2814,10 @@ endif # ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt$(EXE); then $(MAKE) installopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
-	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
-	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
+	   $(LN_S) ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   $(LN_S) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	   (test -f flexlink.byte$(EXE) && \
-	      $(LN) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
+	      $(LN_S) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
 	fi
 else
 	if test -f ocamlopt$(EXE); then $(MAKE) installopt; fi
@@ -2904,11 +2904,11 @@ endif
 ifeq "$(INSTALL_BYTECODE_PROGRAMS)" "true"
 	if test -f ocamlopt.opt$(EXE); then $(MAKE) installoptopt; else \
 	   cd "$(INSTALL_BINDIR)"; \
-	   $(LN) ocamlc.byte$(EXE) ocamlc$(EXE); \
-	   $(LN) ocamlopt.byte$(EXE) ocamlopt$(EXE); \
-	   $(LN) ocamllex.byte$(EXE) ocamllex$(EXE); \
+	   $(LN_S) ocamlc.byte$(EXE) ocamlc$(EXE); \
+	   $(LN_S) ocamlopt.byte$(EXE) ocamlopt$(EXE); \
+	   $(LN_S) ocamllex.byte$(EXE) ocamllex$(EXE); \
 	   (test -f flexlink.byte$(EXE) && \
-	     $(LN) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
+	     $(LN_S) flexlink.byte$(EXE) flexlink$(EXE)) || true; \
 	fi
 else
 	if test -f ocamlopt.opt$(EXE); then $(MAKE) installoptopt; fi
@@ -2923,13 +2923,13 @@ installoptopt:
 	$(INSTALL_PROG) ocamlopt.opt$(EXE) "$(INSTALL_BINDIR)"
 	$(INSTALL_PROG) lex/ocamllex.opt$(EXE) "$(INSTALL_BINDIR)"
 	cd "$(INSTALL_BINDIR)"; \
-	   $(LN) ocamlc.opt$(EXE) ocamlc$(EXE); \
-	   $(LN) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
-	   $(LN) ocamllex.opt$(EXE) ocamllex$(EXE)
+	   $(LN_S) ocamlc.opt$(EXE) ocamlc$(EXE); \
+	   $(LN_S) ocamlopt.opt$(EXE) ocamlopt$(EXE); \
+	   $(LN_S) ocamllex.opt$(EXE) ocamllex$(EXE)
 ifeq "$(BOOTSTRAPPING_FLEXDLL)" "true"
 	$(INSTALL_PROG) flexlink.opt$(EXE) "$(INSTALL_BINDIR)"
 	cd "$(INSTALL_BINDIR)"; \
-	  $(LN) flexlink.opt$(EXE) flexlink$(EXE)
+	  $(LN_S) flexlink.opt$(EXE) flexlink$(EXE)
 endif
 	$(INSTALL_DATA) \
 	   utils/*.cmx parsing/*.cmx typing/*.cmx bytecomp/*.cmx \

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -167,7 +167,7 @@ OC_NATIVE_COMPFLAGS = @oc_native_compflags@
 OC_NATIVE_LINKFLAGS = -g
 
 # Platform-dependent command to create symbolic links
-LN = @ln@
+LN_S = @LN_S@
 
 # Platform-dependent assembler files to use to build the runtime
 runtime_ASM_OBJECTS = $(addprefix runtime/,@runtime_asm_objects@)

--- a/Makefile.build_config.in
+++ b/Makefile.build_config.in
@@ -183,3 +183,9 @@ TSAN=@tsan@
 # Contains TSan-specific runtime files, or nothing if TSan support is
 # disabled
 TSAN_NATIVE_RUNTIME_C_SOURCES = @tsan_native_runtime_c_sources@
+
+# Windows-specific overrides
+ifeq "$(UNIX_OR_WIN32)" "win32"
+  export CYGWIN := @CYGWIN@
+  export MSYS := @MSYS@
+endif

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -543,3 +543,61 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
       [Define if the C compiler supports the labels as values extension.])
   fi
 ])
+
+AC_DEFUN([OCAML_PROG_LN_S], [
+  AS_CASE([$host],
+    [*-pc-windows|*-w64-mingw32*],
+      [AC_CACHE_CHECK([for options needed to enable Windows native symlinks],
+        [ocaml_cv_prog_ln_s_native],
+        [ocaml_cv_prog_ln_s_native='cannot detect'
+        for ocaml_arg in dnl
+          ''dnl
+          'winsymlinks:nativestrict'dnl
+          'winsymlinks:native'dnl
+        ; do
+          saved_CYGWIN="$CYGWIN"
+          saved_MSYS="$MSYS"
+          if test "${CYGWIN@%:@*winsymlinks}" = "$CYGWIN"; then
+            export CYGWIN="$CYGWIN${CYGWIN:+ }$ocaml_arg"
+          elif test "${MSYS@%:@*winsymlinks}" = "$MSYS"; then
+            export MSYS="$MSYS${MSYS:+ }$ocaml_arg"
+          fi
+
+          # Inspired by _AS_LN_S_PREPARE.
+          # On MSYS, both `ln -s file dir' and `ln file dir' fail.
+          # but we don't care because we use `(cd dir && $(LN_S) file .)'.
+          rm -f conf$$
+          if (echo >conf$$.file) 2>/dev/null; then
+            if ln -s conf$$.file conf$$ 2>/dev/null; then
+              as_ln_s='ln -s'
+            elif ln conf$$.file conf$$ 2>/dev/null; then
+              as_ln_s=ln
+            else
+              as_ln_s='cp -pR'
+            fi
+          else
+            as_ln_s='cp -pR'
+          fi
+
+          if test "$as_ln_s" = "ln -s" && \
+              cmd /c dir conf$$ 2>/dev/null | grep -F SYMLINK >/dev/null; then
+            if test -z "$ocaml_arg"; then
+              ocaml_cv_prog_ln_s_native='none needed'
+            else
+              ocaml_cv_prog_ln_s_native="$ocaml_arg"
+            fi
+            CYGWIN="$saved_CYGWIN"
+            MSYS="$saved_MSYS"
+            rm -f conf$$ conf$$.file
+            break
+          fi
+          CYGWIN="$saved_CYGWIN"
+          MSYS="$saved_MSYS"
+          rm -f conf$$ conf$$.file
+          done])
+      if test "x$ocaml_cv_prog_ln_s_native" != "xcannot detect"; then
+        export CYGWIN="$CYGWIN${CYGWIN:+ }$ocaml_cv_prog_ln_s_native"
+        export MSYS="$MSYS${MSYS:+ }$ocaml_cv_prog_ln_s_native"
+      fi],
+    [AC_PROG_LN_S])
+])

--- a/configure
+++ b/configure
@@ -888,7 +888,6 @@ syslib
 outputobj
 outputexe
 ocamlyacc_wstr_module
-ln
 unix_or_win32
 ocamlsrcdir
 systhread_support
@@ -3392,7 +3391,6 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
-
 
 
 
@@ -13831,16 +13829,15 @@ esac
 case $host in #(
   *-*-mingw32*|*-pc-windows) :
     unix_or_win32="win32"
-    ln='cp -pf'
     ocamltest_libunix="Some false"
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
     ocamlyacc_wstr_module="yacc/wstr" ;; #(
   *) :
     unix_or_win32="unix"
-  ln='ln -sf'
   ocamltest_libunix="Some true"
   ocamlyacc_wstr_module="" ;;
 esac
+as_ln_s="${as_ln_s}f"
 
 case $host in #(
   *-*-cygwin*|*-*-mingw32*|*-pc-windows) :

--- a/configure
+++ b/configure
@@ -746,7 +746,6 @@ STRIP
 ac_ct_AR
 DLLTOOL
 OBJDUMP
-LN_S
 NM
 ac_ct_DUMPBIN
 DUMPBIN
@@ -773,6 +772,7 @@ COMPILER_BYTECODE_CPPFLAGS
 COMPILER_BYTECODE_CFLAGS
 PARTIALLD
 csc
+LN_S
 target_os
 target_vendor
 target_cpu
@@ -911,6 +911,8 @@ libext
 OBJEXT
 exeext
 ac_tool_prefix
+MSYS
+CYGWIN
 CSCFLAGS
 CSC
 DIFF_FLAGS
@@ -3388,6 +3390,8 @@ LINEAR_MAGIC_NUMBER=Caml1999L035
 
 
 
+
+
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
@@ -3695,17 +3699,82 @@ test -n "$target_alias" &&
     NONENONEs,x,x, &&
   program_prefix=${target_alias}-
 
-# Ensure that AC_CONFIG_LINKS will either create symlinks which are compatible
-# with native Windows (i.e. NTFS symlinks, not WSL or Cygwin-emulated ones) or
-# use its fallback mechanisms. Native Windows versions of ocamlc/ocamlopt cannot
-# interpret either WSL or Cygwin-emulated symlinks.
-case $host in #(
+# Ensure that LN_S and AC_CONFIG_LINKS will either create symlinks which are
+# compatible with native Windows (i.e. NTFS symlinks, not WSL or Cygwin-emulated
+# ones) or use its fallback mechanisms. Native Windows versions of
+# ocamlc/ocamlopt cannot interpret either WSL or Cygwin-emulated symlinks.
+
+  case $host in #(
   *-pc-windows|*-w64-mingw32*) :
-    ac_config_commands="$ac_config_commands native-symlinks"
- ;; #(
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for options needed to enable Windows native symlinks" >&5
+printf %s "checking for options needed to enable Windows native symlinks... " >&6; }
+if test ${ocaml_cv_prog_ln_s_native+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ocaml_cv_prog_ln_s_native='cannot detect'
+        for ocaml_arg in           ''          'winsymlinks:nativestrict'          'winsymlinks:native'        ; do
+          saved_CYGWIN="$CYGWIN"
+          saved_MSYS="$MSYS"
+          if test "${CYGWIN#*winsymlinks}" = "$CYGWIN"; then
+            export CYGWIN="$CYGWIN${CYGWIN:+ }$ocaml_arg"
+          elif test "${MSYS#*winsymlinks}" = "$MSYS"; then
+            export MSYS="$MSYS${MSYS:+ }$ocaml_arg"
+          fi
+
+          # Inspired by _AS_LN_S_PREPARE.
+          # On MSYS, both `ln -s file dir' and `ln file dir' fail.
+          # but we don't care because we use `(cd dir && $(LN_S) file .)'.
+          rm -f conf$$
+          if (echo >conf$$.file) 2>/dev/null; then
+            if ln -s conf$$.file conf$$ 2>/dev/null; then
+              as_ln_s='ln -s'
+            elif ln conf$$.file conf$$ 2>/dev/null; then
+              as_ln_s=ln
+            else
+              as_ln_s='cp -pR'
+            fi
+          else
+            as_ln_s='cp -pR'
+          fi
+
+          if test "$as_ln_s" = "ln -s" && \
+              cmd /c dir conf$$ 2>/dev/null | grep -F SYMLINK >/dev/null; then
+            if test -z "$ocaml_arg"; then
+              ocaml_cv_prog_ln_s_native='none needed'
+            else
+              ocaml_cv_prog_ln_s_native="$ocaml_arg"
+            fi
+            CYGWIN="$saved_CYGWIN"
+            MSYS="$saved_MSYS"
+            rm -f conf$$ conf$$.file
+            break
+          fi
+          CYGWIN="$saved_CYGWIN"
+          MSYS="$saved_MSYS"
+          rm -f conf$$ conf$$.file
+          done
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_ln_s_native" >&5
+printf "%s\n" "$ocaml_cv_prog_ln_s_native" >&6; }
+      if test "x$ocaml_cv_prog_ln_s_native" != "xcannot detect"; then
+        export CYGWIN="$CYGWIN${CYGWIN:+ }$ocaml_cv_prog_ln_s_native"
+        export MSYS="$MSYS${MSYS:+ }$ocaml_cv_prog_ln_s_native"
+      fi ;; #(
   *) :
-     ;;
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ln -s works" >&5
+printf %s "checking whether ln -s works... " >&6; }
+LN_S=$as_ln_s
+if test "$LN_S" = "ln -s"; then
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+else
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, using $LN_S" >&5
+printf "%s\n" "no, using $LN_S" >&6; }
+fi
+ ;;
 esac
+
 
 # Systems that are known not to work, even in bytecode only.
 
@@ -4229,6 +4298,7 @@ else $as_nop
 fi
 
 # Initialization of libtool
+
 # Allow the MSVC linker to be found even if ld isn't installed.
 # User-specified LD still takes precedence.
 if test -n "$ac_tool_prefix"; then
@@ -4340,6 +4410,7 @@ esac
     LD=$ac_ct_LD
   fi
 fi
+
 
 # libtool expects host_os=mingw for native Windows
 # Also, it has been observed that, on some platforms (e.g. msvc) LT_INIT
@@ -6097,17 +6168,6 @@ else $as_nop
 fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_nm_interface" >&5
 printf "%s\n" "$lt_cv_nm_interface" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ln -s works" >&5
-printf %s "checking whether ln -s works... " >&6; }
-LN_S=$as_ln_s
-if test "$LN_S" = "ln -s"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, using $LN_S" >&5
-printf "%s\n" "no, using $LN_S" >&6; }
-fi
 
 # find the maximum length of command line arguments
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking the maximum length of command line arguments" >&5
@@ -13837,7 +13897,6 @@ case $host in #(
   ocamltest_libunix="Some true"
   ocamlyacc_wstr_module="" ;;
 esac
-as_ln_s="${as_ln_s}f"
 
 case $host in #(
   *-*-cygwin*|*-*-mingw32*|*-pc-windows) :
@@ -21810,8 +21869,6 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 #
 # INIT-COMMANDS
 #
-export CYGWIN="\$CYGWIN\${CYGWIN:+ }winsymlinks:nativestrict"
-      export MSYS="\$MSYS\${MSYS:+ }winsymlinks:nativestrict"
 
 
 # The HP-UX ksh and POSIX shell print the target directory to stdout
@@ -22126,7 +22183,6 @@ do
     "otherlibs/dynlink/META") CONFIG_FILES="$CONFIG_FILES otherlibs/dynlink/META" ;;
     "otherlibs/runtime_events/META") CONFIG_FILES="$CONFIG_FILES otherlibs/runtime_events/META" ;;
     "stdlib/META") CONFIG_FILES="$CONFIG_FILES stdlib/META" ;;
-    "native-symlinks") CONFIG_COMMANDS="$CONFIG_COMMANDS native-symlinks" ;;
     "ocamldoc/META") CONFIG_FILES="$CONFIG_FILES ocamldoc/META" ;;
     "libtool") CONFIG_COMMANDS="$CONFIG_COMMANDS libtool" ;;
     "$dldir/dynlink_cmo_format.mli") CONFIG_LINKS="$CONFIG_LINKS $dldir/dynlink_cmo_format.mli:file_formats/cmo_format.mli" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,8 @@ AC_SUBST([CC])
 AC_SUBST([DIFF_FLAGS])
 AC_SUBST([CSC])
 AC_SUBST([CSCFLAGS])
+AC_SUBST([CYGWIN])
+AC_SUBST([MSYS])
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
@@ -296,15 +298,11 @@ AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
 
-# Ensure that AC_CONFIG_LINKS will either create symlinks which are compatible
-# with native Windows (i.e. NTFS symlinks, not WSL or Cygwin-emulated ones) or
-# use its fallback mechanisms. Native Windows versions of ocamlc/ocamlopt cannot
-# interpret either WSL or Cygwin-emulated symlinks.
-AS_CASE([$host],
-  [*-pc-windows|*-w64-mingw32*],
-    [AC_CONFIG_COMMANDS([native-symlinks], [],
-      [export CYGWIN="\$CYGWIN\${CYGWIN:+ }winsymlinks:nativestrict"
-      export MSYS="\$MSYS\${MSYS:+ }winsymlinks:nativestrict"])])
+# Ensure that LN_S and AC_CONFIG_LINKS will either create symlinks which are
+# compatible with native Windows (i.e. NTFS symlinks, not WSL or Cygwin-emulated
+# ones) or use its fallback mechanisms. Native Windows versions of
+# ocamlc/ocamlopt cannot interpret either WSL or Cygwin-emulated symlinks.
+OCAML_PROG_LN_S
 
 # Systems that are known not to work, even in bytecode only.
 
@@ -610,9 +608,11 @@ AS_IF([test x"$enable_ocamldoc" = "xno"],
   AC_CONFIG_FILES([ocamldoc/META])])
 
 # Initialization of libtool
+
 # Allow the MSVC linker to be found even if ld isn't installed.
 # User-specified LD still takes precedence.
 AC_CHECK_TOOLS([LD],[ld link])
+
 # libtool expects host_os=mingw for native Windows
 # Also, it has been observed that, on some platforms (e.g. msvc) LT_INIT
 # alters the CFLAGS variable, so we save its value before calling the macro
@@ -731,7 +731,6 @@ AS_CASE([$host],
   [unix_or_win32="unix"
   ocamltest_libunix="Some true"
   ocamlyacc_wstr_module=""])
-as_ln_s="${as_ln_s}f"
 
 AS_CASE([$host],
   [*-*-cygwin*|*-*-mingw32*|*-pc-windows],

--- a/configure.ac
+++ b/configure.ac
@@ -151,7 +151,6 @@ AC_SUBST([oc_native_cppflags])
 AC_SUBST([systhread_support])
 AC_SUBST([ocamlsrcdir])
 AC_SUBST([unix_or_win32])
-AC_SUBST([ln])
 AC_SUBST([ocamlyacc_wstr_module])
 AC_SUBST([outputexe])
 AC_SUBST([outputobj])
@@ -726,14 +725,13 @@ AS_CASE([$lt_cv_ar_at_file],
 AS_CASE([$host],
   [*-*-mingw32*|*-pc-windows],
     [unix_or_win32="win32"
-    ln='cp -pf'
     ocamltest_libunix="Some false"
     ocamlsrcdir="$(LC_ALL=C.UTF-8 cygpath -w -- "$ocamlsrcdir")"
     ocamlyacc_wstr_module="yacc/wstr"],
   [unix_or_win32="unix"
-  ln='ln -sf'
   ocamltest_libunix="Some true"
   ocamlyacc_wstr_module=""])
+as_ln_s="${as_ln_s}f"
 
 AS_CASE([$host],
   [*-*-cygwin*|*-*-mingw32*|*-pc-windows],


### PR DESCRIPTION
Previously Windows unconditionally uses `cp`, doubling the size
required for the OCaml binaries. `configure` now determines if `ln`
creates native symlinks and only uses `cp` if that fails. Users of the
compiler are simply required to enable Developer Mode (or build OCaml
using an elevated shell) to benefit from symlinks.

https://cygwin.com/cygwin-ug-net/using.html#pathnames-symlinks
https://www.msys2.org/docs/symlinks/

Harden the implementation by setting the `CYGWIN` and `MSYS`
environment variables in stone in the Makefile.