### PR TITLE
Detect support for compiler attributes

### DIFF
--- a/runtime/caml/alloc.h
+++ b/runtime/caml/alloc.h
@@ -57,7 +57,7 @@ CAMLextern value caml_copy_nativeint (intnat);  /* defined in [ints.c] */
 CAMLextern value caml_alloc_array (value (*funct) (char const *),
                                    char const * const * array);
 CAMLextern value caml_alloc_sprintf(const char * format, ...)
-#ifdef __GNUC__
+#if __has_attribute(format) || defined(__GNUC__)
   __attribute__ ((format (printf, 1, 2)))
 #endif
 ;

--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -46,7 +46,7 @@ enum {
   CAMLextern CAMLthread_local caml_domain_state* caml_state;
   #define Caml_state_opt caml_state
 #else
-#ifdef __GNUC__
+#if __has_attribute(pure) || defined(__GNUC__)
   __attribute__((pure))
 #endif
   CAMLextern caml_domain_state* caml_get_domain_state(void);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -45,7 +45,7 @@
 
 /* Deprecation warnings */
 
-#if defined(__GNUC__) || defined(__clang__)
+#if __has_attribute(deprecated) || defined(__GNUC__)
   /* Supported since at least GCC 3.1 */
   #define CAMLdeprecated_typedef(name, type) \
     typedef type name __attribute__ ((deprecated))
@@ -56,9 +56,7 @@
   #define CAMLdeprecated_typedef(name, type) typedef type name
 #endif
 
-#if defined(__GNUC__)                                           \
-    && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L \
-    || defined(_MSC_VER) && _MSC_VER >= 1925
+#if defined(__GNUC__) || defined(__llvm__) || defined(_MSC_VER)
 
 #define CAML_STRINGIFY(x) #x
 #ifdef _MSC_VER


### PR DESCRIPTION
Useful for clang-cl which doesn't define `__GNUC__`. Follow-up of #13280.