### PR TITLE
Don't use MSVC 64 bits extension types

### DIFF
--- a/otherlibs/unix/mmap_win32.c
+++ b/otherlibs/unix/mmap_win32.c
@@ -42,7 +42,7 @@ CAMLprim value caml_unix_map_file(value vfd, value vkind, value vlayout,
   int flags, major_dim, mode, perm;
   intnat num_dims;
   intnat dim[CAML_BA_MAX_NUM_DIMS];
-  __int64 startpos, data_size;
+  int64_t startpos, data_size;
   LARGE_INTEGER file_size;
   uintnat array_size, delta;
   void * addr;

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -75,7 +75,7 @@ static const int file_kind_table[] = {
 static double stat_timestamp(__time64_t tm)
 {
   /* Split the timestamp into seconds and remaining 100ns units */
-  __int64 sec = tm / 10000000;  /* 10^7 */
+  int64_t sec = tm / 10000000;  /* 10^7 */
   int n100sec = tm % 10000000;
   /* The conversion of sec to FP is exact for the foreseeable future.
      (It starts rounding when sec > 2^53, i.e. in 285 million years.) */
@@ -91,7 +91,7 @@ static double stat_timestamp(__time64_t tm)
   return t;
 }
 
-static value stat_aux(int use_64, __int64 st_ino, struct _stat64 *buf)
+static value stat_aux(int use_64, int64_t st_ino, struct _stat64 *buf)
 {
   CAMLparam0 ();
   CAMLlocal1 (v);
@@ -162,7 +162,7 @@ Caml_inline ULONGLONG convert_time(FILETIME time)
 }
 
 /* path allocated outside the OCaml heap */
-static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, __int64* st_ino, struct _stat64* res)
+static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, int64_t* st_ino, struct _stat64* res)
 {
   BY_HANDLE_FILE_INFORMATION info;
   wchar_t* ptr;
@@ -269,8 +269,8 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
         res->st_size = 0;
       }
       else {
-        res->st_size = ((__int64)(info.nFileSizeHigh)) << 32 |
-                       ((__int64)info.nFileSizeLow);
+        res->st_size = ((int64_t)(info.nFileSizeHigh)) << 32 |
+                       ((int64_t)info.nFileSizeLow);
       }
     }
 
@@ -296,7 +296,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
      */
     res->st_nlink = info.nNumberOfLinks;
     res->st_dev = info.dwVolumeSerialNumber;
-    *st_ino = ((__int64)(info.nFileIndexHigh)) << 32 | ((__int64)info.nFileIndexLow);
+    *st_ino = ((int64_t)(info.nFileIndexHigh)) << 32 | ((int64_t)info.nFileIndexLow);
   }
 
   if (do_lstat && is_symlink) {
@@ -326,7 +326,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, _
   return 1;
 }
 
-static int do_stat(int do_lstat, int use_64, const char* opath, HANDLE fstat, __int64* st_ino, struct _stat64* res)
+static int do_stat(int do_lstat, int use_64, const char* opath, HANDLE fstat, int64_t* st_ino, struct _stat64* res)
 {
   wchar_t* wpath;
   int ret;
@@ -340,7 +340,7 @@ CAMLprim value caml_unix_stat(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "stat");
   if (!do_stat(0, 0, String_val(path), NULL, &st_ino, &buf)) {
@@ -353,7 +353,7 @@ CAMLprim value caml_unix_stat_64(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "stat");
   if (!do_stat(0, 1, String_val(path), NULL, &st_ino, &buf)) {
@@ -366,7 +366,7 @@ CAMLprim value caml_unix_lstat(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "lstat");
   if (!do_stat(1, 0, String_val(path), NULL, &st_ino, &buf)) {
@@ -379,7 +379,7 @@ CAMLprim value caml_unix_lstat_64(value path)
 {
   CAMLparam1(path);
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
 
   caml_unix_check_path(path, "lstat");
   if (!do_stat(1, 1, String_val(path), NULL, &st_ino, &buf)) {
@@ -391,7 +391,7 @@ CAMLprim value caml_unix_lstat_64(value path)
 static value do_fstat(value handle, int use_64)
 {
   struct _stat64 buf;
-  __int64 st_ino;
+  int64_t st_ino;
   HANDLE h;
   DWORD ft;
 

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -36,6 +36,8 @@
 #include <winioctl.h>
 #include "caml/winsupport.h"
 
+_Static_assert(sizeof(time_t) == 8, "time_t is not 64 bits.");
+
 #ifndef S_IFLNK
 /*
  * The Microsoft CRT doesn't support lstat and so has no S_IFLNK
@@ -72,7 +74,7 @@ static const int file_kind_table[] = {
    when the same file is accessed either from Windows or from Linux.
  */
 
-static double stat_timestamp(__time64_t tm)
+static double stat_timestamp(time_t tm)
 {
   /* Split the timestamp into seconds and remaining 100ns units */
   int64_t sec = tm / 10000000;  /* 10^7 */
@@ -170,7 +172,7 @@ static int safe_do_stat(int do_lstat, int use_64, wchar_t* path, HANDLE fstat, i
   unsigned short mode;
   int is_symlink = 0;
   ULONGLONG stamp;
-  __time64_t mtime = 0;
+  time_t mtime = 0;
 
   if (!path) {
     h = fstat;

--- a/otherlibs/unix/truncate_win32.c
+++ b/otherlibs/unix/truncate_win32.c
@@ -26,7 +26,7 @@
 #include "caml/unixsupport.h"
 #include <windows.h>
 
-static int truncate_handle(HANDLE fh, __int64 len)
+static int truncate_handle(HANDLE fh, int64_t len)
 {
   LARGE_INTEGER fp;
   fp.QuadPart = len;
@@ -38,7 +38,7 @@ static int truncate_handle(HANDLE fh, __int64 len)
   return 0;
 }
 
-static int ftruncate(HANDLE fh, __int64 len)
+static int ftruncate(HANDLE fh, int64_t len)
 {
   HANDLE dupfh, currproc;
   int ret;
@@ -54,7 +54,7 @@ static int ftruncate(HANDLE fh, __int64 len)
   return ret;
 }
 
-static int truncate(WCHAR * path, __int64 len)
+static int truncate(WCHAR * path, int64_t len)
 {
   HANDLE fh;
   int ret;
@@ -91,7 +91,7 @@ CAMLprim value caml_unix_truncate_64(value path, value vlen)
   CAMLparam2(path, vlen);
   WCHAR * p;
   int ret;
-  __int64 len = Int64_val(vlen);
+  int64_t len = Int64_val(vlen);
   caml_unix_check_path(path, "truncate");
   p = caml_stat_strdup_to_utf16(String_val(path));
   caml_enter_blocking_section();
@@ -119,7 +119,7 @@ CAMLprim value caml_unix_ftruncate_64(value fd, value vlen)
 {
   int ret;
   HANDLE h = Handle_val(fd);
-  __int64 len = Int64_val(vlen);
+  int64_t len = Int64_val(vlen);
   caml_enter_blocking_section();
   ret = ftruncate(h, len);
   caml_leave_blocking_section();

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -98,8 +98,8 @@
   #define ARCH_UINT64_TYPE unsigned long long
   #define ARCH_INT64_PRINTF_FORMAT "I64"
 #elif defined(_MSC_VER)
-  #define ARCH_INT64_TYPE __int64
-  #define ARCH_UINT64_TYPE unsigned __int64
+  #define ARCH_INT64_TYPE int64_t
+  #define ARCH_UINT64_TYPE uint64_t
   #define ARCH_INT64_PRINTF_FORMAT "I64"
 #else
   #if SIZEOF_LONG == 8

--- a/runtime/caml/io.h
+++ b/runtime/caml/io.h
@@ -41,7 +41,7 @@ typedef intptr_t caml_plat_mutex;
 #endif
 
 #if defined(_WIN32)
-typedef __int64 file_offset;
+typedef int64_t file_offset;
 #else
 #include <sys/types.h>
 typedef off_t file_offset;

--- a/testsuite/tests/lib-unix/win-stat/fakeclock.c
+++ b/testsuite/tests/lib-unix/win-stat/fakeclock.c
@@ -16,13 +16,13 @@
 
 typedef union ufiletime_int64
 {
-  unsigned __int64 scalar;
+  uint64_t scalar;
   FILETIME ft;
 } filetime_int64;
 
 static filetime_int64 clk;
 static DWORD wall = 0;
-static unsigned __int64 bias = 0LL;
+static uint64_t bias = 0LL;
 
 BOOL WINAPI FakeConvert(const FILETIME* lpFileTime, LPFILETIME lpLocalFileTime)
 {

--- a/testsuite/tests/lib-unix/win-stat/fakeclock.c
+++ b/testsuite/tests/lib-unix/win-stat/fakeclock.c
@@ -13,6 +13,7 @@
 /**************************************************************************/
 
 #include <windows.h>
+#include <stdint.h>
 
 typedef union ufiletime_int64
 {


### PR DESCRIPTION
Using fewer compiler extensions makes the code more standard and idiomatic.