### PR TITLE
Explicit units in time management

### DIFF
--- a/otherlibs/unix/itimer.c
+++ b/otherlibs/unix/itimer.c
@@ -24,6 +24,8 @@
 #include <math.h>
 #include <sys/time.h>
 
+#define USEC_PER_SEC UINT64_C(1000000)
+
 static void caml_unix_set_timeval(struct timeval * tv, double d)
 {
   double integr, frac;
@@ -31,8 +33,8 @@ static void caml_unix_set_timeval(struct timeval * tv, double d)
   /* Round time up so that if d is small but not 0, we end up with
      a non-0 timeval. */
   tv->tv_sec = integr;
-  tv->tv_usec = ceil(1e6 * frac);
-  if (tv->tv_usec >= 1000000) { tv->tv_sec++; tv->tv_usec = 0; }
+  tv->tv_usec = ceil(frac * USEC_PER_SEC);
+  if (tv->tv_usec >= USEC_PER_SEC) { tv->tv_sec++; tv->tv_usec = 0; }
 }
 
 static value caml_unix_convert_itimer(struct itimerval *tp)

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -1072,7 +1072,8 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       if (tm_sec >= 0.0)
         {
-          tm_msec = (DWORD)(tm_sec * MSEC_PER_SEC);
+          double msec = tm_sec * MSEC_PER_SEC;
+          tm_msec = msec < INFINITE ? (DWORD)msec : INFINITE - 1;
           DEBUG_PRINT("Will wait %d ms", tm_msec);
         }
       else

--- a/otherlibs/unix/select_win32.c
+++ b/otherlibs/unix/select_win32.c
@@ -21,6 +21,7 @@
 #include <caml/signals.h>
 #include "winworker.h"
 #include <stdio.h>
+#include <math.h>
 #include "windbug.h"
 #include "winlist.h"
 
@@ -964,8 +965,11 @@ static value fdset_to_fdlist(value fdlist, fd_set *fdset)
   CAMLreturn(res);
 }
 
+#define USEC_PER_SEC UINT64_C(1000000)
+#define MSEC_PER_SEC UINT64_C(1000)
+
 CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
-                           value timeout)
+                                value timeout_sec)
 {
   /* Event associated to handle */
   DWORD   nEventsCount;
@@ -986,7 +990,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   DWORD err;
 
   /* Time to wait */
-  DWORD milliseconds;
+  DWORD tm_msec;
 
   /* Is there static select data */
   BOOL  hasStaticData = FALSE;
@@ -1001,26 +1005,26 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
   DWORD writefds_len;
   DWORD exceptfds_len;
 
-  CAMLparam4 (readfds, writefds, exceptfds, timeout);
+  CAMLparam4 (readfds, writefds, exceptfds, timeout_sec);
   CAMLlocal5 (read_list, write_list, except_list, res, l);
   CAMLlocal1 (fd);
 
   fd_set read, write, except;
-  double tm;
+  double tm_sec, tmint_sec, tmfrac_sec;
   struct timeval tv;
   struct timeval * tvp;
 
   DEBUG_PRINT("in select");
 
   err = 0;
-  tm = Double_val(timeout);
+  tm_sec = Double_val(timeout_sec);
   if (readfds == Val_emptylist
       && writefds == Val_emptylist
       && exceptfds == Val_emptylist) {
     DEBUG_PRINT("nothing to do");
-    if ( tm > 0.0 ) {
+    if ( tm_sec > 0.0 ) {
       caml_enter_blocking_section();
-      Sleep( (int)(tm * 1000));
+      Sleep( (DWORD)(tm_sec * MSEC_PER_SEC));
       caml_leave_blocking_section();
     }
     read_list = write_list = except_list = Val_emptylist;
@@ -1029,11 +1033,12 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
         && fdlist_to_fdset(writefds, &write)
         && fdlist_to_fdset(exceptfds, &except)) {
       DEBUG_PRINT("only sockets to select on, using classic select");
-      if (tm < 0.0) {
+      if (tm_sec < 0.0) {
         tvp = (struct timeval *) NULL;
       } else {
-        tv.tv_sec = (int) tm;
-        tv.tv_usec = (int) (1e6 * (tm - (int) tm));
+        tmfrac_sec = modf(tm_sec, &tmint_sec);
+        tv.tv_sec = (long) tmint_sec;
+        tv.tv_usec = (long) (tmfrac_sec * USEC_PER_SEC);
         tvp = &tv;
       }
       caml_enter_blocking_section();
@@ -1065,14 +1070,14 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
 
       hdsData = (HANDLE *)caml_stat_alloc(sizeof(HANDLE) * hdsMax);
 
-      if (tm >= 0.0)
+      if (tm_sec >= 0.0)
         {
-          milliseconds = (DWORD)(1000 * tm);
-          DEBUG_PRINT("Will wait %d ms", milliseconds);
+          tm_msec = (DWORD)(tm_sec * MSEC_PER_SEC);
+          DEBUG_PRINT("Will wait %d ms", tm_msec);
         }
       else
         {
-          milliseconds = INFINITE;
+          tm_msec = INFINITE;
         }
 
 
@@ -1184,7 +1189,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
             {
               DEBUG_PRINT("Waiting for one select worker to be done");
               switch (WaitForMultipleObjects(nEventsCount, lpEventsDone, FALSE,
-                                             milliseconds))
+                                             tm_msec))
                 {
                 case WAIT_FAILED:
                   err = GetLastError();
@@ -1228,7 +1233,7 @@ CAMLprim value caml_unix_select(value readfds, value writefds, value exceptfds,
       /* Nothing to monitor but some time to wait. */
       else if (!hasStaticData)
         {
-          Sleep(milliseconds);
+          Sleep(tm_msec);
         }
       caml_leave_blocking_section();
 

--- a/otherlibs/unix/stat_win32.c
+++ b/otherlibs/unix/stat_win32.c
@@ -72,11 +72,13 @@ static const int file_kind_table[] = {
    when the same file is accessed either from Windows or from Linux.
  */
 
+#define NSEC_PER_SEC UINT64_C(1000000000)
+
 static double stat_timestamp(__time64_t tm)
 {
   /* Split the timestamp into seconds and remaining 100ns units */
-  __int64 sec = tm / 10000000;  /* 10^7 */
-  int n100sec = tm % 10000000;
+  __int64 sec = tm / (NSEC_PER_SEC / 100);  /* 10^7 */
+  int n100sec = tm % (NSEC_PER_SEC / 100);
   /* The conversion of sec to FP is exact for the foreseeable future.
      (It starts rounding when sec > 2^53, i.e. in 285 million years.) */
   double s = (double) sec;

--- a/otherlibs/unix/unix.mli
+++ b/otherlibs/unix/unix.mli
@@ -1097,7 +1097,11 @@ val select :
    The result is composed of three sets of descriptors: those ready
    for reading (first component), ready for writing (second component),
    and over which an exceptional condition is pending (third
-   component). *)
+   component).
+
+   On Windows, if one of descriptor lists exceeds [FD_SETSIZE] elements
+   (64 by default), or if at least one non-socket file descriptor is
+   used, the maximal timeout is capped to 2{^32} milliseconds. *)
 
 (** {1 Locking} *)
 

--- a/otherlibs/unix/unixLabels.mli
+++ b/otherlibs/unix/unixLabels.mli
@@ -1097,7 +1097,11 @@ val select :
    The result is composed of three sets of descriptors: those ready
    for reading (first component), ready for writing (second component),
    and over which an exceptional condition is pending (third
-   component). *)
+   component).
+
+   On Windows, if one of descriptor lists exceeds [FD_SETSIZE] elements
+   (64 by default), or if at least one non-socket file descriptor is
+   used, the maximal timeout is capped to 2{^32} milliseconds. *)
 
 (** {1 Locking} *)
 

--- a/otherlibs/unix/utimes_unix.c
+++ b/otherlibs/unix/utimes_unix.c
@@ -27,6 +27,8 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
+#define USEC_PER_SEC UINT64_C(1000000)
+
 CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
 {
   CAMLparam3(path, atime, mtime);
@@ -41,9 +43,9 @@ CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
     t = (struct timeval *) NULL;
   } else {
     tv[0].tv_sec = at;
-    tv[0].tv_usec = (at - tv[0].tv_sec) * 1000000;
+    tv[0].tv_usec = (at - tv[0].tv_sec) * USEC_PER_SEC;
     tv[1].tv_sec = mt;
-    tv[1].tv_usec = (mt - tv[1].tv_sec) * 1000000;
+    tv[1].tv_usec = (mt - tv[1].tv_sec) * USEC_PER_SEC;
     t = tv;
   }
   p = caml_stat_strdup(String_val(path));

--- a/otherlibs/unix/utimes_win32.c
+++ b/otherlibs/unix/utimes_win32.c
@@ -25,6 +25,8 @@
 
 #include <windows.h>
 
+#define NSEC_PER_SEC UINT64_C(1000000000)
+
 CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
 {
   CAMLparam3(path, atime, mtime);
@@ -59,9 +61,9 @@ CAMLprim value caml_unix_utimes(value path, value atime, value mtime)
     lastModificationTime.ul = lastAccessTime.ul;
   } else {
     lastAccessTime.ul =
-      (ULONGLONG)(at * 10000000.0) + CAML_NT_EPOCH_100ns_TICKS;
+      (ULONGLONG)(at * (NSEC_PER_SEC / 100)) + CAML_NT_EPOCH_100ns_TICKS;
     lastModificationTime.ul =
-      (ULONGLONG)(mt * 10000000.0) + CAML_NT_EPOCH_100ns_TICKS;
+      (ULONGLONG)(mt * (NSEC_PER_SEC / 100)) + CAML_NT_EPOCH_100ns_TICKS;
   }
   caml_enter_blocking_section();
   res = SetFileTime(hFile, NULL, &lastAccessTime.ft, &lastModificationTime.ft);

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -469,34 +469,33 @@ void caml_mem_unmap(void* mem, uintnat size)
 #endif
 }
 
-#define POW10_3       1000
-#define POW10_4      10000
-#define POW10_6    1000000
-#define POW10_9 1000000000
+#define NSEC_PER_USEC UINT64_C(1000)
+#define NSEC_PER_MSEC UINT64_C(1000000)
+#define NSEC_PER_SEC  UINT64_C(1000000000)
 
-#define Min_sleep_ns  POW10_4 /* 10 us */
-#define Slow_sleep_ns POW10_6 /*  1 ms */
-#define Max_sleep_ns  POW10_9 /*  1 s  */
+#define Min_sleep_nsec  (10 /* usec */ * NSEC_PER_USEC)
+#define Slow_sleep_nsec  (1 /* msec */ * NSEC_PER_MSEC)
+#define Max_sleep_nsec   (1 /*  sec */ * NSEC_PER_SEC)
 
-unsigned caml_plat_spin_back_off(unsigned sleep_ns,
+unsigned caml_plat_spin_back_off(unsigned sleep_nsec,
                                  const struct caml_plat_srcloc* loc)
 {
-  if (sleep_ns < Min_sleep_ns) sleep_ns = Min_sleep_ns;
-  if (sleep_ns > Max_sleep_ns) sleep_ns = Max_sleep_ns;
-  unsigned next_sleep_ns = sleep_ns + sleep_ns / 4;
-  if (sleep_ns < Slow_sleep_ns && Slow_sleep_ns <= next_sleep_ns) {
+  if (sleep_nsec < Min_sleep_nsec) sleep_nsec = Min_sleep_nsec;
+  if (sleep_nsec > Max_sleep_nsec) sleep_nsec = Max_sleep_nsec;
+  unsigned next_sleep_nsec = sleep_nsec + sleep_nsec / 4;
+  if (sleep_nsec < Slow_sleep_nsec && Slow_sleep_nsec <= next_sleep_nsec) {
     caml_gc_log("Slow spin-wait loop in %s at %s:%d",
                 loc->function, loc->file, loc->line);
   }
 #ifdef _WIN32
-  Sleep(sleep_ns / POW10_6);
+  Sleep(sleep_nsec / NSEC_PER_MSEC);
 #elif defined (HAS_NANOSLEEP)
   const struct timespec req = {
-    .tv_sec = sleep_ns / POW10_9,
-    .tv_nsec = sleep_ns % POW10_9 };
+    .tv_sec = sleep_nsec / NSEC_PER_SEC,
+    .tv_nsec = sleep_nsec % NSEC_PER_SEC };
   nanosleep(&req, NULL);
 #else
-  usleep(sleep_ns / POW10_3);
+  usleep(sleep_nsec / NSEC_PER_USEC);
 #endif
-  return next_sleep_ns;
+  return next_sleep_nsec;
 }

--- a/runtime/unix.c
+++ b/runtime/unix.c
@@ -422,6 +422,9 @@ char *caml_secure_getenv (char const *var)
 #endif
 }
 
+#define NSEC_PER_USEC UINT64_C(1000)
+#define NSEC_PER_SEC  UINT64_C(1000000000)
+
 uint64_t caml_time_counter(void)
 {
 #if defined(HAS_CLOCK_GETTIME_NSEC_NP)
@@ -430,14 +433,14 @@ uint64_t caml_time_counter(void)
   struct timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
   return
-    (uint64_t)t.tv_sec  * (uint64_t)1000000000 +
+    (uint64_t)t.tv_sec  * NSEC_PER_SEC +
     (uint64_t)t.tv_nsec;
 #elif defined(HAS_GETTIMEOFDAY)
   struct timeval t;
   gettimeofday(&t, 0);
   return
-    (uint64_t)t.tv_sec  * (uint64_t)1000000000 +
-    (uint64_t)t.tv_usec * (uint64_t)1000;
+    (uint64_t)t.tv_sec  * NSEC_PER_SEC +
+    (uint64_t)t.tv_usec * NSEC_PER_USEC;
 #else
 # error "No timesource available"
 #endif

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -1082,24 +1082,28 @@ int caml_num_rows_fd(int fd)
   return -1;
 }
 
+#define NSEC_PER_USEC UINT64_C(1000)
+#define NSEC_PER_MSEC UINT64_C(1000000)
+#define NSEC_PER_SEC  UINT64_C(1000000000)
+
 /* UCRT clock function returns wall-clock time */
 CAMLexport clock_t caml_win32_clock(void)
 {
   FILETIME _creation, _exit;
-  CAML_ULONGLONG_FILETIME stime, utime;
-  ULONGLONG clocks_per_sec;
+  CAML_ULONGLONG_FILETIME kernel_time, user_time;
+  uint64_t cpu_time_100_nsec;
 
   if (!(GetProcessTimes(GetCurrentProcess(), &_creation, &_exit,
-                        &stime.ft, &utime.ft))) {
+                        &kernel_time.ft, &user_time.ft))) {
     return (clock_t)(-1);
   }
 
   /* total in 100-nanosecond intervals (1e7 / CLOCKS_PER_SEC) */
-  clocks_per_sec = 10000000ULL / (ULONGLONG)CLOCKS_PER_SEC;
-  return (clock_t)((stime.ul + utime.ul) / clocks_per_sec);
+  cpu_time_100_nsec = kernel_time.ul + user_time.ul;
+  return (clock_t)(cpu_time_100_nsec / (NSEC_PER_SEC / 100 / CLOCKS_PER_SEC));
 }
 
-static double clock_period = 0;
+static double clock_period_nsec = 0;
 
 void caml_init_os_params(void)
 {
@@ -1114,7 +1118,7 @@ void caml_init_os_params(void)
 
   /* Get the number of nanoseconds for each tick in QueryPerformanceCounter */
   QueryPerformanceFrequency(&frequency);
-  clock_period = (1000000000.0 / frequency.QuadPart);
+  clock_period_nsec = (double)NSEC_PER_SEC / frequency.QuadPart;
 }
 
 uint64_t caml_time_counter(void)
@@ -1122,7 +1126,7 @@ uint64_t caml_time_counter(void)
   LARGE_INTEGER now;
 
   QueryPerformanceCounter(&now);
-  return (uint64_t)(now.QuadPart * clock_period);
+  return (uint64_t)(now.QuadPart * clock_period_nsec);
 }
 
 void *caml_plat_mem_map(uintnat size, int reserve_only)

--- a/testsuite/tests/tsan/waitgroup_stubs.c
+++ b/testsuite/tests/tsan/waitgroup_stubs.c
@@ -5,12 +5,12 @@
 #include <caml/mlvalues.h>
 #include <caml/tsan.h>
 
-#define POW10_3       1000
-#define POW10_7   10000000
-#define POW10_9 1000000000
+#define NSEC_PER_USEC UINT64_C(1000)
+#define NSEC_PER_MSEC UINT64_C(1000000)
+#define NSEC_PER_SEC  UINT64_C(1000000000)
 
 #define MAX_WAITGROUP   8
-#define SPIN_WAIT_NS    POW10_7 /* 10ms */
+#define SPIN_WAIT_NSEC  (10 /* msec */ * NSEC_PER_MSEC)
 
 /* waitgroup inspired by Golang's `sync.WaitGroup`. This version does *not*
  * allow to restart a waitgroup. */
@@ -58,11 +58,11 @@ CAMLno_tsan value wg_wait(value t)
   do {
 #ifdef HAS_NANOSLEEP
     const struct timespec ts = {
-      .tv_sec = SPIN_WAIT_NS / POW10_9,
-      .tv_nsec = SPIN_WAIT_NS % POW10_9 };
+      .tv_sec = SPIN_WAIT_NSEC / NSEC_PER_SEC,
+      .tv_nsec = SPIN_WAIT_NSEC % NSEC_PER_SEC };
     nanosleep(&ts, NULL);
 #else
-    usleep(SPIN_WAIT_NS / POW10_3);
+    usleep(SPIN_WAIT_NS / NSEC_PER_USEC);
 #endif
   }
   while (wg->count != wg->limit);


### PR DESCRIPTION
The first commit is a refactor and aims at improving readability of the code by:
- keeping track of the time unit in variable names; and
- defining cleverly-named constants to help with conversions.

It makes use of C99 fixed-size integers that we now use unconditionally.

The second commits fixes a potential bug on Windows, where a timeout too big passed to `Unix.select` would actually make it wait for an unbounded time.