### PR TITLE
Support MSYS2

### DIFF
--- a/Changes
+++ b/Changes
@@ -172,6 +172,9 @@ Working version
   team.
   (Nathan Rebours, review by Florian Angeletti)
 
+- #?????: Allow building on MSYS2.
+  (Antonin Décimo, review by ???)
+
 ### Bug fixes:
 
 - #13408: Fix misplaced debug runtime assertion triggerable by a race

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -307,7 +307,7 @@ AC_DEFUN([OCAML_TEST_FLEXLINK], [
     # flexlink can cope. The reverse test is unnecessary (a Cygwin-compiled
     # flexlink can read anything).
     mv conftest.$ac_objext conftest1.$ac_objext
-    AS_CASE([$4],[*-pc-cygwin],
+    AS_CASE([$4],[*-pc-cygwin|*-pc-msys],
       [ln -s conftest1.$ac_objext conftest2.$ac_objext],
       [cp conftest1.$ac_objext conftest2.$ac_objext])
 
@@ -458,7 +458,8 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
     AS_CASE([$enable_imprecise_c99_float_ops,$target],
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
-      [*,x86_64-pc-cygwin|*,x86_64-w64-mingw32*], [hard_error=false],
+      [*,x86_64-pc-cygwin|*,x86_64-pc-msys|*,x86_64-w64-mingw32*],
+        [hard_error=false],
       [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
@@ -467,7 +468,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
       [AC_MSG_WARN(m4_normalize([
         fma does not work; emulation enabled]))])],
     [AS_CASE([$target],
-      [x86_64-pc-cygwin|x86_64-w64-mingw32*],
+      [x86_64-pc-cygwin|x86_64-pc-msys|x86_64-w64-mingw32*],
         [AC_MSG_RESULT([cross-compiling; assume not])],
       [AC_MSG_RESULT([cross-compiling; assume yes])
       AC_DEFINE([HAS_WORKING_FMA], [1])])])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -458,7 +458,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
     AS_CASE([$enable_imprecise_c99_float_ops,$target],
       [no,*], [hard_error=true],
       [yes,*], [hard_error=false],
-      [*,x86_64-w64-mingw32*|*,x86_64-*-cygwin*], [hard_error=false],
+      [*,x86_64-pc-cygwin|*,x86_64-w64-mingw32*], [hard_error=false],
       [hard_error=true])
     AS_IF([test x"$hard_error" = "xtrue"],
       [AC_MSG_ERROR(m4_normalize([
@@ -467,7 +467,7 @@ AC_DEFUN([OCAML_C99_CHECK_FMA], [
       [AC_MSG_WARN(m4_normalize([
         fma does not work; emulation enabled]))])],
     [AS_CASE([$target],
-      [x86_64-w64-mingw32*|x86_64-*-cygwin*],
+      [x86_64-pc-cygwin|x86_64-w64-mingw32*],
         [AC_MSG_RESULT([cross-compiling; assume not])],
       [AC_MSG_RESULT([cross-compiling; assume yes])
       AC_DEFINE([HAS_WORKING_FMA], [1])])])

--- a/configure
+++ b/configure
@@ -3789,7 +3789,7 @@ fi
 if test -n "$csc"
 then :
   case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     CSC=csc
       CSCFLAGS="/nologo /nowarn:1668"
       case $host_cpu in #(
@@ -14565,7 +14565,7 @@ esac
 # Libraries to build depending on the host
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     unix_or_win32="win32"
     ln='cp -pf'
     ocamltest_libunix="Some false"
@@ -14579,7 +14579,7 @@ case $host in #(
 esac
 
 case $host in #(
-  *-*-cygwin*|*-*-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
     exeext=".exe" ;; #(
   *) :
     exeext='' ;;
@@ -14651,7 +14651,7 @@ launch_method='exe'
 if test "x$interpval" = "xyes"
 then :
   case $host in #(
-  *-cygwin) :
+  *-pc-cygwin) :
     # Cygwin supports shebangs, which we use for the compiler itself, but
       # partially for legacy, and partially so that executables can be easily
       # run from outside Cygwin, the executables ocamlc and ocamlopt produce do
@@ -14662,7 +14662,7 @@ then :
 then :
   target_launch_method='exe'
 fi ;; #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     shebangscripts=true
@@ -14816,7 +14816,7 @@ case $enable_warn_error,true in #(
 esac
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     case $WINDOWS_UNICODE_MODE in #(
   ansi) :
     windows_unicode=0 ;; #(
@@ -14920,7 +14920,7 @@ esac
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 case $host in #(
-  i686-*-mingw32*) :
+  i686-w64-mingw32*) :
     internal_cflags="$internal_cflags -mfpmath=sse -msse2" ;; #(
   *) :
      ;;
@@ -14930,7 +14930,7 @@ esac
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64" ;;
@@ -14967,7 +14967,7 @@ case $host in #(
     flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
   *-*-cygwin*) :
-    as_fn_error $? "unknown cygwin variant" "$LINENO" 5 ;; #(
+    as_fn_error $? "unknown Cygwin variant" "$LINENO" 5 ;; #(
   i686-w64-mingw32*) :
     flexdll_chain='mingw'
     flexlink_flags='-stack 16777216' ;; #(
@@ -14997,7 +14997,7 @@ printf "%s\n" "disabled" >&6; }
 else $as_nop
   flexmsg=''
     case $target in #(
-  *-*-cygwin*|*-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
                                              if test x"$with_flexdll" = 'x' || test x"$with_flexdll" = 'xflexdll'
 then :
   if test -f 'flexdll/flexdll.h'
@@ -15178,7 +15178,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 then :
 
       case $build in #(
-  *-pc-msys|*-pc-cygwin*) :
+  *-pc-cygwin|*-pc-msys) :
     flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
           if test -z "$flexlink_where"
 then :
@@ -15304,7 +15304,7 @@ fi
 fi
 
 case $have_flexdll_h,$supports_shared_libraries,$host in #(
-  no,true,*-*-cygwin*) :
+  no,true,*-pc-cygwin) :
     supports_shared_libraries=false
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;} ;; #(
@@ -15315,7 +15315,7 @@ printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disa
 esac
 
 case $flexdll_source_dir,$supports_shared_libraries,$flexlink,$host in #(
-  ,true,,*-*-cygwin*) :
+  ,true,,*-pc-cygwin) :
     supports_shared_libraries=false
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexlink not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexlink not found: shared library support disabled." >&2;} ;; #(
@@ -15335,7 +15335,7 @@ case $ocaml_cc_vendor,$host in #(
   *,aarch64-*-darwin*|*,arm64-*-darwin*) :
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  *,*-*-cygwin*) :
+  *,*-pc-cygwin) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries
 then :
@@ -15348,7 +15348,7 @@ else $as_nop
 
 fi
     ostype="Cygwin" ;; #(
-  *,*-*-mingw32*) :
+  *,*-w64-mingw32*) :
     case $host in #(
   i686-*-*) :
     oc_dll_ldflags="-static-libgcc" ;; #(
@@ -16556,7 +16556,7 @@ fi
 # macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 case $host in #(
-  *-apple-darwin*|*-mingw32*|*-pc-windows) :
+  *-apple-darwin*|*-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     printf "%s\n" "#define HAS_FULL_THREAD_VARIABLES 1" >>confdefs.h
@@ -16584,7 +16584,7 @@ then :
   aarch64-apple-darwin*|arm64-apple-darwin*) :
     mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true ;; #(
-  *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
     mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="flexlink ${mkdll_flags}"
@@ -16673,9 +16673,9 @@ natdynlink=false
 if test x"$supports_shared_libraries" = 'xtrue'
 then :
   case "$host" in #(
-  *-*-cygwin*) :
+  *-pc-cygwin) :
     natdynlink=true ;; #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     natdynlink=true ;; #(
   *-pc-windows) :
     natdynlink=true ;; #(
@@ -16893,7 +16893,7 @@ case $host in #(
     arch=i386; system=beos ;; #(
   i[3456]86-*-cygwin) :
     arch=i386; system=cygwin ;; #(
-  i[3456]86-*-mingw32*) :
+  i[3456]86-w64-mingw32*) :
     arch=i386; system=mingw ;; #(
   i[3456]86-*-gnu*) :
     arch=i386; system=gnu ;; #(
@@ -16960,7 +16960,7 @@ case $host in #(
     has_native_backend=yes; arch=arm64; system=macosx ;; #(
   x86_64-*-darwin*) :
     has_native_backend=yes; arch=amd64; system=macosx ;; #(
-  x86_64-*-mingw32*) :
+  x86_64-w64-mingw32*) :
     has_native_backend=yes; arch=amd64; system=mingw64 ;; #(
   aarch64-*-linux*) :
     if $arch64
@@ -16975,7 +16975,7 @@ fi ;; #(
     has_native_backend=yes; arch=arm64; system=openbsd ;; #(
   aarch64-*-netbsd*) :
     has_native_backend=yes; arch=arm64; system=netbsd ;; #(
-  x86_64-*-cygwin*) :
+  x86_64-pc-cygwin) :
     has_native_backend=yes; arch=amd64; system=cygwin ;; #(
   riscv64-*-linux*) :
     has_native_backend=yes; arch=riscv; model=riscv64; system=linux ;; #(
@@ -17480,7 +17480,7 @@ fi
   if test "$cross_compiling" = yes
 then :
   case $target in #(
-  x86_64-w64-mingw32*|x86_64-*-cygwin*) :
+  x86_64-pc-cygwin|x86_64-w64-mingw32*) :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross-compiling; assume not" >&5
 printf "%s\n" "cross-compiling; assume not" >&6; } ;; #(
   *) :
@@ -17541,7 +17541,7 @@ printf "%s\n" "no" >&6; }
     hard_error=true ;; #(
   yes,*) :
     hard_error=false ;; #(
-  *,x86_64-w64-mingw32*|*,x86_64-*-cygwin*) :
+  *,x86_64-pc-cygwin|*,x86_64-w64-mingw32*) :
     hard_error=false ;; #(
   *) :
     hard_error=true ;;
@@ -17635,7 +17635,7 @@ fi
 ## On MacOS clock_gettime's CLOCK_MONOTONIC flag is not actually monotonic.
 
 case $host in #(
-  *-*-windows) :
+  *-pc-windows) :
     has_monotonic_clock=true ;; #(
   *-apple-darwin*) :
 
@@ -17700,7 +17700,7 @@ then :
     case $host in #(
   sparc-sun-solaris*) :
     instrumented_runtime=false ;; #(
-  *-*-windows) :
+  *-pc-windows) :
     instrumented_runtime=true ;; #(
   *-apple-darwin*) :
 
@@ -18084,7 +18084,7 @@ fi
 sockets=true
 
 case $host in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     cclibs="$cclibs -lws2_32"
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
 printf %s "checking for library containing socket... " >&6; }
@@ -18432,7 +18432,7 @@ fi
 ## socklen_t
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     ac_fn_c_check_type "$LINENO" "socklen_t" "ac_cv_type_socklen_t" "#include <ws2tcpip.h>
 "
 if test "x$ac_cv_type_socklen_t" = xyes
@@ -18463,7 +18463,7 @@ fi
 ## Unix domain sockets support on Windows
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
            for ac_header in afunix.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "afunix.h" "ac_cv_header_afunix_h" "#include <winsock2.h>
@@ -18485,7 +18485,7 @@ esac
 ipv6=true
 
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     ac_fn_c_check_type "$LINENO" "struct sockaddr_in6" "ac_cv_type_struct_sockaddr_in6" "#include <ws2tcpip.h>
 "
 if test "x$ac_cv_type_struct_sockaddr_in6" = xyes
@@ -18583,7 +18583,7 @@ fi
 # seem to detect it properly on Windows so we hardcode the definition
 # of HAS_UTIME on Windows but this will probably need to be clarified
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
  ;; #(
   *) :
@@ -18798,7 +18798,7 @@ fi
 # Note: detection fails on Windows so hardcoding the result
 # (should be debugged later)
 case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
  ;; #(
   *) :
@@ -18854,7 +18854,7 @@ fi
 ## setsid
 
 case $host in #(
-  *-cygwin|*-*-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "setsid" "ac_cv_func_setsid"
@@ -18967,7 +18967,7 @@ esac
 if $supports_shared_libraries
 then :
   case $host in #(
-  *-*-mingw32*|*-pc-windows|*-*-cygwin*) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
     DLLIBS="" ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
@@ -19067,7 +19067,7 @@ fi
 
 ## -fdebug-prefix-map support by the C compiler
 case $ocaml_cc_vendor,$host in #(
-  *,*-*-mingw32*) :
+  *,*-w64-mingw32*) :
     cc_has_debug_prefix_map=false ;; #(
   *,*-pc-windows) :
     cc_has_debug_prefix_map=false ;; #(
@@ -20088,7 +20088,7 @@ esac
 ## Determine how to link with the POSIX threads library
 
 case $host in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     link_gcc_eh=''
      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for printf in -lgcc_eh" >&5
 printf %s "checking for printf in -lgcc_eh... " >&6; }
@@ -21056,7 +21056,7 @@ asm_cfi_supported=false
 if $native_compiler
 then :
   case $host in #(
-  *-*-mingw32*|*-pc-windows) :
+  *-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
 
@@ -21594,7 +21594,7 @@ else $as_nop
   amd64|arm64|power|riscv|s390x) :
     # not supported on arm32, see issue #9124.
      case $target in #(
-  *-cygwin*|*-mingw*|*-windows|*-apple-darwin*) :
+  *-pc-cygwin|*-w64-mingw32*|*-pc-windows|*-apple-darwin*) :
     function_sections=false;
            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: No support for function sections on $target." >&5
 printf "%s\n" "$as_me: No support for function sections on $target." >&6;} ;; #(
@@ -21674,7 +21674,7 @@ bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
 native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
 
 case $host in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization" ;; #(
   *-pc-windows) :
     # For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
@@ -21729,7 +21729,7 @@ fi
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 case $host in #(
-  *-*-mingw32*) :
+  *-w64-mingw32*) :
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h

--- a/configure
+++ b/configure
@@ -14579,7 +14579,7 @@ case $host in #(
 esac
 
 case $host in #(
-  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows) :
     exeext=".exe" ;; #(
   *) :
     exeext='' ;;
@@ -14651,7 +14651,7 @@ launch_method='exe'
 if test "x$interpval" = "xyes"
 then :
   case $host in #(
-  *-pc-cygwin) :
+  *-pc-cygwin|*-pc-msys) :
     # Cygwin supports shebangs, which we use for the compiler itself, but
       # partially for legacy, and partially so that executables can be easily
       # run from outside Cygwin, the executables ocamlc and ocamlopt produce do
@@ -14960,14 +14960,14 @@ fi
 # Define flexlink chain and flags correctly for the different Windows ports
 flexlink_flags=''
 case $host in #(
-  i686-*-cygwin) :
+  i686-pc-cygwin|i686-pc-msys) :
     flexdll_chain='cygwin'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
-  x86_64-*-cygwin) :
+  x86_64-pc-cygwin|x86_64-pc-msys) :
     flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216' ;; #(
-  *-*-cygwin*) :
-    as_fn_error $? "unknown Cygwin variant" "$LINENO" 5 ;; #(
+  *-*-cygwin*|*-*-msys*) :
+    as_fn_error $? "unknown Cygwin/MSYS variant" "$LINENO" 5 ;; #(
   i686-w64-mingw32*) :
     flexdll_chain='mingw'
     flexlink_flags='-stack 16777216' ;; #(
@@ -14997,7 +14997,7 @@ printf "%s\n" "disabled" >&6; }
 else $as_nop
   flexmsg=''
     case $target in #(
-  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows) :
                                              if test x"$with_flexdll" = 'x' || test x"$with_flexdll" = 'xflexdll'
 then :
   if test -f 'flexdll/flexdll.h'
@@ -15119,7 +15119,7 @@ then :
     # flexlink can read anything).
     mv conftest.$ac_objext conftest1.$ac_objext
     case $host in #(
-  *-pc-cygwin) :
+  *-pc-cygwin|*-pc-msys) :
     ln -s conftest1.$ac_objext conftest2.$ac_objext ;; #(
   *) :
     cp conftest1.$ac_objext conftest2.$ac_objext ;;
@@ -15304,7 +15304,7 @@ fi
 fi
 
 case $have_flexdll_h,$supports_shared_libraries,$host in #(
-  no,true,*-pc-cygwin) :
+  no,true,*-pc-cygwin|*-pc-msys) :
     supports_shared_libraries=false
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexdll.h not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disabled." >&2;} ;; #(
@@ -15315,7 +15315,7 @@ printf "%s\n" "$as_me: WARNING: flexdll.h not found: shared library support disa
 esac
 
 case $flexdll_source_dir,$supports_shared_libraries,$flexlink,$host in #(
-  ,true,,*-pc-cygwin) :
+  ,true,,*-pc-cygwin|*-pc-msys) :
     supports_shared_libraries=false
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: flexlink not found: shared library support disabled." >&5
 printf "%s\n" "$as_me: WARNING: flexlink not found: shared library support disabled." >&2;} ;; #(
@@ -15335,7 +15335,7 @@ case $ocaml_cc_vendor,$host in #(
   *,aarch64-*-darwin*|*,arm64-*-darwin*) :
     printf "%s\n" "#define HAS_ARCH_CODE32 1" >>confdefs.h
  ;; #(
-  *,*-pc-cygwin) :
+  *,*-pc-cygwin|*-pc-msys) :
     common_cppflags="$common_cppflags -U_WIN32"
     if $supports_shared_libraries
 then :
@@ -16584,7 +16584,7 @@ then :
   aarch64-apple-darwin*|arm64-apple-darwin*) :
     mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true ;; #(
-  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows) :
     mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="flexlink ${mkdll_flags}"
@@ -16673,7 +16673,7 @@ natdynlink=false
 if test x"$supports_shared_libraries" = 'xtrue'
 then :
   case "$host" in #(
-  *-pc-cygwin) :
+  *-pc-cygwin|*-pc-msys) :
     natdynlink=true ;; #(
   *-w64-mingw32*) :
     natdynlink=true ;; #(
@@ -16891,7 +16891,7 @@ case $host in #(
     arch=i386; system=openbsd ;; #(
   i[3456]86-*-haiku*) :
     arch=i386; system=beos ;; #(
-  i[3456]86-*-cygwin) :
+  i345686-pc-cygwin|i345686-pc-msys) :
     arch=i386; system=cygwin ;; #(
   i[3456]86-w64-mingw32*) :
     arch=i386; system=mingw ;; #(
@@ -16975,7 +16975,7 @@ fi ;; #(
     has_native_backend=yes; arch=arm64; system=openbsd ;; #(
   aarch64-*-netbsd*) :
     has_native_backend=yes; arch=arm64; system=netbsd ;; #(
-  x86_64-pc-cygwin) :
+  x86_64-pc-cygwin|x86_64-pc-msys) :
     has_native_backend=yes; arch=amd64; system=cygwin ;; #(
   riscv64-*-linux*) :
     has_native_backend=yes; arch=riscv; model=riscv64; system=linux ;; #(
@@ -17480,7 +17480,7 @@ fi
   if test "$cross_compiling" = yes
 then :
   case $target in #(
-  x86_64-pc-cygwin|x86_64-w64-mingw32*) :
+  x86_64-pc-cygwin|x86_64-pc-msys|x86_64-w64-mingw32*) :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross-compiling; assume not" >&5
 printf "%s\n" "cross-compiling; assume not" >&6; } ;; #(
   *) :
@@ -17541,7 +17541,7 @@ printf "%s\n" "no" >&6; }
     hard_error=true ;; #(
   yes,*) :
     hard_error=false ;; #(
-  *,x86_64-pc-cygwin|*,x86_64-w64-mingw32*) :
+  *,x86_64-pc-cygwin|*,x86_64-pc-msys|*,x86_64-w64-mingw32*) :
     hard_error=false ;; #(
   *) :
     hard_error=true ;;
@@ -18854,7 +18854,7 @@ fi
 ## setsid
 
 case $host in #(
-  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows) :
      ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "setsid" "ac_cv_func_setsid"
@@ -18967,7 +18967,7 @@ esac
 if $supports_shared_libraries
 then :
   case $host in #(
-  *-pc-cygwin|*-w64-mingw32*|*-pc-windows) :
+  *-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows) :
     DLLIBS="" ;; #(
   *) :
     ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
@@ -21594,7 +21594,7 @@ else $as_nop
   amd64|arm64|power|riscv|s390x) :
     # not supported on arm32, see issue #9124.
      case $target in #(
-  *-pc-cygwin|*-w64-mingw32*|*-pc-windows|*-apple-darwin*) :
+  *-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows|*-apple-darwin*) :
     function_sections=false;
            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: No support for function sections on $target." >&5
 printf "%s\n" "$as_me: No support for function sections on $target." >&6;} ;; #(
@@ -21717,7 +21717,7 @@ else $as_nop
           && test "$host_vendor-$host_os" != "$build_vendor-$build_os"
 then :
   case $build in #(
-  *-pc-cygwin) :
+  *-pc-cygwin|*-pc-msys) :
     prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")" ;; #(
   *) :
      ;;

--- a/configure.ac
+++ b/configure.ac
@@ -736,7 +736,7 @@ AS_CASE([$host],
   ocamlyacc_wstr_module=""])
 
 AS_CASE([$host],
-  [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
+  [*-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows],
     [exeext=".exe"],
   [exeext=''])
 
@@ -781,7 +781,7 @@ shebangscripts=false
 launch_method='exe'
 AS_IF([test "x$interpval" = "xyes"],
   [AS_CASE([$host],
-    [*-pc-cygwin],
+    [*-pc-cygwin|*-pc-msys],
       [# Cygwin supports shebangs, which we use for the compiler itself, but
       # partially for legacy, and partially so that executables can be easily
       # run from outside Cygwin, the executables ocamlc and ocamlopt produce do
@@ -957,14 +957,14 @@ AS_IF([test x"$enable_shared" = "xno"],
 # Define flexlink chain and flags correctly for the different Windows ports
 flexlink_flags=''
 AS_CASE([$host],
-  [i686-*-cygwin],
+  [i686-pc-cygwin|i686-pc-msys],
     [flexdll_chain='cygwin'
     flexlink_flags='-merge-manifest -stack 16777216'],
-  [x86_64-*-cygwin],
+  [x86_64-pc-cygwin|x86_64-pc-msys],
     [flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216'],
-  [*-*-cygwin*],
-    [AC_MSG_ERROR([unknown Cygwin variant])],
+  [*-*-cygwin*|*-*-msys*],
+    [AC_MSG_ERROR([unknown Cygwin/MSYS variant])],
   [i686-w64-mingw32*],
     [flexdll_chain='mingw'
     flexlink_flags='-stack 16777216'],
@@ -986,7 +986,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     AC_MSG_RESULT([disabled])],
     [flexmsg=''
     AS_CASE([$target],
-      [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
+      [*-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows],
       [dnl When bootstrapping from the git submodule (flexdll directory), just
        dnl use that, however if another directory has been specified with
        dnl --with-flexdll=<path> then copy the contents of <path> to
@@ -1047,14 +1047,14 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
 ])
 
 AS_CASE([$have_flexdll_h,$supports_shared_libraries,$host],
- [no,true,*-pc-cygwin],
+ [no,true,*-pc-cygwin|*-pc-msys],
    [supports_shared_libraries=false
    AC_MSG_WARN([flexdll.h not found: shared library support disabled.])],
  [no,*,*-w64-mingw32*|no,*,*-pc-windows],
    [AC_MSG_ERROR([flexdll.h is required for native Win32])])
 
 AS_CASE([$flexdll_source_dir,$supports_shared_libraries,$flexlink,$host],
-  [,true,,*-pc-cygwin],
+  [,true,,*-pc-cygwin|*-pc-msys],
     [supports_shared_libraries=false
     AC_MSG_WARN([flexlink not found: shared library support disabled.])],
   [,*,,*-w64-mingw32*|,*,,*-pc-windows],
@@ -1068,7 +1068,7 @@ AS_CASE([$ocaml_cc_vendor,$host],
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [*,aarch64-*-darwin*|*,arm64-*-darwin*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
-  [*,*-pc-cygwin],
+  [*,*-pc-cygwin|*-pc-msys],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
       [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
@@ -1295,7 +1295,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
       [mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true],
-    [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
+    [*-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows],
       [mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="flexlink ${mkdll_flags}"
@@ -1362,7 +1362,7 @@ natdynlink=false
 
 AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
   [AS_CASE(["$host"],
-    [*-pc-cygwin], [natdynlink=true],
+    [*-pc-cygwin|*-pc-msys], [natdynlink=true],
     [*-w64-mingw32*], [natdynlink=true],
     [*-pc-windows], [natdynlink=true],
     [[i[3456]86-*-linux*]], [natdynlink=true],
@@ -1436,7 +1436,7 @@ AS_CASE([$host],
     [arch=i386; system=openbsd],
   [[i[3456]86-*-haiku*]],
     [arch=i386; system=beos],
-  [[i[3456]86-*-cygwin]],
+  [i[3456]86-pc-cygwin|i[3456]86-pc-msys],
     [arch=i386; system=cygwin],
   [[i[3456]86-w64-mingw32*]],
     [arch=i386; system=mingw],
@@ -1517,7 +1517,7 @@ AS_CASE([$host],
     [has_native_backend=yes; arch=arm64; system=openbsd],
   [aarch64-*-netbsd*],
     [has_native_backend=yes; arch=arm64; system=netbsd],
-  [x86_64-pc-cygwin],
+  [x86_64-pc-cygwin|x86_64-pc-msys],
     [has_native_backend=yes; arch=amd64; system=cygwin],
   [riscv64-*-linux*],
     [has_native_backend=yes; arch=riscv; model=riscv64; system=linux],
@@ -2124,7 +2124,7 @@ AC_CHECK_FUNC([mktime], [AC_DEFINE([HAS_MKTIME], [1])])
 ## setsid
 
 AS_CASE([$host],
-  [*-pc-cygwin|*-w64-mingw32*|*-pc-windows], [],
+  [*-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows], [],
   [AC_CHECK_FUNC([setsid], [AC_DEFINE([HAS_SETSID], [1])])])
 
 ## putenv
@@ -2161,7 +2161,7 @@ AS_CASE([$host],
 ## shared library support
 AS_IF([$supports_shared_libraries],
   [AS_CASE([$host],
-    [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
+    [*-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows],
       [DLLIBS=""],
     [AC_CHECK_FUNC([dlopen],
       [supports_shared_libraries=true DLLIBS=""],
@@ -2595,7 +2595,7 @@ AS_IF([test x"$enable_function_sections" = "xno"],
   [AS_CASE([$arch],
     [amd64|arm64|power|riscv|s390x], # not supported on arm32, see issue #9124.
      [AS_CASE([$target],
-        [*-pc-cygwin|*-w64-mingw32*|*-pc-windows|*-apple-darwin*],
+        [*-pc-cygwin|*-pc-msys|*-w64-mingw32*|*-pc-windows|*-apple-darwin*],
           [function_sections=false;
            AC_MSG_NOTICE([No support for function sections on $target.])],
         [AS_CASE([$ocaml_cc_vendor],
@@ -2676,7 +2676,8 @@ AS_IF([test x"$prefix" = "xNONE"],
   [AS_IF([test x"$unix_or_win32" = "xwin32" \
           && test "$host_vendor-$host_os" != "$build_vendor-$build_os" ],
     [AS_CASE([$build],
-      [*-pc-cygwin], [prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")"])])])
+      [*-pc-cygwin|*-pc-msys],
+        [prefix="$(LC_ALL=C.UTF-8 cygpath -m "$prefix")"])])])
 
 # Define a few macros that were defined in config/m-nt.h
 # but whose value is not guessed properly by configure

--- a/configure.ac
+++ b/configure.ac
@@ -334,7 +334,7 @@ AS_CASE([$host],
 AC_CHECK_PROG([csc],[csc],[csc])
 AS_IF([test -n "$csc"],
   [AS_CASE([$host],
-    [*-*-mingw32*|*-pc-windows],
+    [*-w64-mingw32*|*-pc-windows],
       [CSC=csc
       CSCFLAGS="/nologo /nowarn:1668"
       AS_CASE([$host_cpu], [i*86], [CSCFLAGS="$CSCFLAGS /platform:x86"])],
@@ -724,7 +724,7 @@ AS_CASE([$lt_cv_ar_at_file],
 # Libraries to build depending on the host
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [unix_or_win32="win32"
     ln='cp -pf'
     ocamltest_libunix="Some false"
@@ -736,7 +736,7 @@ AS_CASE([$host],
   ocamlyacc_wstr_module=""])
 
 AS_CASE([$host],
-  [*-*-cygwin*|*-*-mingw32*|*-pc-windows],
+  [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
     [exeext=".exe"],
   [exeext=''])
 
@@ -781,7 +781,7 @@ shebangscripts=false
 launch_method='exe'
 AS_IF([test "x$interpval" = "xyes"],
   [AS_CASE([$host],
-    [*-cygwin],
+    [*-pc-cygwin],
       [# Cygwin supports shebangs, which we use for the compiler itself, but
       # partially for legacy, and partially so that executables can be easily
       # run from outside Cygwin, the executables ocamlc and ocamlopt produce do
@@ -790,7 +790,7 @@ AS_IF([test "x$interpval" = "xyes"],
       launch_method='sh'
       AS_IF([test x"$target_launch_method" = 'x'],
         [target_launch_method='exe'])],
-    [*-*-mingw32*|*-pc-windows], [],
+    [*-w64-mingw32*|*-pc-windows], [],
     [shebangscripts=true
     launch_method='sh']
   )]
@@ -867,7 +867,7 @@ AS_CASE([$enable_warn_error,OCAML__DEVELOPMENT_VERSION],
     [cc_warnings="$cc_warnings $warn_error_flag"])
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AS_CASE([$WINDOWS_UNICODE_MODE],
       [ansi],
         [windows_unicode=0],
@@ -929,14 +929,14 @@ AS_CASE([$ocaml_cc_vendor],
 
 # Enable SSE2 on x86 mingw to avoid using 80-bit registers.
 AS_CASE([$host],
-  [i686-*-mingw32*],
+  [i686-w64-mingw32*],
     [internal_cflags="$internal_cflags -mfpmath=sse -msse2"])
 
 # Use 64-bit file offset if possible
 # See also AC_SYS_LARGEFILE
 # Problem: flags are added to CC rather than CPPFLAGS
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows], [],
+  [*-w64-mingw32*|*-pc-windows], [],
   [common_cppflags="$common_cppflags -D_FILE_OFFSET_BITS=64"])
 
 # Adjust according to target
@@ -964,7 +964,7 @@ AS_CASE([$host],
     [flexdll_chain='cygwin64'
     flexlink_flags='-merge-manifest -stack 16777216'],
   [*-*-cygwin*],
-    [AC_MSG_ERROR([unknown cygwin variant])],
+    [AC_MSG_ERROR([unknown Cygwin variant])],
   [i686-w64-mingw32*],
     [flexdll_chain='mingw'
     flexlink_flags='-stack 16777216'],
@@ -986,7 +986,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     AC_MSG_RESULT([disabled])],
     [flexmsg=''
     AS_CASE([$target],
-      [*-*-cygwin*|*-w64-mingw32*|*-pc-windows],
+      [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
       [dnl When bootstrapping from the git submodule (flexdll directory), just
        dnl use that, however if another directory has been specified with
        dnl --with-flexdll=<path> then copy the contents of <path> to
@@ -1029,7 +1029,7 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
     # is only necessary when cross-compiling.
     AS_IF([test x"$build" != x"$host"],[
       AS_CASE([$build],
-        [*-pc-msys|*-pc-cygwin*],
+        [*-pc-cygwin|*-pc-msys],
           [flexlink_where="$(cmd /c "$flexlink" -where 2>/dev/null)"
           AS_IF([test -z "$flexlink_where"],
             [AC_MSG_ERROR(m4_normalize([$flexlink is not executable from a
@@ -1047,14 +1047,14 @@ AS_IF([test x"$supports_shared_libraries" != 'xfalse'], [
 ])
 
 AS_CASE([$have_flexdll_h,$supports_shared_libraries,$host],
- [no,true,*-*-cygwin*],
+ [no,true,*-pc-cygwin],
    [supports_shared_libraries=false
    AC_MSG_WARN([flexdll.h not found: shared library support disabled.])],
  [no,*,*-w64-mingw32*|no,*,*-pc-windows],
    [AC_MSG_ERROR([flexdll.h is required for native Win32])])
 
 AS_CASE([$flexdll_source_dir,$supports_shared_libraries,$flexlink,$host],
-  [,true,,*-*-cygwin*],
+  [,true,,*-pc-cygwin],
     [supports_shared_libraries=false
     AC_MSG_WARN([flexlink not found: shared library support disabled.])],
   [,*,,*-w64-mingw32*|,*,,*-pc-windows],
@@ -1068,7 +1068,7 @@ AS_CASE([$ocaml_cc_vendor,$host],
     AC_DEFINE([HAS_ARCH_CODE32], [1])],
   [*,aarch64-*-darwin*|*,arm64-*-darwin*],
     AC_DEFINE([HAS_ARCH_CODE32], [1]),
-  [*,*-*-cygwin*],
+  [*,*-pc-cygwin],
     [common_cppflags="$common_cppflags -U_WIN32"
     AS_IF([$supports_shared_libraries],
       [mkexe_cmd_exp="flexlink -exe -chain ${flexdll_chain} ${flexlink_flags}"
@@ -1078,7 +1078,7 @@ AS_CASE([$ocaml_cc_vendor,$host],
       oc_ldflags='-Wl,--stack,16777216']
     )
     ostype="Cygwin"],
-  [*,*-*-mingw32*],
+  [*,*-w64-mingw32*],
     [AS_CASE([$host],
       [i686-*-*], [oc_dll_ldflags="-static-libgcc"])
     ostype="Win32"
@@ -1272,7 +1272,7 @@ AS_IF([! $cc_supports_atomic],
 # macOS and MinGW-w64 have problems with thread local storage accessed from DLLs
 
 AS_CASE([$host],
-  [*-apple-darwin*|*-mingw32*|*-pc-windows], [],
+  [*-apple-darwin*|*-w64-mingw32*|*-pc-windows], [],
   [AC_DEFINE([HAS_FULL_THREAD_VARIABLES], [1])]
 )
 
@@ -1295,7 +1295,7 @@ AS_IF([test x"$enable_shared" != "xno"],
     [aarch64-apple-darwin*|arm64-apple-darwin*],
       [mkdll_flags='-shared -undefined dynamic_lookup -Wl,-w'
       supports_shared_libraries=true],
-    [*-*-mingw32*|*-pc-windows|*-*-cygwin*],
+    [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
       [mkdll_flags="-chain ${flexdll_chain} ${flexlink_flags}"
       mkdll_exp="flexlink ${mkdll_flags}"
       mkdll="flexlink ${mkdll_flags}"
@@ -1362,8 +1362,8 @@ natdynlink=false
 
 AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
   [AS_CASE(["$host"],
-    [*-*-cygwin*], [natdynlink=true],
-    [*-*-mingw32*], [natdynlink=true],
+    [*-pc-cygwin], [natdynlink=true],
+    [*-w64-mingw32*], [natdynlink=true],
     [*-pc-windows], [natdynlink=true],
     [[i[3456]86-*-linux*]], [natdynlink=true],
     [[x86_64-*-linux*]], [natdynlink=true],
@@ -1438,7 +1438,7 @@ AS_CASE([$host],
     [arch=i386; system=beos],
   [[i[3456]86-*-cygwin]],
     [arch=i386; system=cygwin],
-  [[i[3456]86-*-mingw32*]],
+  [[i[3456]86-w64-mingw32*]],
     [arch=i386; system=mingw],
   [[i[3456]86-*-gnu*]],
     [arch=i386; system=gnu],
@@ -1505,7 +1505,7 @@ AS_CASE([$host],
     [has_native_backend=yes; arch=arm64; system=macosx],
   [x86_64-*-darwin*],
     [has_native_backend=yes; arch=amd64; system=macosx],
-  [x86_64-*-mingw32*],
+  [x86_64-w64-mingw32*],
     [has_native_backend=yes; arch=amd64; system=mingw64],
   [aarch64-*-linux*],
     [AS_IF([$arch64],
@@ -1517,7 +1517,7 @@ AS_CASE([$host],
     [has_native_backend=yes; arch=arm64; system=openbsd],
   [aarch64-*-netbsd*],
     [has_native_backend=yes; arch=arm64; system=netbsd],
-  [x86_64-*-cygwin*],
+  [x86_64-pc-cygwin],
     [has_native_backend=yes; arch=amd64; system=cygwin],
   [riscv64-*-linux*],
     [has_native_backend=yes; arch=riscv; model=riscv64; system=linux],
@@ -1719,7 +1719,7 @@ AC_CHECK_FUNC([issetugid], [AC_DEFINE([HAS_ISSETUGID], [1])])
 ## On MacOS clock_gettime's CLOCK_MONOTONIC flag is not actually monotonic.
 
 AS_CASE([$host],
-  [*-*-windows],
+  [*-pc-windows],
     [has_monotonic_clock=true],
   [*-apple-darwin*], [
     AC_CHECK_FUNCS([clock_gettime_nsec_np],
@@ -1753,7 +1753,7 @@ AS_IF([test "x$enable_instrumented_runtime" != "xno" ],
     AS_CASE([$host],
     [sparc-sun-solaris*],
       [instrumented_runtime=false],
-    [*-*-windows],
+    [*-pc-windows],
       [instrumented_runtime=true],
     [*-apple-darwin*], [
       AS_CASE([$enable_instrumented_runtime,$has_monotonic_clock],
@@ -1942,7 +1942,7 @@ AS_IF([$tsan],
 sockets=true
 
 AS_CASE([$host],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [cclibs="$cclibs -lws2_32"
     AC_SEARCH_LIBS([socket], [ws2_32])
     AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR], [1])])],
@@ -1970,7 +1970,7 @@ AS_IF([$sockets], [AC_DEFINE([HAS_SOCKETS], [1])])
 ## socklen_t
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T], [1])], [],
       [#include <ws2tcpip.h>])],
   [AC_CHECK_TYPE([socklen_t], [AC_DEFINE([HAS_SOCKLEN_T], [1])], [],
@@ -1981,7 +1981,7 @@ AC_CHECK_FUNC([inet_aton], [AC_DEFINE([HAS_INET_ATON], [1])])
 ## Unix domain sockets support on Windows
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AC_CHECK_HEADERS([afunix.h], [AC_DEFINE([HAS_AFUNIX_H], [1])], [],
       [#include <winsock2.h>])])
 
@@ -1990,7 +1990,7 @@ AS_CASE([$host],
 ipv6=true
 
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows],
+  [*-w64-mingw32*|*-pc-windows],
     [AC_CHECK_TYPE(
       [struct sockaddr_in6], [], [ipv6=false], [#include <ws2tcpip.h>])],
   [AC_CHECK_TYPE(
@@ -2024,7 +2024,7 @@ AC_CHECK_FUNC([system], [AC_DEFINE([HAS_SYSTEM], [1])])
 # seem to detect it properly on Windows so we hardcode the definition
 # of HAS_UTIME on Windows but this will probably need to be clarified
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_UTIME], [1])],
+  [*-w64-mingw32*|*-pc-windows], [AC_DEFINE([HAS_UTIME], [1])],
   [AC_CHECK_HEADER([sys/types.h],
     [AC_CHECK_HEADER([utime.h],
       [AC_CHECK_FUNC([utime], [AC_DEFINE([HAS_UTIME], [1])])])])])
@@ -2100,7 +2100,7 @@ AC_CHECK_FUNC([setitimer],
 # Note: detection fails on Windows so hardcoding the result
 # (should be debugged later)
 AS_CASE([$host],
-  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME], [1])],
+  [*-w64-mingw32*|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME], [1])],
   [AC_CHECK_FUNC([gethostname], [AC_DEFINE([HAS_GETHOSTNAME], [1])])])
 
 ## uname
@@ -2124,7 +2124,7 @@ AC_CHECK_FUNC([mktime], [AC_DEFINE([HAS_MKTIME], [1])])
 ## setsid
 
 AS_CASE([$host],
-  [*-cygwin|*-*-mingw32*|*-pc-windows], [],
+  [*-pc-cygwin|*-w64-mingw32*|*-pc-windows], [],
   [AC_CHECK_FUNC([setsid], [AC_DEFINE([HAS_SETSID], [1])])])
 
 ## putenv
@@ -2161,7 +2161,7 @@ AS_CASE([$host],
 ## shared library support
 AS_IF([$supports_shared_libraries],
   [AS_CASE([$host],
-    [*-*-mingw32*|*-pc-windows|*-*-cygwin*],
+    [*-pc-cygwin|*-w64-mingw32*|*-pc-windows],
       [DLLIBS=""],
     [AC_CHECK_FUNC([dlopen],
       [supports_shared_libraries=true DLLIBS=""],
@@ -2187,7 +2187,7 @@ AC_CHECK_FUNC([pwrite], [AC_DEFINE([HAS_PWRITE], [1])])
 
 ## -fdebug-prefix-map support by the C compiler
 AS_CASE([$ocaml_cc_vendor,$host],
-  [*,*-*-mingw32*], [cc_has_debug_prefix_map=false],
+  [*,*-w64-mingw32*], [cc_has_debug_prefix_map=false],
   [*,*-pc-windows], [cc_has_debug_prefix_map=false],
   [xlc*,powerpc-ibm-aix*], [cc_has_debug_prefix_map=false],
   [sunc*,sparc-sun-*], [cc_has_debug_prefix_map=false],
@@ -2367,7 +2367,7 @@ AS_CASE([$enable_debug_runtime],
 ## Determine how to link with the POSIX threads library
 
 AS_CASE([$host],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [link_gcc_eh=''
      AC_CHECK_LIB([gcc_eh], [printf], [link_gcc_eh="-lgcc_eh"])
      PTHREAD_LIBS="-l:libpthread.a $link_gcc_eh"],
@@ -2461,7 +2461,7 @@ as_has_debug_prefix_map=false
 asm_cfi_supported=false
 AS_IF([$native_compiler],
   [AS_CASE([$host],
-    [*-*-mingw32*|*-pc-windows], [],
+    [*-w64-mingw32*|*-pc-windows], [],
     [OCAML_AS_HAS_DEBUG_PREFIX_MAP
     OCAML_AS_HAS_CFI_DIRECTIVES])])
 
@@ -2595,7 +2595,7 @@ AS_IF([test x"$enable_function_sections" = "xno"],
   [AS_CASE([$arch],
     [amd64|arm64|power|riscv|s390x], # not supported on arm32, see issue #9124.
      [AS_CASE([$target],
-        [*-cygwin*|*-mingw*|*-windows|*-apple-darwin*],
+        [*-pc-cygwin|*-w64-mingw32*|*-pc-windows|*-apple-darwin*],
           [function_sections=false;
            AC_MSG_NOTICE([No support for function sections on $target.])],
         [AS_CASE([$ocaml_cc_vendor],
@@ -2650,7 +2650,7 @@ bytecode_cppflags="$common_cppflags $COMPILER_BYTECODE_CPPFLAGS"
 native_cppflags="$common_cppflags $COMPILER_NATIVE_CPPFLAGS"
 
 AS_CASE([$host],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [cclibs="$cclibs -lole32 -luuid -lversion -lshlwapi -lsynchronization"],
   [*-pc-windows],
     [# For whatever reason, flexlink includes -ladvapi32 and -lshell32 for
@@ -2682,7 +2682,7 @@ AS_IF([test x"$prefix" = "xNONE"],
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 AS_CASE([$host],
-  [*-*-mingw32*],
+  [*-w64-mingw32*],
     [AC_DEFINE([HAS_BROKEN_PRINTF], [1])
     AC_DEFINE([HAS_IPV6], [1])
     AC_DEFINE([HAS_NICE], [1])],


### PR DESCRIPTION
Also changed to match configure triplets for Windows on `*-pc-cygwin`, `*-pc-msys`, `*-w64-mingw32*`, and `*-pc-windows`, where applicable.