### PR TITLE
Configure fixes for Windows

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -545,3 +545,35 @@ AC_DEFUN([OCAML_CC_SUPPORTS_LABELS_AS_VALUES], [
       [Define if the C compiler supports the labels as values extension.])
   fi
 ])
+
+# OCAML_CL_SEARCH_LIBS(FUNCTION, SEARCH-LIBS,
+#                      [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND],
+#                      [OTHER-LIBRARIES])
+# --------------------------------------------------------
+# Search for a library defining FUNC, if it's not already available.
+AC_DEFUN([OCAML_CL_SEARCH_LIBS],
+[AS_VAR_PUSHDEF([ocaml_Search], [ocaml_cv_search_$1])dnl
+AC_CACHE_CHECK([for library containing $1], [ocaml_Search],
+[ocaml_func_search_save_LIBS=$LIBS
+AC_LANG_CONFTEST([AC_LANG_CALL([], [$1])])
+for ocaml_lib in '' $2
+do
+  if test -z "$ocaml_lib"; then
+    ocaml_res="none required"
+  else
+    ocaml_res=${ocaml_lib}.lib
+    LIBS="${ocaml_lib}.lib $5 $ocaml_func_search_save_LIBS"
+  fi
+  AC_LINK_IFELSE([], [AS_VAR_SET([ocaml_Search], [$ocaml_res])])
+  AS_VAR_SET_IF([ocaml_Search], [break])
+done
+AS_VAR_SET_IF([ocaml_Search], , [AS_VAR_SET([ocaml_Search], [no])])
+rm conftest.$ac_ext
+LIBS=$ocaml_func_search_save_LIBS])
+AS_VAR_COPY([ocaml_res], [ocaml_Search])
+AS_IF([test "$ocaml_res" != no],
+  [test "$ocaml_res" = "none required" || LIBS="$ocaml_res $LIBS"
+  $3],
+      [$4])
+AS_VAR_POPDEF([ocaml_Search])dnl
+])

--- a/configure
+++ b/configure
@@ -20420,21 +20420,20 @@ printf "%s\n" "#define HAVE_LOCALE 1" >>confdefs.h
 fi
 
 ## strtod_l
-# Note: not detected on MSVC so hardcoding the result
-# (should be debugged later)
-case $target in #(
-  *-pc-windows) :
-    printf "%s\n" "#define HAS_STRTOD_L 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_func "$LINENO" "strtod_l" "ac_cv_func_strtod_l"
-if test "x$ac_cv_func_strtod_l" = xyes
-then :
-  printf "%s\n" "#define HAS_STRTOD_L 1" >>confdefs.h
 
+  for ac_func in strtod_l _strtod_l
+do :
+  as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"
+then :
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+ break
 fi
- ;;
-esac
+
+done
 
 ## shared library support
 if $supports_shared_libraries

--- a/configure
+++ b/configure
@@ -23297,19 +23297,10 @@ fi
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 case $target in #(
-  *-*-mingw32*) :
+  *-*-mingw32*|*-pc-windows) :
     printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
 
     printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_NICE 1" >>confdefs.h
- ;; #(
-  *-pc-windows) :
-    printf "%s\n" "#define HAS_BROKEN_PRINTF 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_IPV6 1" >>confdefs.h
-
-    printf "%s\n" "#define HAS_NICE 1" >>confdefs.h
  ;; #(
   *-*-solaris*) :
     # This is required as otherwise floats are printed

--- a/configure
+++ b/configure
@@ -20353,60 +20353,71 @@ fi
 fi
 
 
-## newlocale() and <locale.h>
-# Note: the detection fails on msvc so we hardcode the result
-# (should be debugged later)
+## locale
+have_locale=false
 case $target in #(
-  *-pc-windows) :
-    printf "%s\n" "#define HAS_LOCALE_H 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_header_compile "$LINENO" "locale.h" "ac_cv_header_locale_h" "$ac_includes_default"
+  *-*-mingw32*|*-pc-windows) :
+           for ac_header in locale.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "locale.h" "ac_cv_header_locale_h" "$ac_includes_default"
 if test "x$ac_cv_header_locale_h" = xyes
 then :
-  ac_fn_c_check_func "$LINENO" "newlocale" "ac_cv_func_newlocale"
-if test "x$ac_cv_func_newlocale" = xyes
+  printf "%s\n" "#define HAVE_LOCALE_H 1" >>confdefs.h
+
+  for ac_func in _create_locale _free_locale setlocale _configthreadlocale
+do :
+  as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"
 then :
-  ac_fn_c_check_func "$LINENO" "freelocale" "ac_cv_func_freelocale"
-if test "x$ac_cv_func_freelocale" = xyes
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+ have_locale=true
+fi
+
+done
+fi
+
+done ;; #(
+  *) :
+           for ac_header in xlocale.h locale.h
+do :
+  as_ac_Header=`printf "%s\n" "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"
 then :
-  ac_fn_c_check_func "$LINENO" "uselocale" "ac_cv_func_uselocale"
-if test "x$ac_cv_func_uselocale" = xyes
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+
+  for ac_func in newlocale freelocale uselocale
+do :
+  as_ac_var=`printf "%s\n" "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"
 then :
-  printf "%s\n" "#define HAS_LOCALE_H 1" >>confdefs.h
-
+  cat >>confdefs.h <<_ACEOF
+#define `printf "%s\n" "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+ have_locale=true
 fi
 
+done
+    if $have_locale
+then :
+  break
+fi
 fi
 
-fi
-
-fi
- ;;
+done ;;
 esac
+if $have_locale
+then :
 
-ac_fn_c_check_header_compile "$LINENO" "xlocale.h" "ac_cv_header_xlocale_h" "$ac_includes_default"
-if test "x$ac_cv_header_xlocale_h" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "newlocale" "ac_cv_func_newlocale"
-if test "x$ac_cv_func_newlocale" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "freelocale" "ac_cv_func_freelocale"
-if test "x$ac_cv_func_freelocale" = xyes
-then :
-  ac_fn_c_check_func "$LINENO" "uselocale" "ac_cv_func_uselocale"
-if test "x$ac_cv_func_uselocale" = xyes
-then :
-  printf "%s\n" "#define HAS_XLOCALE_H 1" >>confdefs.h
+printf "%s\n" "#define HAVE_LOCALE 1" >>confdefs.h
 
 fi
-
-fi
-
-fi
-
-fi
-
 
 ## strtod_l
 # Note: not detected on MSVC so hardcoding the result

--- a/configure
+++ b/configure
@@ -19618,11 +19618,11 @@ fi
     cclibs="$cclibs ws2_32.lib"
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
 printf %s "checking for library containing socket... " >&6; }
-if test ${ac_cv_search_socket+y}
+if test ${ocaml_cv_search_socket+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_func_search_save_LIBS=$LIBS
+  ocaml_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -19638,40 +19638,40 @@ return socket ();
   return 0;
 }
 _ACEOF
-for ac_lib in '' ws2_32
+for ocaml_lib in '' ws2_32
 do
-  if test -z "$ac_lib"; then
-    ac_res="none required"
+  if test -z "$ocaml_lib"; then
+    ocaml_res="none required"
   else
-    ac_res=-l$ac_lib
-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+    ocaml_res=${ocaml_lib}.lib
+    LIBS="${ocaml_lib}.lib  $ocaml_func_search_save_LIBS"
   fi
   if ac_fn_c_try_link "$LINENO"
 then :
-  ac_cv_search_socket=$ac_res
+  ocaml_cv_search_socket=$ocaml_res
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.beam \
     conftest$ac_exeext
-  if test ${ac_cv_search_socket+y}
+  if test ${ocaml_cv_search_socket+y}
 then :
   break
 fi
 done
-if test ${ac_cv_search_socket+y}
+if test ${ocaml_cv_search_socket+y}
 then :
 
 else $as_nop
-  ac_cv_search_socket=no
+  ocaml_cv_search_socket=no
 fi
 rm conftest.$ac_ext
-LIBS=$ac_func_search_save_LIBS
+LIBS=$ocaml_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_socket" >&5
-printf "%s\n" "$ac_cv_search_socket" >&6; }
-ac_res=$ac_cv_search_socket
-if test "$ac_res" != no
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_search_socket" >&5
+printf "%s\n" "$ocaml_cv_search_socket" >&6; }
+ocaml_res=$ocaml_cv_search_socket
+if test "$ocaml_res" != no
 then :
-  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+  test "$ocaml_res" = "none required" || LIBS="$ocaml_res $LIBS"
 
 fi
 
@@ -20257,21 +20257,13 @@ fi
 
 
 ## gethostname
-# Note: detection fails on Windows so hardcoding the result
-# (should be debugged later)
-case $target in #(
-  *-*-mingw32*|*-pc-windows) :
-    printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
- ;; #(
-  *) :
-    ac_fn_c_check_func "$LINENO" "gethostname" "ac_cv_func_gethostname"
+ac_fn_c_check_func "$LINENO" "gethostname" "ac_cv_func_gethostname"
 if test "x$ac_cv_func_gethostname" = xyes
 then :
-  printf "%s\n" "#define HAS_GETHOSTNAME 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_GETHOSTNAME 1" >>confdefs.h
 
 fi
- ;;
-esac
+
 
 ## uname
 

--- a/configure
+++ b/configure
@@ -20041,13 +20041,10 @@ fi
 
 
 ## utime
-## Note: this was defined in config/s-nt.h but the autoconf macros do not
-# seem to detect it properly on Windows so we hardcode the definition
-# of HAS_UTIME on Windows but this will probably need to be clarified
 case $target in #(
+  # SetFileTime is used instead of _utime,
   *-*-mingw32*|*-pc-windows) :
-    printf "%s\n" "#define HAS_UTIME 1" >>confdefs.h
- ;; #(
+     ;; #(
   *) :
     ac_fn_c_check_header_compile "$LINENO" "sys/types.h" "ac_cv_header_sys_types_h" "$ac_includes_default"
 if test "x$ac_cv_header_sys_types_h" = xyes

--- a/configure.ac
+++ b/configure.ac
@@ -2093,11 +2093,9 @@ AC_CHECK_FUNC([getcwd], [AC_DEFINE([HAS_GETCWD], [1])])
 AC_CHECK_FUNC([system], [AC_DEFINE([HAS_SYSTEM], [1])])
 
 ## utime
-## Note: this was defined in config/s-nt.h but the autoconf macros do not
-# seem to detect it properly on Windows so we hardcode the definition
-# of HAS_UTIME on Windows but this will probably need to be clarified
 AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_UTIME], [1])],
+  # SetFileTime is used instead of _utime,
+  [*-*-mingw32*|*-pc-windows], ,
   [AC_CHECK_HEADER([sys/types.h],
     [AC_CHECK_HEADER([utime.h],
       [AC_CHECK_FUNC([utime], [AC_DEFINE([HAS_UTIME], [1])])])])])

--- a/configure.ac
+++ b/configure.ac
@@ -2759,14 +2759,9 @@ AS_IF([test x"$prefix" = "xNONE"],
 # but whose value is not guessed properly by configure
 # (all this should be understood and fixed)
 AS_CASE([$target],
-  [*-*-mingw32*],
+  [*-*-mingw32*|*-pc-windows],
     [AC_DEFINE([HAS_BROKEN_PRINTF], [1])
-    AC_DEFINE([HAS_IPV6], [1])
-    AC_DEFINE([HAS_NICE], [1])],
-  [*-pc-windows],
-    [AC_DEFINE([HAS_BROKEN_PRINTF], [1])
-    AC_DEFINE([HAS_IPV6], [1])
-    AC_DEFINE([HAS_NICE], [1])],
+    AC_DEFINE([HAS_IPV6], [1])],
   [*-*-solaris*],
     # This is required as otherwise floats are printed
     # as "Infinity" and "Inf" instead of the expected "inf"

--- a/configure.ac
+++ b/configure.ac
@@ -2021,7 +2021,7 @@ AS_CASE([$target],
     AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR], [1])])],
   [*-pc-windows],
     [cclibs="$cclibs ws2_32.lib"
-    AC_SEARCH_LIBS([socket], [ws2_32])
+    OCAML_CL_SEARCH_LIBS([socket], [ws2_32])
     AC_CHECK_FUNC([socketpair], [AC_DEFINE([HAS_SOCKETPAIR], [1])])],
   [*-*-haiku],
     [cclibs="$cclibs -lnetwork"
@@ -2170,11 +2170,7 @@ AC_CHECK_FUNC([setitimer],
   [setitimer=false])
 
 ## gethostname
-# Note: detection fails on Windows so hardcoding the result
-# (should be debugged later)
-AS_CASE([$target],
-  [*-*-mingw32*|*-pc-windows], [AC_DEFINE([HAS_GETHOSTNAME], [1])],
-  [AC_CHECK_FUNC([gethostname], [AC_DEFINE([HAS_GETHOSTNAME], [1])])])
+AC_CHECK_FUNCS([gethostname])
 
 ## uname
 

--- a/configure.ac
+++ b/configure.ac
@@ -2209,20 +2209,19 @@ AC_CHECK_FUNC([putenv], [AC_DEFINE([HAS_PUTENV], [1])])
 AC_CHECK_FUNC([setenv],
   [AC_CHECK_FUNC([unsetenv], [AC_DEFINE([HAS_SETENV_UNSETENV], [1])])])
 
-## newlocale() and <locale.h>
-# Note: the detection fails on msvc so we hardcode the result
-# (should be debugged later)
+## locale
+have_locale=false
 AS_CASE([$target],
-  [*-pc-windows], [AC_DEFINE([HAS_LOCALE_H], [1])],
-  [AC_CHECK_HEADER([locale.h],
-    [AC_CHECK_FUNC([newlocale],
-      [AC_CHECK_FUNC([freelocale],
-        [AC_CHECK_FUNC([uselocale], [AC_DEFINE([HAS_LOCALE_H], [1])])])])])])
-
-AC_CHECK_HEADER([xlocale.h],
-  [AC_CHECK_FUNC([newlocale],
-    [AC_CHECK_FUNC([freelocale],
-      [AC_CHECK_FUNC([uselocale], [AC_DEFINE([HAS_XLOCALE_H], [1])])])])])
+  [*-*-mingw32*|*-pc-windows],
+    [AC_CHECK_HEADERS([locale.h],
+      [AC_CHECK_FUNCS([_create_locale _free_locale setlocale
+                       _configthreadlocale], [have_locale=true])])],
+  [AC_CHECK_HEADERS([xlocale.h locale.h],
+    [AC_CHECK_FUNCS([newlocale freelocale uselocale], [have_locale=true])
+    AS_IF([$have_locale], [break])])])
+AS_IF([$have_locale],
+  [AC_DEFINE([HAVE_LOCALE], [1], [Define to 1 if you have the POSIX,
+    Windows, or extended locale header and functions.])])
 
 ## strtod_l
 # Note: not detected on MSVC so hardcoding the result

--- a/configure.ac
+++ b/configure.ac
@@ -2224,11 +2224,7 @@ AS_IF([$have_locale],
     Windows, or extended locale header and functions.])])
 
 ## strtod_l
-# Note: not detected on MSVC so hardcoding the result
-# (should be debugged later)
-AS_CASE([$target],
-  [*-pc-windows], [AC_DEFINE([HAS_STRTOD_L], [1])],
-  [AC_CHECK_FUNC([strtod_l], [AC_DEFINE([HAS_STRTOD_L], [1])])])
+AC_CHECK_FUNCS([strtod_l _strtod_l], [break])
 
 ## shared library support
 AS_IF([$supports_shared_libraries],

--- a/otherlibs/unix/gethostname.c
+++ b/otherlibs/unix/gethostname.c
@@ -21,7 +21,7 @@
 #endif
 #include "caml/unixsupport.h"
 
-#ifdef HAS_GETHOSTNAME
+#ifdef HAVE_GETHOSTNAME
 
 #ifndef MAXHOSTNAMELEN
 #define MAXHOSTNAMELEN 256

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -42,4 +42,8 @@
 #define HAS_UNISTD 1
 #endif
 
+#if defined(HAVE_STRTOD_L) || defined(HAVE__STRTOD_L)
+#define HAS_STRTOD_L 1
+#endif
+
 #endif  /* CAML_COMPATIBILITY_H */

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -46,4 +46,8 @@
 #define HAS_STRTOD_L 1
 #endif
 
+#ifdef HAVE_GETHOSTNAME
+#define HAS_GETHOSTNAME 1
+#endif
+
 #endif  /* CAML_COMPATIBILITY_H */

--- a/runtime/caml/compatibility.h
+++ b/runtime/caml/compatibility.h
@@ -17,6 +17,15 @@
 #ifndef CAML_COMPATIBILITY_H
 #define CAML_COMPATIBILITY_H
 
+#if defined(HAVE_LOCALE)
+#define HAS_LOCALE 1
+#if defined(HAVE_LOCALE_H)
+#define HAS_LOCALE_H 1
+#elif defined(HAVE_XLOCALE_H)
+#define HAVE_XLOCALE_H 1
+#endif
+#endif
+
 #define HAS_STDINT_H 1 /* Deprecated since OCaml 5.3 */
 
 /* HAS_NANOSECOND_STAT is deprecated since OCaml 5.3 */

--- a/runtime/caml/config.h
+++ b/runtime/caml/config.h
@@ -46,11 +46,6 @@
 
 #include <stddef.h>
 #include <limits.h>
-
-#if defined(HAS_LOCALE_H) || defined(HAS_XLOCALE_H)
-#define HAS_LOCALE
-#endif
-
 #include <stdint.h>
 
 /* Disable the mingw-w64 *printf shims */

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -206,9 +206,9 @@
 
 /* Define HAS_SETITIMER if you have setitimer(). */
 
-#undef HAS_GETHOSTNAME
+#undef HAVE_GETHOSTNAME
 
-/* Define HAS_GETHOSTNAME if you have gethostname(). */
+/* Define HAVE_GETHOSTNAME if you have gethostname(). */
 
 #undef HAS_UNAME
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -234,15 +234,18 @@
 
 /* Define HAS_SETENV_UNSETENV if you have setenv() and unsetenv(). */
 
-#undef HAS_LOCALE_H
+#undef HAVE_LOCALE_H
 
-/* Define HAS_LOCALE_H if you have the include file <locale.h> and the
-   uselocale() function. */
+/* Define to 1 if you have the <locale.h> header file. */
 
-#undef HAS_XLOCALE_H
+#undef HAVE_XLOCALE_H
 
-/* Define HAS_XLOCALE_H if you have the include file <xlocale.h> and the
-   uselocale() function. */
+/* Define to 1 if you have the <xlocale.h> header file. */
+
+#undef HAVE_LOCALE
+
+/* Define to 1 if you have the POSIX, Windows, or extended locale header and
+   functions. */
 
 #undef HAS_STRTOD_L
 

--- a/runtime/caml/s.h.in
+++ b/runtime/caml/s.h.in
@@ -247,9 +247,11 @@
 /* Define to 1 if you have the POSIX, Windows, or extended locale header and
    functions. */
 
-#undef HAS_STRTOD_L
+#undef HAVE_STRTOD_L
 
 /* Define HAS_STRTOD_L if you have strtod_l */
+
+#undef HAVE__STRTOD_L
 
 #undef HAS_MMAP
 

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -50,7 +50,8 @@
 #ifndef freelocale
 #define freelocale _free_locale
 #endif
-#ifndef strtod_l
+#if !defined(strtod_l) && defined(HAVE__STRTOD_L)
+#define HAVE_STRTOD_L 1
 #define strtod_l _strtod_l
 #endif
 #endif
@@ -395,13 +396,13 @@ CAMLprim value caml_float_of_string(value vs)
     if (sign < 0) d = -d;
   } else {
     /* Convert using strtod */
-#if defined(HAS_STRTOD_L) && defined(HAVE_LOCALE)
+#if defined(HAVE_STRTOD_L) && defined(HAVE_LOCALE)
     d = strtod_l((const char *) buf, &end, caml_locale);
 #else
     USE_LOCALE;
     d = strtod((const char *) buf, &end);
     RESTORE_LOCALE;
-#endif /* HAS_STRTOD_L */
+#endif /* HAVE_STRTOD_L */
     if (end != dst) goto error;
   }
   if (buf != parse_buffer) caml_stat_free(buf);

--- a/runtime/floats.c
+++ b/runtime/floats.c
@@ -17,11 +17,9 @@
 
 /* The interface of this file is in "caml/mlvalues.h" and "caml/alloc.h" */
 
-/* Needed for uselocale */
-#define _XOPEN_SOURCE 700
-
-/* Needed for strtod_l */
-#define _GNU_SOURCE
+#define _XOPEN_SOURCE 700       /* Needed for uselocale */
+#define _GNU_SOURCE             /* Needed for strtod_l */
+#define _USE_MATH_DEFINES       /* Needed for M_LOG2E */
 
 #include <math.h>
 #include <stdio.h>
@@ -39,17 +37,13 @@
 #include "caml/reverse.h"
 #include "caml/fiber.h"
 
-#if defined(HAS_LOCALE) || defined(__MINGW32__)
-
-#if defined(HAS_LOCALE_H) || defined(__MINGW32__)
+#if defined(HAVE_LOCALE_H)
 #include <locale.h>
-#endif
-
-#if defined(HAS_XLOCALE_H)
+#elif defined(HAVE_XLOCALE_H)
 #include <xlocale.h>
 #endif
 
-#if defined(_MSC_VER)
+#if defined(_WIN32) && defined(HAVE_LOCALE)
 #ifndef locale_t
 #define locale_t _locale_t
 #endif
@@ -61,9 +55,7 @@
 #endif
 #endif
 
-#endif /* defined(HAS_LOCALE) */
-
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <float.h>
 #ifndef isnan
 #define isnan _isnan
@@ -109,15 +101,15 @@ CAMLexport void caml_Store_double_val(value val, double dbl)
  standard "C" locale by default, but it is possible that
  third-party code loaded into process does.
 */
-#ifdef HAS_LOCALE
+#ifdef HAVE_LOCALE
 locale_t caml_locale = (locale_t)0;
 #endif
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
-/* there is no analogue to uselocale in MSVC so just set locale for thread */
+#if defined(_WIN32) && defined(HAVE_LOCALE)
+/* There is no analogue to uselocale on Windows so just set locale for thread */
 #define USE_LOCALE setlocale(LC_NUMERIC,"C")
 #define RESTORE_LOCALE do {} while(0)
-#elif defined(HAS_LOCALE)
+#elif defined(HAVE_LOCALE)
 #define USE_LOCALE locale_t saved_locale = uselocale(caml_locale)
 #define RESTORE_LOCALE uselocale(saved_locale)
 #else
@@ -127,13 +119,13 @@ locale_t caml_locale = (locale_t)0;
 
 void caml_init_locale(void)
 {
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#ifdef HAVE_LOCALE
+#ifdef _WIN32
   _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
 #endif
-#ifdef HAS_LOCALE
   if ((locale_t)0 == caml_locale)
   {
-#if defined(_MSC_VER)
+#ifdef _WIN32
     caml_locale = _create_locale(LC_NUMERIC, "C");
 #else
     caml_locale = newlocale(LC_NUMERIC_MASK,"C",(locale_t)0);
@@ -144,7 +136,7 @@ void caml_init_locale(void)
 
 void caml_free_locale(void)
 {
-#ifdef HAS_LOCALE
+#ifdef HAVE_LOCALE
   if ((locale_t)0 != caml_locale) freelocale(caml_locale);
   caml_locale = (locale_t)0;
 #endif
@@ -403,7 +395,7 @@ CAMLprim value caml_float_of_string(value vs)
     if (sign < 0) d = -d;
   } else {
     /* Convert using strtod */
-#if defined(HAS_STRTOD_L) && defined(HAS_LOCALE)
+#if defined(HAS_STRTOD_L) && defined(HAVE_LOCALE)
     d = strtod_l((const char *) buf, &end, caml_locale);
 #else
     USE_LOCALE;


### PR DESCRIPTION
Debug a few places in the configure script to improve Windows support.
- allow searching for functions in other libraries (e.g., `socket` in `ws2_32`), as `cl.exe` takes `ws2_32.lib` as a parameter instead of `-lws2_32`;
- correctly detect some functions,
- unify locale handling between MinGW-w64 and MSVC.