### PR TITLE
Use `static` in array declarators in function parameters if possible

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -527,6 +527,21 @@ AC_DEFUN([OCAML_CC_SUPPORTS_ATOMIC], [
   OCAML_CC_RESTORE_VARIABLES
 ])
 
+AC_DEFUN([OCAML_CC_SUPPORTS_STATIC_ARRAY_DECLARATOR],
+  [AC_CACHE_CHECK([if $CC supports the static keyword in array declarators],
+    [ocaml_cv_prog_cc_static_array_declarator],
+    [ocaml_cv_prog_cc_static_array_declarator=no
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+      [[static void f(int array[static 16]) { }]], [[]])],
+      [ocaml_cv_prog_cc_static_array_declarator=yes])])
+  AS_IF([test "x$ocaml_cv_prog_cc_static_array_declarator" = xyes],
+    [ocaml_keyword='static'], [ocaml_keyword=''])
+  AC_DEFINE_UNQUOTED([STATIC_ARRAY_DECLARATOR], [$ocaml_keyword],
+    [Define to 'static' (unquoted) if the C compiler supports the 'static'
+    keyword appearing within the [ and ] of array type derivations in function
+    parameters.])
+])
+
 # Detects whether the C compiler generates an explicit .note.GNU-stack section
 # to mark the stack as non-executable, so that we can follow suit
 AC_DEFUN([OCAML_WITH_NONEXECSTACK_NOTE],

--- a/configure
+++ b/configure
@@ -18448,6 +18448,46 @@ printf "%s\n" "#define HAVE_LABELS_AS_VALUES 1" >>confdefs.h
   fi
 
 
+# Check whether the C compiler supports the 'static' keyword appearing
+# within the [ and ] of array type derivations in function parameters.
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC supports the static keyword in array declarators" >&5
+printf %s "checking if $CC supports the static keyword in array declarators... " >&6; }
+if test ${ocaml_cv_prog_cc_static_array_declarator+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ocaml_cv_prog_cc_static_array_declarator=no
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+static void f(int array[static 16]) { }
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ocaml_cv_prog_cc_static_array_declarator=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ocaml_cv_prog_cc_static_array_declarator" >&5
+printf "%s\n" "$ocaml_cv_prog_cc_static_array_declarator" >&6; }
+  if test "x$ocaml_cv_prog_cc_static_array_declarator" = xyes
+then :
+  ocaml_keyword='static'
+else $as_nop
+  ocaml_keyword=''
+fi
+
+printf "%s\n" "#define STATIC_ARRAY_DECLARATOR $ocaml_keyword" >>confdefs.h
+
+
+
 # Configure the native-code compiler
 
 arch=none

--- a/configure.ac
+++ b/configure.ac
@@ -1500,6 +1500,10 @@ OCAML_CC_SUPPORTS_TREE_VECTORIZE([$warn_error_flag])
 # Check whether the C compiler supports the labels as values extension.
 OCAML_CC_SUPPORTS_LABELS_AS_VALUES
 
+# Check whether the C compiler supports the 'static' keyword appearing
+# within the [ and ] of array type derivations in function parameters.
+OCAML_CC_SUPPORTS_STATIC_ARRAY_DECLARATOR
+
 # Configure the native-code compiler
 
 arch=none

--- a/runtime/caml/codefrag.h
+++ b/runtime/caml/codefrag.h
@@ -78,7 +78,8 @@ extern struct code_fragment * caml_find_code_fragment_by_num(int fragnum);
 /* Find the code fragment whose digest is equal to the given digest.
    Returns NULL if none exists. */
 extern struct code_fragment *
-   caml_find_code_fragment_by_digest(unsigned char digest[16]);
+caml_find_code_fragment_by_digest(
+  unsigned char digest[STATIC_ARRAY_DECLARATOR 16]);
 
 /* Return the digest of the given code fragment.
    If the code fragment was registered in [DIGEST_LATER] mode

--- a/runtime/caml/m.h.in
+++ b/runtime/caml/m.h.in
@@ -91,3 +91,8 @@
 
 /* Define WITH_NONEXECSTACK_NOTE when an explicit ".note.GNU-stack" section
    is to be added to indicate the stack should not be executable */
+
+#undef STATIC_ARRAY_DECLARATOR
+
+/* Define to 'static' if the C compiler supports the 'static' keyword appearing
+   within the [ and ] of array type derivations in function parameters. */

--- a/runtime/caml/md5.h
+++ b/runtime/caml/md5.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "io.h"
 
-CAMLextern void caml_md5_block(unsigned char digest[16],
+CAMLextern void caml_md5_block(unsigned char digest[STATIC_ARRAY_DECLARATOR 16],
                                void * data, uintnat len);
 
 CAMLextern value caml_md5_channel(struct channel *chan, intnat toread);

--- a/runtime/codefrag.c
+++ b/runtime/codefrag.c
@@ -156,7 +156,9 @@ unsigned char *caml_digest_of_code_fragment(struct code_fragment *cf) {
 }
 
 struct code_fragment *
-caml_find_code_fragment_by_digest(unsigned char digest[16]) {
+caml_find_code_fragment_by_digest(
+  unsigned char digest[STATIC_ARRAY_DECLARATOR 16])
+{
   FOREACH_LF_SKIPLIST_ELEMENT(e, &code_fragments_by_pc, {
     struct code_fragment *cf = (struct code_fragment *)e->data;
     const unsigned char *d = caml_digest_of_code_fragment(cf);

--- a/runtime/md5.c
+++ b/runtime/md5.c
@@ -79,7 +79,7 @@ CAMLprim value caml_md5_chan(value vchan, value len)
    CAMLreturn (caml_md5_channel(Channel(vchan), Long_val(len)));
 }
 
-CAMLexport void caml_md5_block(unsigned char digest[16],
+CAMLexport void caml_md5_block(unsigned char digest[STATIC_ARRAY_DECLARATOR 16],
                                void * data, uintnat len)
 {
   struct MD5Context ctx;

--- a/runtime/sys.c
+++ b/runtime/sys.c
@@ -623,9 +623,9 @@ CAMLprim value caml_sys_time(value unit)
 }
 
 #ifdef _WIN32
-extern int caml_win32_random_seed (intnat data[16]);
+extern int caml_win32_random_seed (intnat data[STATIC_ARRAY_DECLARATOR 16]);
 #else
-int caml_unix_random_seed(intnat data[16])
+int caml_unix_random_seed(intnat data[STATIC_ARRAY_DECLARATOR 16])
 {
   int n = 0;
   unsigned char buffer[12];

--- a/runtime/win32.c
+++ b/runtime/win32.c
@@ -620,7 +620,7 @@ void caml_win32_unregister_overflow_detection(void)
 
 /* Seeding of pseudo-random number generators */
 
-int caml_win32_random_seed (intnat data[16])
+int caml_win32_random_seed (intnat data[STATIC_ARRAY_DECLARATOR 16])
 {
   /* For better randomness, consider:
      http://msdn.microsoft.com/library/en-us/seccrypto/security/rtlgenrandom.asp


### PR DESCRIPTION
This is a C99 feature that helps with static analysis.

>  If the keyword `static` also appears within the `[` and `]` of the array type derivation, then for each call to the function, the value of the corresponding actual argument shall provide access to the first element of an array with at least as many elements as specified by the size expression.

See _Array declarators_ and _Function declarators_ from the C standard.

It is not supported by MSVC: [C11: static inside array parameter square brackets](https://developercommunity.visualstudio.com/t/C11:-static-inside-array-parameter-squar/1475168).

Both gcc and clang warn if `NULL` or if an array too small is passed to the function. Interestingly gcc also warns in the non-static case if an array too small is passed. cppcheck considers in both cases that the array has a fixed size and warns for out-of-bounds accesses.

<details>

```c
void f(int a[10]);
void g(int a[static 10]);
void h(int a[static 10]) {
    a[42] = 42;
}

void m(void) {
    int a[8];
    int b[11];

    f(0);
    f(a);
    f(b);

    g(0);
    g(a);
    g(b);
}
```

```console
$ /opt/homebrew/Cellar/gcc/14.2.0_1/bin/gcc-14  -O0 -Wall -Wextra -D_FORTIFY_SOURCE=3 -c test.c
test.c: In function 'm':
test.c:15:5: warning: argument 1 null where non-null expected [-Wnonnull]
   15 |     g(0);
      |     ^
test.c:2:6: note: in a call to function 'g' declared 'nonnull'
    2 | void g(int a[static 10]);
      |      ^
test.c:12:5: warning: 'f' accessing 40 bytes in a region of size 32 [-Wstringop-overflow=]
   12 |     f(a);
      |     ^~~~
test.c:12:5: note: referencing argument 1 of type 'int[10]'
test.c:1:6: note: in a call to function 'f'
    1 | void f(int a[10]);
      |      ^
test.c:16:5: warning: 'g' accessing 40 bytes in a region of size 32 [-Wstringop-overflow=]
   16 |     g(a);
      |     ^~~~
test.c:16:5: note: referencing argument 1 of type 'int[10]'
test.c:2:6: note: in a call to function 'g'
    2 | void g(int a[static 10]);
      |      ^
$ /opt/homebrew/Cellar/llvm/19.1.2/bin/clang -O0 -Wall -Wextra -D_FORTIFY_SOURCE=3 -c test.c
test.c:15:5: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
   15 |     g(0);
      |     ^ ~
test.c:2:12: note: callee declares array parameter as static here
    2 | void g(int a[static 10]);
      |            ^~~~~~~~~~~~
test.c:16:5: warning: array argument is too small; contains 8 elements, callee requires at least 10 [-Warray-bounds]
   16 |     g(a);
      |     ^ ~
test.c:2:12: note: callee declares array parameter as static here
    2 | void g(int a[static 10]);
      |            ^~~~~~~~~~~~
2 warnings generated.
```

</details>