### PR TITLE
Fix GCC 11 notes of ABI break in aligning 64 bits atomic ints on x86

### DIFF
--- a/runtime/caml/runtime_events.h
+++ b/runtime/caml/runtime_events.h
@@ -208,8 +208,9 @@ CAMLextern int caml_runtime_events_are_active(void);
 #ifdef CAML_INTERNALS
 
 struct runtime_events_buffer_header {
-  atomic_uint_fast64_t ring_head;
-  atomic_uint_fast64_t ring_tail;
+  /* CAMLalign(8) prevents a note about an ABI break on GCC >= 11.1 on i386. */
+  CAMLalign(8) atomic_uint_fast64_t ring_head;
+  CAMLalign(8) atomic_uint_fast64_t ring_tail;
   uint64_t padding[8]; /* Padding so headers don't share cache lines. Eight
                           words guarantees that buffer headers don't share
                           cache lines, even for non-aligned allocations. */


### PR DESCRIPTION
GCC had a bug before 11.1 in x86 (32-bits) where it could align to 4 bytes an 8 byte value, breaking atomicity when operating on it. It was fixed in GCC, but newer versions print note that GCC had to introduce an ABI break when fixing the bug. To silence the note, the solution is to re-state the alignment: 8 bytes.

    runtime/caml/runtime_events.h:216:1: note: the alignment of
    '_Atomic long long unsigned int' fields changed in GCC 11.1
     216 | };
         | ^

See also:
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65146