### PR TITLE
Set OC_CFLAGS to OC_NATIVE_CFLAGS for native comp in otherlibs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
   # in the runtime system.
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
   # Fully print commands executed by Make
-  # MAKEFLAGS: V=1
+  MAKEFLAGS: V=1
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
 # Concurrent workflows are grouped by the PR or branch that triggered them
@@ -192,6 +192,13 @@ jobs:
       - name: configure tree
         run: |
           CONFIG_ARG='--enable-codegen-invariants ${{ matrix.config_arg }}' MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh configure
+          echo
+          echo "::group::Makefile.config"
+          cat Makefile.config
+          echo "::endgroup"
+          echo "::group::Makefile.build_config"
+          cat Makefile.build_config
+          echo "::endgroup"
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build

--- a/Changes
+++ b/Changes
@@ -1023,12 +1023,11 @@ OCaml 5.3.0 (8 January 2025)
   (Sébastien Hinderer, review by Miod Vallat, Gabriel Scherer and
   Olivier Nicole)
 
-* #12578, #12589, #13322, #13519: Use configured CFLAGS and CPPFLAGS *only*
-  during the build of the compiler itself. Do not use them when
-  compiling third-party C sources through the compiler. Flags for
-  compiling third-party C sources can still be specified at configure
-  time in the COMPILER_{BYTECODE,NATIVE}_{CFLAGS,CPPFLAGS}
-  configuration variables.
+* #12578, #12589, #13322, #13519, #?????: Use configured CFLAGS and CPPFLAGS
+  *only* during the build of the compiler itself. Do not use them when compiling
+  third-party C sources through the compiler. Flags for compiling third-party C
+  sources can still be specified at configure time in the
+  COMPILER_{BYTECODE,NATIVE}_{CFLAGS,CPPFLAGS} configuration variables.
   (Sébastien Hinderer, report by William Hu, review by David Allsopp)
 
 - #13285: continue the merge of the sub-makefiles into the root

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -164,7 +164,7 @@ distclean:: clean
 	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
 	  $(OUTPUTOBJ)$@ -c $<
 
-%.n.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
+%.n.$(O): OC_CFLAGS = $(OC_NATIVE_CFLAGS)
 
 %.n.$(O): %.c $(REQUIRED_HEADERS)
 	$(V_CC)$(CC) $(OC_CFLAGS) $(CFLAGS) \


### PR DESCRIPTION
Probably an omission from 12589, and more specifically X31cdf41.