### PR TITLE
Rename `ccomptype` to `ccomp_type` for consistency

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -186,7 +186,7 @@ NATIVECCLIBS=@cclibs@
 SYSTHREAD_SUPPORT=@systhread_support@
 STRIP=@STRIP@
 PACKLD=@PACKLD@$(EMPTY)
-CCOMPTYPE=@ccomptype@
+CCOMPTYPE=@ccomp_type@
 TOOLCHAIN=@toolchain@
 CMXS=@cmxs@
 

--- a/configure
+++ b/configure
@@ -892,7 +892,7 @@ tsan
 oc_cflags
 common_cflags
 toolchain
-ccomptype
+ccomp_type
 mkexe_via_cc_extra_cmd
 mkexe_via_cc_ldflags
 mkexedebugflag
@@ -3829,14 +3829,14 @@ case $target in #(
 then :
   CC=cl
 fi
-    ccomptype=msvc
+    ccomp_type=msvc
     S=asm
     SO=dll
     outputexe=-Fe
     outputobj=-Fo
     syslib='$(1).lib' ;; #(
   *) :
-    ccomptype=cc
+    ccomp_type=cc
   S=s
   SO=so
   outputexe='-o '
@@ -18581,7 +18581,7 @@ native_cflags=''
 oc_native_cflags=''
 oc_native_cppflags="-DNATIVE_CODE\
  -DTARGET_${arch} -DMODEL_${model} -DSYS_${system}"
-case $ccomptype in #(
+case $ccomp_type in #(
   msvc) :
     runtime_asm_objects=${arch}nt.${OBJEXT} ;; #(
   *) :
@@ -23457,7 +23457,7 @@ fi
 # Enable debugging support
 # TODO: add a --disable-debug-info configure option that disables debugging
 # info for both C and OCaml
-if test "$ccomptype" != "msvc"
+if test "$ccomp_type" != "msvc"
 then :
   internal_cflags="-g $internal_cflags"
 fi
@@ -23807,7 +23807,7 @@ then :
 fi
   mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}\$(OC_LDFLAGS) \$(LDFLAGS)"
   # cl requires linker flags after the objects.
-  if test "$ccomptype" = 'msvc'
+  if test "$ccomp_type" = 'msvc'
 then :
   mkexe_via_cc_ldflags=\
 "/nologo \$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"

--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AC_SUBST([mkexe_exp])
 AC_SUBST([mkexedebugflag])
 AC_SUBST([mkexe_via_cc_ldflags])
 AC_SUBST([mkexe_via_cc_extra_cmd])
-AC_SUBST([ccomptype])
+AC_SUBST([ccomp_type])
 AC_SUBST([toolchain])
 AC_SUBST([common_cflags])
 AC_SUBST([oc_cflags])
@@ -352,13 +352,13 @@ If your host is 64 bits, you can try with './configure CC="gcc -m64"' \
 AS_CASE([$target],
   [*-pc-windows],
     [AS_IF([test -z "$CC"], [CC=cl])
-    ccomptype=msvc
+    ccomp_type=msvc
     S=asm
     SO=dll
     outputexe=-Fe
     outputobj=-Fo
     syslib='$(1).lib'],
-  [ccomptype=cc
+  [ccomp_type=cc
   S=s
   SO=so
   outputexe='-o '
@@ -1614,7 +1614,7 @@ native_cflags=''
 oc_native_cflags=''
 oc_native_cppflags="-DNATIVE_CODE\
  -DTARGET_${arch} -DMODEL_${model} -DSYS_${system}"
-AS_CASE([$ccomptype],
+AS_CASE([$ccomp_type],
   [msvc],
     [runtime_asm_objects=${arch}nt.${OBJEXT}],
   [runtime_asm_objects=${arch}.${OBJEXT}])
@@ -2727,7 +2727,7 @@ AS_IF([test x"$with_afl" = "xyes"],
 # Enable debugging support
 # TODO: add a --disable-debug-info configure option that disables debugging
 # info for both C and OCaml
-AS_IF([test "$ccomptype" != "msvc"],
+AS_IF([test "$ccomp_type" != "msvc"],
   [internal_cflags="-g $internal_cflags"])
 
 oc_cflags="$common_cflags $internal_cflags"
@@ -2880,7 +2880,7 @@ ${mkdll_ldflags}"
     [mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}${oc_exe_ldflags} "])
   mkexe_via_cc_ldflags="${mkexe_via_cc_ldflags}\$(OC_LDFLAGS) \$(LDFLAGS)"
   # cl requires linker flags after the objects.
-  AS_IF([test "$ccomptype" = 'msvc'],
+  AS_IF([test "$ccomp_type" = 'msvc'],
     [mkexe_via_cc_ldflags=\
 "/nologo \$(OUTPUTEXE)\$(1) \$(2) $mkexe_via_cc_ldflags"],
     [mkexe_via_cc_ldflags=\

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -130,7 +130,7 @@ let not_windows = make
 let not_msvc = make
   ~name:"not-msvc"
   ~description:"Pass if not using MSVC / clang-cl"
-  (Actions_helpers.pass_or_skip (Ocamltest_config.ccomptype <> "msvc")
+  (Actions_helpers.pass_or_skip (Ocamltest_config.ccomp_type <> "msvc")
     "not using MSVC / clang-cl"
     "using MSVC / clang-cl")
 

--- a/ocamltest/ocaml_actions.ml
+++ b/ocamltest/ocaml_actions.ml
@@ -707,7 +707,7 @@ let run_codegen log env =
     if exit_status=0
     then begin
       let finalise =
-        if Ocamltest_config.ccomptype="msvc"
+        if Ocamltest_config.ccomp_type="msvc"
         then finalise_codegen_msvc
         else finalise_codegen_cc
       in
@@ -729,7 +729,7 @@ let run_cc log env =
   let what = Printf.sprintf "Running C compiler to build %s" program in
   Printf.fprintf log "%s\n%!" what;
   let output_exe =
-    if Ocamltest_config.ccomptype="msvc" then "/Fe" else "-o "
+    if Ocamltest_config.ccomp_type="msvc" then "/Fe" else "-o "
   in
   let commandline =
   [

--- a/ocamltest/ocaml_tests.ml
+++ b/ocamltest/ocaml_tests.ml
@@ -153,7 +153,7 @@ let asmgen_skip_on_bytecode_only =
   Actions_helpers.skip_with_reason "native compiler disabled"
 
 let msvc64 =
-  Ocamltest_config.ccomptype = "msvc" && Ocamltest_config.arch="amd64"
+  Ocamltest_config.ccomp_type = "msvc" && Ocamltest_config.arch="amd64"
 
 let asmgen_skip_on_msvc64 =
   Actions_helpers.skip_with_reason "not ported to MSVC64 yet"

--- a/ocamltest/ocamltest_config.ml.in
+++ b/ocamltest/ocamltest_config.ml.in
@@ -31,7 +31,7 @@ let cc = {@QS@|@CC@|@QS@}
 
 let cflags = {@QS@|@common_cflags@|@QS@}
 
-let ccomptype = {@QS@|@ccomptype@|@QS@}
+let ccomp_type = {@QS@|@ccomp_type@|@QS@}
 
 let target_os_type = {@QS@|@target_os_type@|@QS@}
 

--- a/ocamltest/ocamltest_config.mli
+++ b/ocamltest/ocamltest_config.mli
@@ -36,7 +36,7 @@ val cc : string
 val cflags : string
 (** Flags to pass to the C compiler *)
 
-val ccomptype : string
+val ccomp_type : string
 (** Type of C compiler (msvc, cc, etc.) *)
 
 val target_os_type : string

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -22,7 +22,7 @@ let bindir = {@QS@|@ocaml_bindir@|@QS@}
 
 let standard_library_default = {@QS@|@ocaml_libdir@|@QS@}
 
-let ccomp_type = {@QS@|@ccomptype@|@QS@}
+let ccomp_type = {@QS@|@ccomp_type@|@QS@}
 let c_compiler = {@QS@|@CC@|@QS@}
 let c_output_obj = {@QS@|@outputobj@|@QS@}
 let c_has_debug_prefix_map = @cc_has_debug_prefix_map@


### PR DESCRIPTION
I was grepping for `ccomp_type` and noticed there were two different spellings of this variable. Use the `ccomp_type` spelling everywhere.