### PR TITLE
Set the recommended domain count to the number of physical CPU cores

### DIFF
--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -43,7 +43,10 @@ typedef cpuset_t cpu_set_t;
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sysinfoapi.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
 #endif
+
 #include "caml/alloc.h"
 #include "caml/backtrace.h"
 #include "caml/backtrace_prim.h"
@@ -2481,7 +2484,11 @@ CAMLprim value caml_recommended_domain_count(value unused)
 skip:
   caml_stat_free(buffer);
 
-#endif /* _WIN32 */
+#elif defined(__APPLE__)
+  size_t len = sizeof(n);
+  if (sysctlbyname("hw.physicalcpu", &n, &len, NULL, 0) == -1)
+    n = -1;
+#endif
 
   /* At least one, even if system says zero */
   if (n <= 0)

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -39,7 +39,7 @@
 #include <sys/cpuset.h>
 typedef cpuset_t cpu_set_t;
 #endif
-#ifdef _WIN32
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sysinfoapi.h>
@@ -2459,10 +2459,28 @@ CAMLprim value caml_recommended_domain_count(value unused)
     n = sysconf(_SC_NPROCESSORS_ONLN);
 #endif /* _SC_NPROCESSORS_ONLN */
 
-#ifdef _WIN32
-  SYSTEM_INFO sysinfo;
-  GetSystemInfo(&sysinfo);
-  n = sysinfo.dwNumberOfProcessors;
+#if defined(_WIN32)
+  PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX buffer = NULL;
+  DWORD length;
+
+  while (! GetLogicalProcessorInformationEx(RelationAll, buffer, &length)) {
+    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+      buffer = caml_stat_resize(buffer, length);
+    } else {
+      goto skip;
+    }
+  }
+
+  n = 0;
+  for (PSYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX ptr = buffer;
+       ptr - buffer < length;
+       ptr += ptr->Size) {
+    n += ptr->Relationship == RelationProcessorCore;
+  }
+
+skip:
+  caml_stat_free(buffer);
+
 #endif /* _WIN32 */
 
   /* At least one, even if system says zero */

--- a/stdlib/domain.mli
+++ b/stdlib/domain.mli
@@ -79,7 +79,7 @@ let temp_file_key = Domain.DLS.new_key (fun _ ->
     case the current domain exits. *)
 
 val cpu_relax : unit -> unit
-(** If busy-waiting, calling cpu_relax () between iterations
+(** If busy-waiting, calling [cpu_relax ()] between iterations
     will improve performance on some CPU architectures *)
 
 val is_main_domain : unit -> bool


### PR DESCRIPTION
## x86 `cpuid`

- https://en.wikipedia.org/wiki/CPUID
- [Intel® 64 Architecture Processor Topology Enumeration](https://cdrdv2-public.intel.com/775917/intel-64-architecture-processor-topology-enumeration.pdf)
- https://github.com/intel/SDM-Processor-Topology-Enumeration
- GCC's [`cpuid.h`](https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/cpuid.h), LLVM's [`cpuid.h`](https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/cpuid.h)

## Windows

- [`GetLogicalProcessorInformationEx`](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlogicalprocessorinformationex)

## Apple

- [Determining system capabilities](https://developer.apple.com/documentation/kernel/1387446-sysctlbyname/determining_system_capabilities)
- [`sysctlbyname`](https://developer.apple.com/documentation/kernel/1387446-sysctlbyname)

## See also

- https://github.com/haesbaert/ocaml-processor