### PR TITLE
Improve definition of `CAMLthread_local` for C⁠+⁠+ compatibility

### DIFF
--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -47,7 +47,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern CAMLthread_local caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local_decl(caml_domain_state*, caml_state);
   #define Caml_state_opt caml_state
 #else
 #if __has_attribute(pure) || defined(__GNUC__)

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "misc.h"
 
-extern CAMLthread_local intnat caml_icount;
+extern _Thread_local intnat caml_icount;
 void caml_stop_here (void);
 void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -165,14 +165,36 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLalign(n) _Alignas(n)
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
-    defined(__cplusplus) && !defined(__CYGWIN__)
-    /* #14220: flexlink does not support C++11 's thread_local,
-       so prefer _Thread_local on Cygwin systems. */
-#define CAMLthread_local thread_local
+/* Thread storage duration */
+
+#if defined(_MSC_VER) && defined(__cplusplus)
+#if __has_cpp_attribute(msvc::no_tls_guard)
+#define CAMLthread_local_msvc 1
+#define CAMLthread_local_msvc_no_tls_guard [[msvc::no_tls_guard]]
 #else
-#define CAMLthread_local _Thread_local
+#define CAMLthread_local_gnuc 1
 #endif
+#elif defined(_MSC_VER)
+#define CAMLthread_local_msvc 1
+#define CAMLthread_local_msvc_no_tls_guard
+#else
+#define CAMLthread_local_gnuc 1
+#endif
+
+/* Use CAMLthread_local_decl for declarations and CAMLthread_local for
+   definitions if the symbol is visible by a C++ compiler. */
+#if defined(CAMLthread_local_msvc)
+#define CAMLthread_local __declspec(thread)
+#define CAMLthread_local_decl(type, name)                       \
+  CAMLthread_local type name CAMLthread_local_msvc_no_tls_guard
+#else
+#define CAMLthread_local __thread
+#define CAMLthread_local_decl(type, name)       \
+  CAMLthread_local type name
+#endif
+
+#undef CAMLthread_local_msvc
+#undef CAMLthread_local_gnuc
 
 /* Prefetching */
 

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -444,7 +444,7 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-CAMLextern CAMLthread_local int caml_lockdepth;
+CAMLextern _Thread_local int caml_lockdepth;
 #define DEBUG_LOCK(m) (caml_lockdepth++)
 #define DEBUG_UNLOCK(m) (caml_lockdepth--)
 #else

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -199,7 +199,7 @@ struct dom_internal {
 };
 typedef struct dom_internal dom_internal;
 
-static CAMLthread_local dom_internal* domain_self;
+static _Thread_local dom_internal* domain_self;
 
 static struct {
   /* enter barrier for STW sections, participating domains arrive into
@@ -356,7 +356,7 @@ static void stop_active_domain(dom_internal* dom) {
   check_stw_domains();
 }
 
-CAMLexport CAMLthread_local caml_domain_state* caml_state;
+CAMLexport _Thread_local caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -356,7 +356,7 @@ static void stop_active_domain(dom_internal* dom) {
   check_stw_domains();
 }
 
-CAMLexport _Thread_local caml_domain_state* caml_state;
+CAMLexport CAMLthread_local caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -32,7 +32,7 @@
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Greater than zero when the current thread is scanning the roots */
-static CAMLthread_local int iterating_roots = 0;
+static _Thread_local int iterating_roots = 0;
 
 enum { ROOT_PRESENT = 0, ROOT_DELETED = 1 };
 

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -36,7 +36,7 @@
 
 extern code_t caml_start_code;
 
-CAMLthread_local intnat caml_icount = 0;
+_Thread_local intnat caml_icount = 0;
 
 void caml_stop_here (void)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -242,7 +242,7 @@ Caml_inline void check_trap_barrier_for_effect
 #endif
 
 #ifdef DEBUG
-static CAMLthread_local intnat caml_bcodcount;
+static _Thread_local intnat caml_bcodcount;
 #endif
 
 static value raise_unhandled_effect;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -82,7 +82,7 @@ static char dummy_buff[1];
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static CAMLthread_local struct channel* last_channel_locked = NULL;
+static _Thread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -60,7 +60,7 @@ CAMLnoret void caml_debug_abort(const char_os * file_os, int line) {
 #endif
 
 #if defined(DEBUG)
-static CAMLthread_local int noalloc_level = 0;
+static _Thread_local int noalloc_level = 0;
 int caml_noalloc_begin(void)
 {
   return noalloc_level++;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -80,7 +80,7 @@ void caml_plat_assert_locked(caml_plat_mutex* m)
 }
 
 #ifdef DEBUG
-CAMLexport CAMLthread_local int caml_lockdepth = 0;
+CAMLexport _Thread_local int caml_lockdepth = 0;
 #endif
 
 void caml_plat_assert_all_locks_unlocked(void)

--- a/testsuite/tests/lib-marshal/intextaux_par.c
+++ b/testsuite/tests/lib-marshal/intextaux_par.c
@@ -20,7 +20,7 @@
 #define CAML_INTERNALS
 
 #define BLOCK_SIZE 512
-static CAMLthread_local char marshal_block[BLOCK_SIZE];
+static _Thread_local char marshal_block[BLOCK_SIZE];
 
 value marshal_to_block(value vlen, value v, value vflags)
 {


### PR DESCRIPTION
Since OCaml 5, with multicore support, the runtime is written in C11 and uses thread-local storage. There's only one variable (a POD) that is public in the OCaml headers. It was first using GCC's `__thread`, then we changed it to use `thread_local` in C23 and C⁠+⁠+11, and `_Thread_local` in C11[^1], for portability. We hit the ABI incompatibility problem that is described in [N2850: `_Thread_local` for better C⁠+⁠+ interoperability with C](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2850.pdf), as if a C++ compiler reads our header, it will use the C⁠+⁠+ `thread_local` ABI to access the variable, instead of the C11 `_Thread_local` semantics.

We hit problems on Cygwin, and I'm expecting problems with MSVC. See `#14220` and `#13541`.

Looking to fix this problem once and for all, I've found N2850, submitted to both the C and C⁠+⁠+ working groups. There is no definitive fix, the paper suggests adding `_Thread_local` to C++, to make it easier to write common headers, or to have `extern "C" thread_local` (in C⁠+⁠+) behave like C11 semantics for the thread-local ABI instead of C⁠+⁠+'s. The paper also suggests moving away from C23 `thread_local` spelling, to avoid confusion with C⁠+⁠+11 `thread_local`, and remain with C11 `_Thread_local`.

I contacted the authors of the paper for advice, here's the short answer:

> The C++ committee was not supportive of adding `_Thread_local` in C++ and the C committee moved forward with adding `thread_local` as their preferred spelling despite being informed of the issue.
> The C++ committee was interested in a potential solution where `thread_local` behaves like `_Thread_local` when used for variables with `extern "C"` linkage; however, I have some qualms with proposing that.

Missing a standard way to use C semantics within a C⁠+⁠+ compiler, we have to resort to compiler extensions. The compiler extensions (`__thread`, `__declspec(thread)`) seem to always be equivalent to `_Thread_local`. Here are my proposed changes:

1. Use C11 `_Thread_local` internally, and for variables protected by `CAML_INTERNALS`. My preference is to use the standard keyword wherever possible.

For exposed symbols (currently only the `caml_state`):

1. If using MSVC, prefer [`__declspec(thread)`](https://learn.microsoft.com/en-us/cpp/cpp/thread?view=msvc-170).
   > On Windows `thread_local` is implemented with `__declspec(thread)`.

   In C⁠+⁠+, also use [`[[msvc::no_tls_guard]]`](https://learn.microsoft.com/en-us/cpp/cpp/attributes?view=msvc-170#msvcno_tls_guard)[^2] on the declaration to avoid intermediary functions checking if the variable has been initialized. Unfortunately Clang doesn't support this attribute (`https://github.com/llvm/llvm-project/issues/57696`), so for the `*-pc-windows` target in C⁠+⁠+ we have to fallback to the `__thread` keyword.
   
   > In Clang, [`__declspec(thread)`](https://clang.llvm.org/docs/AttributeReference.html#id820) is generally equivalent in functionality to the GNU `__thread` keyword.

2. Otherwise the compiler is GCC or Clang, or [another compiler](https://en.wikipedia.org/wiki/Thread-local_storage#C_and_C++) (nowadays Intel® oneAPI DPC++/C⁠+⁠+ Compiler and IBM Open XL C/C⁠+⁠+ for AIX are both based on LLVM), and supports `__thread` with GCC's semantics:
   > G++ now implements the C⁠+⁠+11 `thread_local` keyword; this differs from the GNU `__thread` keyword primarily in that it allows dynamic initialization and destruction semantics. Unfortunately, this support requires a run-time penalty for references to non-function-local thread_local variables defined in a different translation unit even if they don't need dynamic initialization, so users may want to continue to use `__thread` for TLS variables with static initialization semantics. ([GCC 4.8](https://gcc.gnu.org/gcc-4.8/changes.html#cxx))

   > ISO C11 thread-local storage (`_Thread_local`, similar to GNU C `__thread`) is now supported. ([GCC 4.9](https://gcc.gnu.org/gcc-4.9/changes.html#c))
   
As an extension, Clang-based compilers also support the C `_Thread_local` keyword in C⁠+⁠+ (GCC doesn't), but we can use `__thread` instead. Unfortunately MSVC rejects mixing `__declspec(thread)` and `_Thread_local` in declarations and definitions.

To help convincing, here's a complete example: https://godbolt.org/z/TKxd1nbMY, with the output of GCC (4.9.4 and trunk), MSVC (19.38 introduced C11 atomic), and Clang (trunk, targets `x86_64-pc-window` and `x86_64-*-linux`), running both in C and C⁠+⁠+, showing that the generated assembly is identical. If you want to come up with a different macro dance, you may validate it with this example.

```sh
> cat <<EOF > test.h
#ifdef __cplusplus
extern "C"
#endif
__declspec(thread) int x;
EOF
> cat <<EOF >test.c
#include "test.h"
__declspec(thread) int x = 42;
EOF
> cat <<EOF >main.cpp
#include "test.h"

int get_x() { return x; }
void set_x(int i) { x = i; }

int main() {
  (void)get_x();
  set_x(1337);
  return get_x();
}
> clang --target=x86_64-pc-windows -Wall -c test.c
> clang --target=x86_64-pc-windows -Wall -c main.c
> clang --target=x86_64-pc-windows -Wall test.o main.o -o main.exe
```

[^1]: `_Thread_local` is a C11 keyword. The macro `thread_local`, defined in `<threads.h>`, expands to `_Thread_local`. If `__STDC_NO_THREADS__`[^3] is defined to `1`, the header is not provided. In C23, `thread_local` becomes a keyword, and the spelling `_Thread_local` is discouraged. 

[^2]: Support for the attribute can be tested with `__has_cpp_attribute` (standard in C++20), supported by all MSVC and Clang version that we're interested in. However for an attribute with a namespace we need to check first for `__cplusplus` as GCC until 11 didn't support the namespace syntax in C mode.

[^3]: There was a [bug](https://developercommunity.visualstudio.com/t/C11-Define-__STDC_NO_THREADS__-if-C11/10510770) where Microsoft [implemented C11 `<threads.h>`](https://devblogs.microsoft.com/cppblog/c11-threads-in-visual-studio-2022-version-17-8-preview-2/), forgot to ship the header, and did not define the guard macro.