### PR TITLE
MASM: use MASM 6 `EXTERN` spelling

### DIFF
--- a/asmcomp/x86_masm.ml
+++ b/asmcomp/x86_masm.ml
@@ -234,7 +234,7 @@ let print_line b = function
   | Word n -> bprintf b "\tWORD\t%a" cst n
 
   (* windows only *)
-  | External (s, ptr) -> bprintf b "\tEXTRN\t%s: %s" s (string_of_datatype ptr)
+  | External (s, ptr) -> bprintf b "\tEXTERN\t%s: %s" s (string_of_datatype ptr)
   | Mode386 -> bprintf b "\t.386"
   | Model name -> bprintf b "\t.MODEL %s" name (* name = FLAT *)
 

--- a/runtime/amd64nt.asm
+++ b/runtime/amd64nt.asm
@@ -20,18 +20,18 @@
 ;     caller must reserve 32 bytes of stack space
 ;     callee must preserve RBX, RBP, RSI, RDI, R12-R15, XMM6-XMM15
 
-        EXTRN  caml_garbage_collection: NEAR
-        EXTRN  caml_apply2: NEAR
-        EXTRN  caml_apply3: NEAR
-        EXTRN  caml_program: NEAR
-        EXTRN  caml_array_bound_error_asm: NEAR
-        EXTRN  caml_stash_backtrace: NEAR
-        EXTRN  caml_try_realloc_stack: NEAR
-        EXTRN  caml_try_realloc_stack: NEAR
-        EXTRN  caml_exn_Stack_overflow: NEAR
-        EXTRN  caml_raise_unhandled_effect: NEAR
-        EXTRN  caml_raise_continuation_already_resumed: NEAR
-        EXTRN  caml_free_stack: NEAR
+        EXTERN  caml_garbage_collection: NEAR
+        EXTERN  caml_apply2: NEAR
+        EXTERN  caml_apply3: NEAR
+        EXTERN  caml_program: NEAR
+        EXTERN  caml_array_bound_error_asm: NEAR
+        EXTERN  caml_stash_backtrace: NEAR
+        EXTERN  caml_try_realloc_stack: NEAR
+        EXTERN  caml_try_realloc_stack: NEAR
+        EXTERN  caml_exn_Stack_overflow: NEAR
+        EXTERN  caml_raise_unhandled_effect: NEAR
+        EXTERN  caml_raise_continuation_already_resumed: NEAR
+        EXTERN  caml_free_stack: NEAR
 
 ; Load caml/domain_state.tbl (via domain_state.inc, to remove C-style comments)
         domain_curr_field = 0


### PR DESCRIPTION
`EXTERN` is a modern (MASM 6, 1991) alternative to MASM 5 (1987) `EXTRN` directive.
In _C++, C, and Assembler_, see [`EXTRN`](https://learn.microsoft.com/en-us/cpp/assembler/masm/extrn?view=msvc-180) and [`EXTERN`](https://learn.microsoft.com/en-us/cpp/assembler/masm/extern-masm?view=msvc-180).

See also from _The Art of Assembly Language Programming_, Randall Hyde, 1996:

> `EXTRN` is an older directive that is a synonym for `EXTERN`. It provides compatibility with old source files. You should always use the `EXTERN` directive in new source code.

This patch is a requirement to make OCaml count as new source code and be ready for a next century of MASM hacking.
(this patch is cosmetic, no incidence on produced code). No change entry needed.