### PR TITLE
`CAMLthreadlocal`

### DIFF
--- a/runtime/caml/domain_state.h
+++ b/runtime/caml/domain_state.h
@@ -47,7 +47,7 @@ enum {
 #define LAST_DOMAIN_STATE_MEMBER extra_params
 
 #if defined(HAS_FULL_THREAD_VARIABLES) || defined(IN_CAML_RUNTIME)
-  CAMLextern CAMLthread_local caml_domain_state* caml_state;
+  CAMLextern CAMLthread_local(caml_domain_state* caml_state);
   #define Caml_state_opt caml_state
 #else
 #if __has_attribute(pure) || defined(__GNUC__)

--- a/runtime/caml/instrtrace.h
+++ b/runtime/caml/instrtrace.h
@@ -23,7 +23,7 @@
 #include "mlvalues.h"
 #include "misc.h"
 
-extern CAMLthread_local intnat caml_icount;
+extern CAMLthread_local(intnat caml_icount);
 void caml_stop_here (void);
 void caml_disasm_instr (code_t pc);
 void caml_trace_value_file (value v, code_t prog, asize_t proglen, FILE * f);

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -41,6 +41,14 @@
 #define __has_builtin(x) 0
 #endif
 
+#if !defined(__has_extension)
+#define __has_extension(x) 0
+#endif
+
+#if !defined(__has_cpp_attribute)
+#define __has_cpp_attribute(x) 0
+#endif
+
 /* Deprecation warnings */
 
 #if __has_attribute(deprecated) || defined(__GNUC__)
@@ -165,12 +173,21 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLalign(n) _Alignas(n)
 #endif
 
-#if !defined(__cplusplus)
+#if !defined(__cplusplus) || __has_extension(c_thread_local)
 #define CAMLthread_local(decl) _Thread_local decl
 #elif defined(_MSC_VER) && !defined(__clang__)
-#define CAMLthread_local(decl) __declspec(thread) decl [[msvc::no_tls_guard]]
-#else
+#define CAMLthread_local(decl) thread_local decl [[msvc::no_tls_guard]]
+#elif defined(__cpp_constinit)
+#define CAMLthread_local(decl) thread_local constinit decl
+#elif __has_cpp_attribute(clang::require_constant_initialization)
+#define CAMLthread_local(decl)                                  \
+  thread_local decl [[clang::require_constant_initialization]]
+#elif defined(__GNUC__) && __GNUC__ >= 10
+#define CAMLthread_local(decl) thread_local __constinit decl
+#elif defined(__GNUC__)
 #define CAMLthread_local(decl) __thread decl
+#else
+#error "No C-thread-local for interoperability with C++"
 #endif
 
 /* Prefetching */

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -165,13 +165,12 @@ CAMLdeprecated_typedef(addr, char *);
 #define CAMLalign(n) _Alignas(n)
 #endif
 
-#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L || \
-    defined(__cplusplus) && !defined(__CYGWIN__)
-    /* #14220: flexlink does not support C++11 's thread_local,
-       so prefer _Thread_local on Cygwin systems. */
-#define CAMLthread_local thread_local
+#if !defined(__cplusplus)
+#define CAMLthread_local(decl) _Thread_local decl
+#elif defined(_MSC_VER) && !defined(__clang__)
+#define CAMLthread_local(decl) __declspec(thread) decl [[msvc::no_tls_guard]]
 #else
-#define CAMLthread_local _Thread_local
+#define CAMLthread_local(decl) __thread decl
 #endif
 
 /* Prefetching */

--- a/runtime/caml/platform.h
+++ b/runtime/caml/platform.h
@@ -632,7 +632,7 @@ Caml_inline void check_err(const char* action, int err)
 }
 
 #ifdef DEBUG
-CAMLextern CAMLthread_local int caml_lockdepth;
+CAMLextern CAMLthread_local(int caml_lockdepth);
 #define DEBUG_LOCK(m) (caml_lockdepth++)
 #define DEBUG_UNLOCK(m) (caml_lockdepth--)
 #else

--- a/runtime/domain.c
+++ b/runtime/domain.c
@@ -202,7 +202,7 @@ struct dom_internal {
 };
 typedef struct dom_internal dom_internal;
 
-static CAMLthread_local dom_internal* domain_self;
+static _Thread_local dom_internal* domain_self;
 
 static struct {
   /* enter barrier for STW sections, participating domains arrive into
@@ -359,7 +359,7 @@ static void stop_active_domain(dom_internal* dom) {
   check_stw_domains();
 }
 
-CAMLexport CAMLthread_local caml_domain_state* caml_state;
+CAMLexport _Thread_local caml_domain_state* caml_state;
 
 #ifndef HAS_FULL_THREAD_VARIABLES
 /* Export a getter for caml_state, to be used in DLLs */
@@ -369,7 +369,7 @@ CAMLexport caml_domain_state* caml_get_domain_state(void)
 }
 #endif
 
-static CAMLthread_local uintnat previous_domain_id = -1;
+static _Thread_local uintnat previous_domain_id = -1;
 
 CAMLexport
 bool caml_thread_running_on_expected_domain(uintnat expected_unique_id)

--- a/runtime/globroots.c
+++ b/runtime/globroots.c
@@ -32,7 +32,7 @@
 static caml_plat_mutex roots_mutex = CAML_PLAT_MUTEX_INITIALIZER;
 
 /* Greater than zero when the current thread is scanning the roots */
-static CAMLthread_local int iterating_roots = 0;
+static _Thread_local int iterating_roots = 0;
 
 enum { ROOT_PRESENT = 0, ROOT_DELETED = 1 };
 

--- a/runtime/instrtrace.c
+++ b/runtime/instrtrace.c
@@ -42,7 +42,7 @@ static char const * const names_of_instructions [] = {
 
 extern code_t caml_start_code;
 
-CAMLthread_local intnat caml_icount = 0;
+_Thread_local intnat caml_icount = 0;
 
 void caml_stop_here (void)
 {

--- a/runtime/interp.c
+++ b/runtime/interp.c
@@ -242,7 +242,7 @@ Caml_inline void check_trap_barrier_for_effect
 #endif
 
 #ifdef DEBUG
-static CAMLthread_local intnat caml_bcodcount;
+static _Thread_local intnat caml_bcodcount;
 #endif
 
 static value raise_unhandled_effect;

--- a/runtime/io.c
+++ b/runtime/io.c
@@ -82,7 +82,7 @@ static char dummy_buff[1];
    currently locked channel (if any), which is then called by
    [caml_raise].
  */
-static CAMLthread_local struct channel* last_channel_locked = NULL;
+static _Thread_local struct channel* last_channel_locked = NULL;
 
 CAMLexport void caml_channel_lock(struct channel *chan)
 {

--- a/runtime/misc.c
+++ b/runtime/misc.c
@@ -60,7 +60,7 @@ CAMLnoret void caml_debug_abort(const char_os * file_os, int line) {
 #endif
 
 #if defined(DEBUG)
-static CAMLthread_local int noalloc_level = 0;
+static _Thread_local int noalloc_level = 0;
 int caml_noalloc_begin(void)
 {
   return noalloc_level++;

--- a/runtime/platform.c
+++ b/runtime/platform.c
@@ -49,7 +49,7 @@ void caml_plat_fatal_error(const char * action, int err)
 /* Mutexes */
 
 #ifdef DEBUG
-CAMLexport CAMLthread_local int caml_lockdepth = 0;
+CAMLexport _Thread_local int caml_lockdepth = 0;
 #endif
 
 void caml_plat_assert_all_locks_unlocked(void)

--- a/testsuite/tests/lib-marshal/intextaux_par.c
+++ b/testsuite/tests/lib-marshal/intextaux_par.c
@@ -20,7 +20,7 @@
 #define CAML_INTERNALS
 
 #define BLOCK_SIZE 512
-static CAMLthread_local char marshal_block[BLOCK_SIZE];
+static _Thread_local char marshal_block[BLOCK_SIZE];
 
 value marshal_to_block(value vlen, value v, value vflags)
 {


### PR DESCRIPTION
The C and C⁠+⁠+ ABI for thread-local storage differs; C⁠+⁠+ mangles
symbols, and adds dynamic initialization. The C⁠+⁠+ compiler will
generate or look for initialization guards. As the OCaml runtime is
built with a C compiler, thread-local symbols are not mangled and no
guards are generated. Therefore, we must prevent the C⁠+⁠+ compiler from
using the C⁠+⁠+ ABI, and rather stick to the C ABI. This is done by
disabling mangling with `extern "C" { ... }` and tagging the
non-initializing declaration of each thread-local symbol, as described
in the following.

In short: if a C⁠+⁠+ compiler sees a stray `thread_local`, it's game
over. The problem is described in
[_`_Thread_local` for better C⁠+⁠+ interoperability with C_ (N2850)][N2850].

The standard ways since C⁠+⁠+20 to avoid to generating guards is to use
the [`constinit`][constinit] keyword. For older revisions of the
standard, Clang provides the
[`[[clang::require_constant_initialization]]`][clang] attribute, MSVC
the [`[[msvc::no_tls_guard]]`][MSVC] attribute, and GCC the
[`__constinit`][GCC] keyword. It is also possible to reach out to
legacy C extensions, `__thread` for GCC and Clang, and
`__declspec(thread)` for MSVC, but I'd like to think there exists
somewhere out there compilers that implement the standard perfectly,
without ad-hoc extensions.

Clang also implements the [`c_thread_local`][C11] extension and allows
using the C `_Thread_local` keyword in C⁠+⁠+.

MSVC always need the `[[msvc::no_tls_guard]]` attribute, even when
`constinit` is specified. Clang-cl doesn't recognize the
`[[msvc::no_tls_guard]]` attribute. The oldest version of MSVC that we
require supports this attribute, so we shouldn't need to use
`__declspec(thread)`. The attribute need to be located either before
the `extern`, or after the identifier.

Clang 7 (Sept. 2018) introduces `__has_cpp_attribute`. GCC 10 (May
2020) introduces the `__constinit` keyword. If an even older GCC or
Clang is used, the `__thread` extension is be available.

Change the `CAMLthread_local` macro to wrap a declaration.

[constinit]: https://en.cppreference.com/cpp/language/constinit
[clang]: https://clang.llvm.org/docs/AttributeReference.html#require-constant-initialization-constinit-c-20
[GCC]: https://developers.redhat.com/blog/2020/09/24/new-c-features-in-gcc-10#the_constinit_keyword-h2
[MSVC]: https://learn.microsoft.com/en-us/cpp/cpp/attributes?view=msvc-180
[C11]: https://clang.llvm.org/docs/LanguageExtensions.html#c11-thread-local
[N2850]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2850.pdf